### PR TITLE
feat: MCP Streamable HTTP transport with daemonize support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-03-27
+
+### Added
+
+- MCP server now supports Streamable HTTP transport (default) in addition to stdio
+- New `--transport http|stdio` flag for `mcp-serve` (defaults to `http`)
+- New `--address` and `--port` flags for MCP HTTP transport (defaults to `127.0.0.1:3000`)
+- New `--daemonize` flag to run MCP HTTP server as a background daemon with PID file and log file support
+- Graceful shutdown via Ctrl+C for MCP HTTP server
+- systemd unit file (`contrib/systemd/netcidr-mcp.service`) for Linux deployment
+- launchd plist (`contrib/launchd/com.netcidr.mcp.plist`) for macOS deployment
+
 ### Changed
 
 - Migrate CI/CD from GitLab CI to GitHub Actions (ci, lint, test, audit, semgrep, CodeQL, release)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,6 +644,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "daemonize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8bfdaacb3c887a54d41bdf48d3af8873b3f5566469f8ba21b92057509f116e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1864,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "netcidr"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1874,6 +1883,7 @@ dependencies = [
  "clap_complete",
  "crossterm",
  "csv",
+ "daemonize",
  "dirs",
  "http-body-util",
  "ipnet",
@@ -1893,6 +1903,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-test",
+ "tokio-util",
  "toml",
  "tower",
  "tower-http",
@@ -2708,18 +2719,27 @@ checksum = "ba6b9d2f0efe2258b23767f1f9e0054cfbcac9c2d6f81a031214143096d7864f"
 dependencies = [
  "async-trait",
  "base64",
+ "bytes",
  "chrono",
  "futures",
+ "http",
+ "http-body",
+ "http-body-util",
  "pastey",
  "pin-project-lite",
+ "rand 0.10.0",
  "rmcp-macros",
  "schemars",
  "serde",
  "serde_json",
+ "sse-stream",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tokio-util",
+ "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -3360,6 +3380,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sse-stream"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3709,6 +3742,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netcidr"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 license = "MIT"
 description = "A fast IPv4 and IPv6 subnet calculator CLI and API"
@@ -32,7 +32,9 @@ chrono = { version = "0.4", features = ["serde"] }
 anyhow = "1"
 async-trait = "0.1"
 dirs = "6"
-rmcp = { version = "1.1", features = ["server", "transport-io", "macros"], optional = true }
+rmcp = { version = "1.1", features = ["server", "transport-io", "transport-streamable-http-server", "macros"], optional = true }
+daemonize = { version = "0.5", optional = true }
+tokio-util = { version = "0.7", features = ["rt"], optional = true }
 schemars = { version = "1", optional = true }
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "query"], optional = true }
 ratatui = { version = "0.30", optional = true }
@@ -56,7 +58,7 @@ reqwest = { version = "0.13", default-features = false, features = ["json", "rus
 default = ["swagger"]
 swagger = ["dep:utoipa", "dep:utoipa-swagger-ui"]
 tui = ["dep:ratatui", "dep:crossterm", "dep:ipnet"]
-mcp = ["dep:rmcp", "dep:schemars", "dep:reqwest"]
+mcp = ["dep:rmcp", "dep:schemars", "dep:reqwest", "dep:tokio-util", "dep:daemonize"]
 ipam-postgres = ["dep:sqlx"]
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A fast IPv4 and IPv6 subnet calculator written in Rust. Available as a CLI tool,
 - **Web dashboard**: Full SPA at `http://localhost:8080/` with subnet calculator, splitter, contains check, summarize, from-range, IPAM dashboard, and subnet visualizer — served automatically when running `netcidr serve`
 - **HTTP API**: REST endpoints for all calculations
 - **OpenAPI documentation**: Machine-readable API specification for easy integration with tools like Swagger Editor, Postman, and Insomnia
-- **MCP server**: [Model Context Protocol](https://modelcontextprotocol.io) server for AI assistant integration (Claude, etc.) over stdio
+- **MCP server**: [Model Context Protocol](https://modelcontextprotocol.io) server for AI assistant integration (Claude, etc.) via Streamable HTTP or stdio
 - **IPAM (IP Address Management)**: IPv4 and IPv6 allocation tracking with conflict detection, audit trail, utilization reporting, reservation TTL/expiry, and JSON export/import — available via CLI (`netcidr ipam`) and REST API (`netcidr serve --ipam-enabled`)
 - **Configurable security**: rate limiting, request size limits, timeouts, restrictive CORS, and security headers
 - **TOML configuration**: server settings via config file with CLI flag overrides
@@ -230,7 +230,7 @@ Supported shells: `bash`, `zsh`, `fish`, `elvish`, `powershell`.
 
 ### MCP Server (AI Assistant Integration)
 
-The MCP server lets AI assistants like Claude use netcidr as a tool for subnet calculations. It communicates over stdio using the [Model Context Protocol](https://modelcontextprotocol.io). Built natively in Rust using the official `rmcp` SDK — no Node.js required.
+The MCP server lets AI assistants like Claude use netcidr as a tool for subnet calculations. Supports [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) (default) and stdio transports via the [Model Context Protocol](https://modelcontextprotocol.io). Built natively in Rust using the official `rmcp` SDK — no Node.js required.
 
 ```bash
 # Build with MCP support
@@ -238,6 +238,41 @@ cargo build --release --features mcp
 
 # Or use make
 make build-mcp
+
+# Start MCP server (Streamable HTTP on 127.0.0.1:3000)
+netcidr mcp-serve
+
+# Custom address and port
+netcidr mcp-serve --address 0.0.0.0 --port 4000
+
+# Use stdio transport (for pipe-based clients like Claude Code)
+netcidr mcp-serve --transport stdio
+
+# With IPAM enabled
+netcidr mcp-serve --ipam-db /path/to/ipam.db
+netcidr mcp-serve --api-url http://localhost:8080
+
+# Run as a background daemon
+netcidr mcp-serve --daemonize --pid-file /var/run/netcidr-mcp.pid --log-file /var/log/netcidr-mcp.log
+```
+
+#### Running as a Service
+
+Service files are provided in `contrib/` for running the MCP server as a system service:
+
+**systemd (Linux):**
+
+```bash
+sudo cp contrib/systemd/netcidr-mcp.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now netcidr-mcp
+```
+
+**launchd (macOS):**
+
+```bash
+cp contrib/launchd/com.netcidr.mcp.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/com.netcidr.mcp.plist
 ```
 
 **Calculator tools** (always available):
@@ -265,16 +300,26 @@ make build-mcp
 | `ipam_find_ip` | Find allocations containing an IP |
 | `ipam_find_resource` | Find allocations by resource ID |
 
-#### Claude Code
+#### Streamable HTTP (remote clients)
 
-Add to `~/.claude.json`:
+Any MCP client that supports Streamable HTTP can connect to:
+
+```
+http://127.0.0.1:3000/mcp
+```
+
+Start the server with `netcidr mcp-serve` (defaults to HTTP on port 3000).
+
+#### Claude Code (stdio)
+
+Claude Code uses stdio transport. Add to `~/.claude.json`:
 
 ```json
 {
   "mcpServers": {
     "netcidr": {
       "command": "/absolute/path/to/netcidr",
-      "args": ["mcp-serve"]
+      "args": ["mcp-serve", "--transport", "stdio"]
     }
   }
 }
@@ -287,7 +332,7 @@ With IPAM enabled (local database):
   "mcpServers": {
     "netcidr": {
       "command": "/absolute/path/to/netcidr",
-      "args": ["mcp-serve", "--ipam-db", "/path/to/ipam.db"]
+      "args": ["mcp-serve", "--transport", "stdio", "--ipam-db", "/path/to/ipam.db"]
     }
   }
 }
@@ -300,7 +345,7 @@ With IPAM via remote API server (connects to a running `netcidr serve`):
   "mcpServers": {
     "netcidr": {
       "command": "/absolute/path/to/netcidr",
-      "args": ["mcp-serve", "--api-url", "http://localhost:8080"]
+      "args": ["mcp-serve", "--transport", "stdio", "--api-url", "http://localhost:8080"]
     }
   }
 }
@@ -308,7 +353,7 @@ With IPAM via remote API server (connects to a running `netcidr serve`):
 
 > **Note:** `--ipam-db` and `--api-url` are mutually exclusive. Use `--api-url` when IPAM state must be shared across multiple MCP clients or when the MCP server runs on a different host.
 
-#### Claude Desktop
+#### Claude Desktop (stdio)
 
 Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
 
@@ -317,7 +362,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
   "mcpServers": {
     "netcidr": {
       "command": "/absolute/path/to/netcidr",
-      "args": ["mcp-serve"]
+      "args": ["mcp-serve", "--transport", "stdio"]
     }
   }
 }

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,9 @@ We actively support and provide security updates for the following versions:
 
 | Version | Supported          | Notes                                    |
 | ------- | ------------------ | ---------------------------------------- |
-| 0.15.x  | :white_check_mark: | Current stable release (recommended)     |
-| 0.14.x  | :white_check_mark: | Supported                                |
-| < 0.14  | :x:                | No longer supported                      |
+| 0.16.x  | :white_check_mark: | Current stable release (recommended)     |
+| 0.15.x  | :white_check_mark: | Supported                                |
+| < 0.15  | :x:                | No longer supported                      |
 
 ## Reporting a Vulnerability
 

--- a/contrib/launchd/com.netcidr.mcp.plist
+++ b/contrib/launchd/com.netcidr.mcp.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.netcidr.mcp</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/netcidr</string>
+        <string>mcp-serve</string>
+        <string>--address</string>
+        <string>127.0.0.1</string>
+        <string>--port</string>
+        <string>3000</string>
+    </array>
+
+    <!-- Uncomment to enable IPAM with a local database:
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/netcidr</string>
+        <string>mcp-serve</string>
+        <string>--address</string>
+        <string>127.0.0.1</string>
+        <string>--port</string>
+        <string>3000</string>
+        <string>--ipam-db</string>
+        <string>/usr/local/var/netcidr/ipam.db</string>
+    </array>
+    -->
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/usr/local/var/log/netcidr-mcp.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/usr/local/var/log/netcidr-mcp.log</string>
+</dict>
+</plist>

--- a/contrib/systemd/netcidr-mcp.service
+++ b/contrib/systemd/netcidr-mcp.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=netcidr MCP Server (Streamable HTTP)
+Documentation=https://github.com/wingnut128/netcidr
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/netcidr mcp-serve --address 127.0.0.1 --port 3000
+Restart=on-failure
+RestartSec=5
+
+# Security hardening
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=read-only
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+
+# Uncomment and adjust to enable IPAM with a local database:
+# ExecStart=/usr/local/bin/netcidr mcp-serve --address 127.0.0.1 --port 3000 --ipam-db /var/lib/netcidr/ipam.db
+# ReadWritePaths=/var/lib/netcidr
+
+# Uncomment to enable IPAM via remote API server:
+# ExecStart=/usr/local/bin/netcidr mcp-serve --address 127.0.0.1 --port 3000 --api-url http://localhost:8080
+
+[Install]
+WantedBy=multi-user.target

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -88,9 +88,33 @@ pub enum Commands {
         command: IpamCommands,
     },
 
-    /// Start the MCP (Model Context Protocol) server over stdio
+    /// Start the MCP (Model Context Protocol) server
     #[cfg(feature = "mcp")]
     McpServe {
+        /// Transport protocol (http or stdio)
+        #[arg(long, default_value = "http")]
+        transport: McpTransport,
+
+        /// Address to bind to (HTTP transport only)
+        #[arg(short, long, default_value = "127.0.0.1")]
+        address: String,
+
+        /// Port to listen on (HTTP transport only)
+        #[arg(short, long, default_value = "3000")]
+        port: u16,
+
+        /// Run as a background daemon (HTTP transport only)
+        #[arg(long)]
+        daemonize: bool,
+
+        /// PID file path (used with --daemonize)
+        #[arg(long, default_value = "/tmp/netcidr-mcp.pid")]
+        pid_file: String,
+
+        /// Log file path (used with --daemonize, stderr otherwise)
+        #[arg(long)]
+        log_file: Option<String>,
+
         /// Path to IPAM SQLite database (enables IPAM tools via local store)
         #[arg(long, conflicts_with = "api_url")]
         ipam_db: Option<String>,
@@ -442,6 +466,16 @@ pub enum OutputFormatArg {
     Text,
     Csv,
     Yaml,
+}
+
+#[cfg(feature = "mcp")]
+#[derive(Clone, Copy, ValueEnum, Default)]
+pub enum McpTransport {
+    /// Streamable HTTP server (default)
+    #[default]
+    Http,
+    /// Legacy stdio transport
+    Stdio,
 }
 
 impl From<OutputFormatArg> for crate::output::OutputFormat {

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,10 +198,27 @@ async fn main() {
             }
         }
         #[cfg(feature = "mcp")]
-        Some(Commands::McpServe { ipam_db, api_url }) => {
-            if let Err(e) =
-                netcidr::mcp::run_mcp_server(ipam_db.as_deref(), api_url.as_deref()).await
-            {
+        Some(Commands::McpServe {
+            transport,
+            address,
+            port,
+            daemonize,
+            pid_file,
+            log_file,
+            ipam_db,
+            api_url,
+        }) => {
+            let mcp_config = netcidr::mcp::McpServerConfig {
+                transport,
+                address: &address,
+                port,
+                daemonize,
+                pid_file: &pid_file,
+                log_file: log_file.as_deref(),
+                ipam_db: ipam_db.as_deref(),
+                api_url: api_url.as_deref(),
+            };
+            if let Err(e) = netcidr::mcp::run_mcp_server(mcp_config).await {
                 eprintln!("MCP server error: {}", e);
                 std::process::exit(1);
             }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -575,19 +575,27 @@ impl ServerHandler for NetcidrMcp {
     }
 }
 
-pub async fn run_mcp_server(
-    ipam_db: Option<&str>,
-    api_url: Option<&str>,
-) -> crate::error::Result<()> {
-    let ipam = match (ipam_db, api_url) {
+pub struct McpServerConfig<'a> {
+    pub transport: crate::cli::McpTransport,
+    pub address: &'a str,
+    pub port: u16,
+    pub daemonize: bool,
+    pub pid_file: &'a str,
+    pub log_file: Option<&'a str>,
+    pub ipam_db: Option<&'a str>,
+    pub api_url: Option<&'a str>,
+}
+
+pub async fn run_mcp_server(config: McpServerConfig<'_>) -> crate::error::Result<()> {
+    let ipam = match (config.ipam_db, config.api_url) {
         (Some(_), Some(_)) => {
             return Err(crate::error::NetcidrError::InvalidInput(
                 "--ipam-db and --api-url are mutually exclusive".to_string(),
             ));
         }
         (Some(db), None) => {
-            let config = crate::ipam::config::IpamConfig::default();
-            let store = crate::ipam::create_store(&config, Some(db), None).await?;
+            let ipam_config = crate::ipam::config::IpamConfig::default();
+            let store = crate::ipam::create_store(&ipam_config, Some(db), None).await?;
             Some(McpIpamBackend::Local(Arc::new(IpamOps::new(store))))
         }
         (None, Some(url)) => {
@@ -597,6 +605,59 @@ pub async fn run_mcp_server(
         (None, None) => None,
     };
 
+    match config.transport {
+        crate::cli::McpTransport::Stdio => {
+            if config.daemonize {
+                return Err(crate::error::NetcidrError::InvalidInput(
+                    "--daemonize is only supported with HTTP transport".to_string(),
+                ));
+            }
+            run_mcp_stdio(ipam).await
+        }
+        crate::cli::McpTransport::Http => {
+            if config.daemonize {
+                daemonize_process(config.pid_file, config.log_file)?;
+            }
+            run_mcp_http(ipam, config.address, config.port).await
+        }
+    }
+}
+
+/// Fork the current process into the background using the `daemonize` crate,
+/// write a PID file, and redirect output to a log file (or /dev/null).
+fn daemonize_process(pid_file: &str, log_file: Option<&str>) -> crate::error::Result<()> {
+    let mut daemon = daemonize::Daemonize::new().pid_file(pid_file);
+
+    if let Some(path) = log_file {
+        let stdout = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .map_err(|e| {
+                crate::error::NetcidrError::InvalidInput(format!(
+                    "Failed to open log file {path}: {e}"
+                ))
+            })?;
+        let stderr = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .map_err(|e| {
+                crate::error::NetcidrError::InvalidInput(format!(
+                    "Failed to open log file {path}: {e}"
+                ))
+            })?;
+        daemon = daemon.stdout(stdout).stderr(stderr);
+    }
+
+    daemon.start().map_err(|e| {
+        crate::error::NetcidrError::InvalidInput(format!("Failed to daemonize: {e}"))
+    })?;
+
+    Ok(())
+}
+
+async fn run_mcp_stdio(ipam: Option<McpIpamBackend>) -> crate::error::Result<()> {
     let server = NetcidrMcp::new(ipam);
     let transport = rmcp::transport::io::stdio();
     let service = server
@@ -607,6 +668,48 @@ pub async fn run_mcp_server(
         .waiting()
         .await
         .map_err(|e| crate::error::NetcidrError::InvalidInput(format!("MCP server error: {e}")))?;
+    Ok(())
+}
+
+async fn run_mcp_http(
+    ipam: Option<McpIpamBackend>,
+    address: &str,
+    port: u16,
+) -> crate::error::Result<()> {
+    use rmcp::transport::streamable_http_server::{
+        StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+    };
+
+    let config = StreamableHttpServerConfig::default();
+    let ct = config.cancellation_token.clone();
+
+    let service = StreamableHttpService::new(
+        move || Ok(NetcidrMcp::new(ipam.clone())),
+        Arc::new(LocalSessionManager::default()),
+        config,
+    );
+
+    let router = axum::Router::new().nest_service("/mcp", service);
+    let bind_addr = format!("{address}:{port}");
+    let listener = tokio::net::TcpListener::bind(&bind_addr)
+        .await
+        .map_err(|e| {
+            crate::error::NetcidrError::InvalidInput(format!("Failed to bind {bind_addr}: {e}"))
+        })?;
+
+    eprintln!("MCP server listening on http://{bind_addr}/mcp");
+
+    let shutdown_ct = ct.clone();
+    tokio::spawn(async move {
+        let _ = tokio::signal::ctrl_c().await;
+        shutdown_ct.cancel();
+    });
+
+    axum::serve(listener, router)
+        .with_graceful_shutdown(async move { ct.cancelled().await })
+        .await
+        .map_err(|e| crate::error::NetcidrError::InvalidInput(format!("MCP server error: {e}")))?;
+
     Ok(())
 }
 
@@ -1112,10 +1215,16 @@ mod tests {
     #[test]
     fn test_mutually_exclusive_options() {
         // run_mcp_server validates this, but we can test the logic directly
-        let result = tokio_test::block_on(run_mcp_server(
-            Some("test.db"),
-            Some("http://localhost:8080"),
-        ));
+        let result = tokio_test::block_on(run_mcp_server(McpServerConfig {
+            transport: crate::cli::McpTransport::Stdio,
+            address: "127.0.0.1",
+            port: 3000,
+            daemonize: false,
+            pid_file: "/tmp/netcidr-test.pid",
+            log_file: None,
+            ipam_db: Some("test.db"),
+            api_url: Some("http://localhost:8080"),
+        }));
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("mutually exclusive"));


### PR DESCRIPTION
## Summary

- Add Streamable HTTP as the default MCP transport (`127.0.0.1:3000/mcp`), replacing stdio as the default
- Add `--daemonize` flag with PID file and log file support for running as a background process
- Add systemd and launchd service files in `contrib/` for managed deployment
- Stdio transport remains available via `--transport stdio`
- Bump version to 0.16.0

## New CLI flags

| Flag | Default | Description |
|------|---------|-------------|
| `--transport` | `http` | Transport protocol (`http` or `stdio`) |
| `--address` | `127.0.0.1` | Bind address (HTTP only) |
| `--port` | `3000` | Listen port (HTTP only) |
| `--daemonize` | off | Fork to background (HTTP only) |
| `--pid-file` | `/tmp/netcidr-mcp.pid` | PID file path |
| `--log-file` | none | Log file path (stderr if unset) |

## Test plan

- [ ] `cargo check --features mcp` compiles
- [ ] `cargo test --features mcp` — all 26 MCP tests pass
- [ ] `make check` — full CI suite passes (366 tests)
- [ ] `cargo run --features mcp -- mcp-serve` starts HTTP server on port 3000
- [ ] `cargo run --features mcp -- mcp-serve --transport stdio` uses stdio
- [ ] `cargo run --features mcp -- mcp-serve --daemonize --log-file /tmp/mcp.log` forks to background
- [ ] `curl -X POST http://127.0.0.1:3000/mcp` returns MCP response