### PR TITLE
fix: MCP --daemonize EBADF on bind (v0.16.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-03-27
+
+### Fixed
+
+- Fix MCP server `--daemonize` failing with "Bad file descriptor (os error 9)" — daemonize now forks before the tokio runtime is created so kqueue/epoll fds are not corrupted
+
 ## [0.16.0] - 2026-03-27
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netcidr"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 license = "MIT"
 description = "A fast IPv4 and IPv6 subnet calculator CLI and API"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -469,7 +469,7 @@ pub enum OutputFormatArg {
 }
 
 #[cfg(feature = "mcp")]
-#[derive(Clone, Copy, ValueEnum, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, ValueEnum, Default)]
 pub enum McpTransport {
     /// Streamable HTTP server (default)
     #[default]

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,8 +76,7 @@ async fn shutdown_signal() {
     info!("Shutdown signal received, starting graceful shutdown");
 }
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let cli = Cli::parse();
 
     // Launch TUI mode if requested
@@ -89,6 +88,33 @@ async fn main() {
         return;
     }
 
+    // Daemonize BEFORE creating the tokio runtime so the fork doesn't
+    // corrupt kqueue/epoll file descriptors used by the async I/O reactor.
+    #[cfg(feature = "mcp")]
+    if let Some(Commands::McpServe {
+        daemonize: true,
+        ref pid_file,
+        ref log_file,
+        ref transport,
+        ..
+    }) = cli.command
+    {
+        if *transport == netcidr::cli::McpTransport::Stdio {
+            eprintln!("Error: --daemonize is only supported with HTTP transport");
+            std::process::exit(1);
+        }
+        if let Err(e) = netcidr::mcp::daemonize_process(pid_file, log_file.as_deref()) {
+            eprintln!("Failed to daemonize: {}", e);
+            std::process::exit(1);
+        }
+    }
+
+    // Build the tokio runtime after any fork so file descriptors are valid.
+    let runtime = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
+    runtime.block_on(async_main(cli));
+}
+
+async fn async_main(cli: Cli) {
     let format: OutputFormat = cli.format.into();
     let writer = OutputWriter::new(format, cli.output.clone());
 
@@ -202,7 +228,7 @@ async fn main() {
             transport,
             address,
             port,
-            daemonize,
+            daemonize: _,
             pid_file,
             log_file,
             ipam_db,
@@ -212,7 +238,10 @@ async fn main() {
                 transport,
                 address: &address,
                 port,
-                daemonize,
+                // Daemonization already happened in main() before the tokio
+                // runtime was created, so we never daemonize inside the async
+                // context where it would corrupt the I/O reactor.
+                daemonize: false,
                 pid_file: &pid_file,
                 log_file: log_file.as_deref(),
                 ipam_db: ipam_db.as_deref(),

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -625,7 +625,11 @@ pub async fn run_mcp_server(config: McpServerConfig<'_>) -> crate::error::Result
 
 /// Fork the current process into the background using the `daemonize` crate,
 /// write a PID file, and redirect output to a log file (or /dev/null).
-fn daemonize_process(pid_file: &str, log_file: Option<&str>) -> crate::error::Result<()> {
+///
+/// **Must be called before creating a tokio runtime.** Forking after the
+/// runtime is alive corrupts the kqueue/epoll file descriptor, causing
+/// `TcpListener::bind` to fail with EBADF (os error 9).
+pub fn daemonize_process(pid_file: &str, log_file: Option<&str>) -> crate::error::Result<()> {
     let mut daemon = daemonize::Daemonize::new().pid_file(pid_file);
 
     if let Some(path) = log_file {


### PR DESCRIPTION
## Summary

- Fix MCP server `--daemonize` failing with "Bad file descriptor (os error 9)" when binding the TCP listener
- Root cause: `daemonize` crate forks the process after the tokio runtime is active, corrupting the kqueue/epoll fd used by the I/O reactor
- Solution: move daemonization to synchronous `main()` before `tokio::runtime::Runtime::new()`, so the child process gets a clean reactor

## Changes

- `src/main.rs`: Convert from `#[tokio::main]` to manual `fn main()` → `Runtime::new()` → `block_on(async_main())`, with daemonize called before runtime creation
- `src/mcp.rs`: Make `daemonize_process` public with doc comment on ordering requirement
- `src/cli.rs`: Add `PartialEq, Eq` to `McpTransport` for pre-fork pattern matching
- `Cargo.toml`: Bump to 0.16.1
- `CHANGELOG.md`: Add 0.16.1 entry

## Test plan

- [x] `cargo build --all-features` — clean, no warnings
- [x] `cargo test --all-features` — all tests pass
- [ ] Manual: `netcidr mcp-serve --daemonize` binds successfully on port 3000