### PR TITLE
Potential fix for code scanning alert no. 10: Uncontrolled allocation size

### DIFF
--- a/src/ipam/operations.rs
+++ b/src/ipam/operations.rs
@@ -8,6 +8,10 @@ use crate::ipam::models::*;
 use crate::ipam::store::IpamStore;
 use crate::validation;
 
+/// Maximum number of items allowed in a single batch release request.
+/// This guards against unbounded memory allocations from user input.
+const MAX_BATCH_RELEASE_ITEMS: usize = 10_000;
+
 /// High-level IPAM operations that sit above the store trait.
 /// All conflict detection and free-space logic lives here, keeping
 /// the store as a thin persistence boundary.
@@ -576,6 +580,15 @@ impl IpamOps {
     pub async fn batch_release(&self, request: &BatchReleaseRequest) -> Result<BatchReleaseResult> {
         // Resolve which allocation IDs to release
         let ids_to_release: Vec<(String, String)> = if let Some(ref ids) = request.allocation_ids {
+            // Explicit IDs — look up each to get the CIDR for the response
+            if ids.len() > MAX_BATCH_RELEASE_ITEMS {
+                return Err(NetcidrError::InvalidInput(
+                    format!(
+                        "batch release exceeds maximum allowed items (max {})",
+                        MAX_BATCH_RELEASE_ITEMS
+                    ),
+                ));
+            }
             // Explicit IDs — look up each to get the CIDR for the response
             let mut resolved = Vec::with_capacity(ids.len());
             for id in ids {


### PR DESCRIPTION
Potential fix for [https://github.com/wingnut128/netcidr/security/code-scanning/10](https://github.com/wingnut128/netcidr/security/code-scanning/10)

In general, to fix uncontrolled allocation sizes coming from user input, we need to enforce an upper bound on the amount of memory we are willing to allocate per request. For vectors, that typically means validating the maximum length of client-supplied lists before using them to size a collection, and returning a clear error if the limit is exceeded. This prevents a client from forcing the server to attempt an arbitrarily large allocation.

In this case, the problematic allocation is `Vec::with_capacity(ids.len())` in `IpamOps::batch_release`. The single best fix without changing existing semantics is to cap the number of `allocation_ids` that can be processed in one batch, and to reject larger requests with a `NetcidrError::InvalidInput`. We can implement this by adding a constant limit (e.g. `MAX_BATCH_RELEASE_ITEMS`) near the top of `operations.rs` and adding a guard when `allocation_ids` is present: if `ids.len()` exceeds the limit, return an error before allocating `resolved`. This preserves the existing behavior for normal-sized batches, adds a clear failure mode for oversized ones, and removes the uncontrolled allocation issue. No extra imports are needed; we only add a constant and a short length check.

Concretely:
- In `src/ipam/operations.rs`, define a constant like `const MAX_BATCH_RELEASE_ITEMS: usize = 10_000;` (value can be tuned).
- In `batch_release`, inside the `if let Some(ref ids) = request.allocation_ids` arm, insert a check before `Vec::with_capacity`:
  - If `ids.len() > MAX_BATCH_RELEASE_ITEMS`, return `Err(NetcidrError::InvalidInput("batch release exceeds maximum allowed items".to_string()))`.
- Keep the rest of the logic as-is.

This keeps functionality intact except for rejecting pathological oversized batches and prevents the vector allocation from being derived from an unbounded user-controlled length.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
