### PR TITLE
fix: replace cargo-audit with rustsec/audit-check@v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - run: cargo install cargo-audit
-      - run: cargo audit
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Replace `cargo install cargo-audit` with `rustsec/audit-check@v2` GitHub Action in CI — faster (pre-built binary), fixes CVSS v4.0 parsing failures
+- Add `rust-toolchain.toml` to pin stable channel for consistent builds across environments
+
 ## [0.18.0] - 2026-03-27
 
 ### Added

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"

--- a/src/mcp_client.rs
+++ b/src/mcp_client.rs
@@ -284,10 +284,7 @@ impl HttpIpamClient {
         }
     }
 
-    pub async fn batch_allocate(
-        &self,
-        items: &[BatchAllocateItem],
-    ) -> Result<BatchAllocateResult> {
+    pub async fn batch_allocate(&self, items: &[BatchAllocateItem]) -> Result<BatchAllocateResult> {
         let resp = self
             .client
             .post(self.url("/batch/allocate"))
@@ -304,10 +301,7 @@ impl HttpIpamClient {
         }
     }
 
-    pub async fn batch_release(
-        &self,
-        request: &BatchReleaseRequest,
-    ) -> Result<BatchReleaseResult> {
+    pub async fn batch_release(&self, request: &BatchReleaseRequest) -> Result<BatchReleaseResult> {
         let resp = self
             .client
             .post(self.url("/batch/release"))
@@ -324,10 +318,7 @@ impl HttpIpamClient {
         }
     }
 
-    pub async fn allocation_summary(
-        &self,
-        supernet_id: Option<&str>,
-    ) -> Result<AllocationSummary> {
+    pub async fn allocation_summary(&self, supernet_id: Option<&str>) -> Result<AllocationSummary> {
         let mut url = self.url("/batch/summary");
         if let Some(id) = supernet_id {
             url = format!("{url}?supernet_id={id}");


### PR DESCRIPTION
## Summary

- Replace `cargo install cargo-audit && cargo audit` with `rustsec/audit-check@v2` GitHub Action — fixes CVSS v4.0 parse failures that break the security audit job
- Add `rust-toolchain.toml` pinning the stable channel for consistent builds across local and CI environments

## Test plan

- [ ] CI audit job passes without CVSS v4.0 parse errors
- [ ] Other CI jobs (format, lint, test) unaffected