### PR TITLE
release: bump version to 0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.1] - 2026-03-28
+
 ### Changed
 
 - Replace `cargo install cargo-audit` with `rustsec/audit-check@v2` GitHub Action in CI — faster (pre-built binary), fixes CVSS v4.0 parsing failures

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "netcidr"
-version = "0.17.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netcidr"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2024"
 license = "MIT"
 description = "A fast IPv4 and IPv6 subnet calculator CLI and API"


### PR DESCRIPTION
## Summary

- Patch release 0.18.1 — bumps `Cargo.toml` version and moves `[Unreleased]` entries to dated `[0.18.1]` section in CHANGELOG

## Test plan

- [ ] CI passes
- [ ] After merge, trigger Release workflow with version `0.18.1`