### PR TITLE
ci: merge fmt+lint, add nextest, fix audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,24 +11,14 @@ env:
   CARGO_INCREMENTAL: "0"
 
 jobs:
-  format:
-    name: Format
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
-      - run: cargo fmt --all -- --check
-
   lint:
-    name: Lint
+    name: Format & Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy
+          components: rustfmt, clippy
       - uses: actions/cache@v5
         with:
           path: |
@@ -42,6 +32,7 @@ jobs:
           node-version: 22
       - name: Build dashboard
         run: cd dashboard && npm ci --silent && npm run build
+      - run: cargo fmt --all -- --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
 
   test:
@@ -50,6 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
       - uses: actions/cache@v5
         with:
           path: |
@@ -63,14 +55,13 @@ jobs:
           node-version: 22
       - name: Build dashboard
         run: cd dashboard && npm ci --silent && npm run build
-      - run: cargo test --features mcp,tui --verbose
+      - run: cargo nextest run --features mcp,tui
 
   audit:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: rustsec/audit-check@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: taiki-e/install-action@cargo-audit
+      - run: cargo audit
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Merge CI format and lint jobs into a single job — saves a runner spin-up
+- Switch CI test runner from `cargo test` to `cargo nextest run` for parallel test execution
+- Replace `rustsec/audit-check@v2` with `taiki-e/install-action@cargo-audit` — pre-built binary avoids 3-minute compilation and removes `checks: write` permission requirement
+
 ## [0.18.1] - 2026-03-28
 
 ### Changed


### PR DESCRIPTION
## Summary

- Merge format and lint into a single CI job — eliminates a redundant runner spin-up, checkout, and toolchain install
- Replace `cargo test` with `cargo nextest run` — runs tests in parallel across binaries (1.5-3x faster on typical projects)
- Replace `rustsec/audit-check@v2` with `taiki-e/install-action@cargo-audit` + `cargo audit` — fixes the `checks: write` permission error and avoids compiling cargo-audit from source (~3 min)

## Test plan

- [ ] Merged "Format & Lint" job passes (fmt check + clippy in one job)
- [ ] Test job passes with `cargo nextest run`
- [ ] Security Audit job passes without permission errors