### PR TITLE
fix: remove rust-toolchain.toml, auto-format in pre-commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,20 +1,16 @@
 #!/bin/sh
 #
 # Pre-commit hook for netcidr
-# Runs formatting check and linting before commit
+# Auto-formats code, then lints before commit
 
 set -e
 
 echo "Running pre-commit checks..."
 
-# Check formatting
-echo "Checking formatting..."
-if ! cargo fmt --all -- --check; then
-    echo ""
-    echo "ERROR: Formatting check failed."
-    echo "Run 'cargo fmt' to fix formatting issues."
-    exit 1
-fi
+# Auto-format and re-stage changed files
+echo "Formatting..."
+cargo fmt --all
+git diff --name-only --diff-filter=M | xargs -r git add
 
 # Run clippy
 echo "Running clippy..."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Switch CI test runner from `cargo test` to `cargo nextest run` for parallel test execution
 - Replace `rustsec/audit-check@v2` with `taiki-e/install-action@cargo-audit` — pre-built binary avoids 3-minute compilation and removes `checks: write` permission requirement
 
+### Removed
+
+- Remove `rust-toolchain.toml` — pinning `stable` adds no value; CI is the formatting authority via `dtolnay/rust-toolchain@stable`
+
 ## [0.18.1] - 2026-03-28
 
 ### Changed

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "stable"


### PR DESCRIPTION
## Summary

- Remove `rust-toolchain.toml` — pinning `stable` doesn't pin a version, CI (`dtolnay/rust-toolchain@stable`) is the formatting authority
- Change pre-commit hook to auto-format with `cargo fmt` and re-stage, instead of just failing with "run cargo fmt"

## Test plan

- [ ] CI passes without `rust-toolchain.toml`
- [ ] Pre-commit hook auto-formats and stages changes on commit