### PR TITLE
fix: cap batch_release input to prevent uncontrolled allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove `rust-toolchain.toml` — pinning `stable` adds no value; CI is the formatting authority via `dtolnay/rust-toolchain@stable`
 
+### Fixed
+
+- Cap `batch_release` allocation IDs at 10,000 to prevent uncontrolled memory allocation from user input (CodeQL alert #10)
+
 ## [0.18.1] - 2026-03-28
 
 ### Changed

--- a/src/ipam/operations.rs
+++ b/src/ipam/operations.rs
@@ -574,6 +574,17 @@ impl IpamOps {
     /// Batch release: release multiple allocations in a single call.
     /// Supports release by explicit IDs, by resource_id, or by supernet_id.
     pub async fn batch_release(&self, request: &BatchReleaseRequest) -> Result<BatchReleaseResult> {
+        const MAX_BATCH_RELEASE_ITEMS: usize = 10_000;
+
+        if let Some(ref ids) = request.allocation_ids
+            && ids.len() > MAX_BATCH_RELEASE_ITEMS
+        {
+            return Err(NetcidrError::InvalidInput(format!(
+                "batch release size {} exceeds maximum of {MAX_BATCH_RELEASE_ITEMS}",
+                ids.len()
+            )));
+        }
+
         // Resolve which allocation IDs to release
         let ids_to_release: Vec<(String, String)> = if let Some(ref ids) = request.allocation_ids {
             // Explicit IDs — look up each to get the CIDR for the response
@@ -2978,5 +2989,20 @@ mod tests {
             list_result.is_ok(),
             "store should remain queryable after concurrent operations"
         );
+    }
+
+    #[tokio::test]
+    async fn test_batch_release_rejects_oversized_request() {
+        let ops = test_ops().await;
+
+        let oversized_ids: Vec<String> = (0..10_001).map(|i| format!("id-{i}")).collect();
+        let request = BatchReleaseRequest {
+            allocation_ids: Some(oversized_ids),
+            resource_id: None,
+            supernet_id: None,
+        };
+
+        let err = ops.batch_release(&request).await.unwrap_err();
+        assert!(matches!(err, NetcidrError::InvalidInput(_)));
     }
 }


### PR DESCRIPTION
## Summary

- Add `MAX_BATCH_RELEASE_ITEMS` (10,000) guard in `batch_release` before `Vec::with_capacity(ids.len())` — prevents a client from forcing an arbitrarily large allocation via `allocation_ids`
- Matches the existing pattern in `batch_allocate` (which already caps at 100)
- Adds unit test for the rejection path

Resolves CodeQL code-scanning alert #10. Closes #12.

## Test plan

- [ ] `test_batch_release_rejects_oversized_request` passes
- [ ] Existing batch release tests unaffected