### PR TITLE
release: bump version to 0.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.2] - 2026-03-28
+
 ### Changed
 
 - Merge CI format and lint jobs into a single job — saves a runner spin-up

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "netcidr"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netcidr"
-version = "0.18.1"
+version = "0.18.2"
 edition = "2024"
 license = "MIT"
 description = "A fast IPv4 and IPv6 subnet calculator CLI and API"


### PR DESCRIPTION
## Summary

- Patch release 0.18.2 — security fix for uncontrolled allocation in `batch_release` (CodeQL alert #10), CI pipeline optimizations

## Test plan

- [ ] CI passes
- [ ] After merge, trigger Release workflow with version `0.18.2`