### PR TITLE
ci: restrict workflow permissions to read-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"


### PR DESCRIPTION
## Summary
- Add top-level `permissions: contents: read` to `ci.yml` to restrict the default `GITHUB_TOKEN` to read-only access, following the principle of least privilege

## Test plan
- [ ] Verify CI jobs (lint, test, audit) still pass with restricted permissions