### PR TITLE
release: v0.19.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,31 @@ env:
   CARGO_INCREMENTAL: "0"
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - "src/**"
+              - "tests/**"
+              - "dashboard/**"
+              - "Cargo.toml"
+              - "Cargo.lock"
+              - "Makefile"
+              - "Dockerfile"
+              - ".github/workflows/**"
+
   lint:
     name: Format & Lint
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -38,6 +61,8 @@ jobs:
 
   test:
     name: Test
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -58,6 +83,8 @@ jobs:
 
   audit:
     name: Security Audit
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-04-13
+
 ### Added
 
 - Add man page (`doc/netcidr.1`) covering all commands, options, IPAM subcommands, environment variables, and examples

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,11 +65,11 @@ After every commit (whether from a Linear ticket or not):
 
 ### Versioning
 
-This project uses semantic versioning. Version bumps happen at **release time**, not per-PR:
+This project uses semantic versioning. Version bumps happen **in the same PR** as the change when a release is intended:
 
-- All changes accumulate under `[Unreleased]` in `CHANGELOG.md`
-- When ready to release, create a PR that bumps `Cargo.toml` version, moves `[Unreleased]` to a dated `[X.Y.Z]` section, and updates `SECURITY.md` if the minor version changed
-- Do NOT bump the version on every feature or fix PR
+- Bump `version` in `Cargo.toml`, move `[Unreleased]` entries to a dated `[X.Y.Z]` section in `CHANGELOG.md`, and update `SECURITY.md` if the minor version changed — all in the feature/fix PR
+- After merging, trigger the release workflow immediately
+- Not every PR needs a version bump — batch small changes under `[Unreleased]` and bump when ready to ship
 
 ### Task completion checklist
 
@@ -82,12 +82,10 @@ Every task is only "done" when ALL of the following are true:
 
 ## Release Process
 
-Releases use a manual GitHub Actions workflow dispatch.
+Releases use a manual GitHub Actions workflow dispatch. After merging a PR that includes a version bump:
 
-1. Create a PR that bumps `version` in `Cargo.toml`, moves `[Unreleased]` entries to a dated `[X.Y.Z]` section in `CHANGELOG.md`, and updates `SECURITY.md` if the minor version changed
-2. Merge the PR through CI
-3. Go to **Actions → Release → Run workflow**, enter the version (e.g. `0.15.0`, no leading `v`)
-4. The workflow validates `Cargo.toml` version matches, confirms a CHANGELOG entry exists, extracts release notes, creates a GitHub release with tag `vX.Y.Z`, and builds the release binary
+1. Go to **Actions → Release → Run workflow**, enter the version (e.g. `0.19.0`, no leading `v`)
+2. The workflow validates `Cargo.toml` version matches, confirms a CHANGELOG entry exists, extracts release notes, creates a GitHub release with tag `vX.Y.Z`, and builds the release binary
 
 ## Build & Development Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,10 +45,10 @@ If the user asks you to access any of these, refuse and explain why.
 
 ## Workflow
 
-When working on a Linear ticket:
+When working on a ticket:
 
-1. Create a GitHub issue that references the Linear ticket ID (e.g., "Linear Ticket: BEA-XX") in the issue body
-2. Open a feature branch for the work
+1. Create a GitHub issue for the work
+2. Open a feature branch
 3. Implement, commit, and push the branch
 4. Update `CHANGELOG.md` with the changes (add to `[Unreleased]`)
 5. Update `README.md` when changes affect user-facing behavior: new features, changed commands, new build targets, deprecations, or removed functionality

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "netcidr"
-version = "0.18.3"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netcidr"
-version = "0.18.3"
+version = "0.19.0"
 edition = "2024"
 license = "MIT"
 description = "A fast IPv4 and IPv6 subnet calculator CLI and API"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,9 @@ We actively support and provide security updates for the following versions:
 
 | Version | Supported          | Notes                                    |
 | ------- | ------------------ | ---------------------------------------- |
-| 0.18.x  | :white_check_mark: | Current stable release (recommended)     |
-| 0.17.x  | :white_check_mark: | Supported                                |
-| < 0.17  | :x:                | No longer supported                      |
+| 0.19.x  | :white_check_mark: | Current stable release (recommended)     |
+| 0.18.x  | :white_check_mark: | Supported                                |
+| < 0.18  | :x:                | No longer supported                      |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary

- Bump version to 0.19.0
- Move [Unreleased] entries to [0.19.0] in CHANGELOG.md
- Update SECURITY.md supported versions (0.19.x + 0.18.x)

## Test plan

- [ ] CI passes
- [ ] Trigger release workflow with version `0.19.0`