### PR TITLE
feat: add parameterized Cloud Build config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.1] - 2026-04-13
+
+### Added
+
+- Add `cloudbuild.yaml` for GCP Cloud Build with parameterized substitutions
+
 ## [0.19.0] - 2026-04-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "netcidr"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netcidr"
-version = "0.19.0"
+version = "0.19.1"
 edition = "2024"
 license = "MIT"
 description = "A fast IPv4 and IPv6 subnet calculator CLI and API"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,30 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/netcidr:$TAG_NAME'
+      - '-t'
+      - '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/netcidr:latest'
+      - '.'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - '--all-tags'
+      - '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/netcidr'
+
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+      - 'run'
+      - 'services'
+      - 'update'
+      - '${_SERVICE_NAME}'
+      - '--image'
+      - '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/netcidr:$TAG_NAME'
+      - '--region'
+      - '${_REGION}'
+
+options:
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## Summary

- Add `cloudbuild.yaml` with parameterized substitutions (`_REGION`, `_AR_REPO`, `_SERVICE_NAME`) — values injected by Pulumi trigger
- Bump to v0.19.1

## Test plan

- [ ] CI passes
- [ ] Cloud Build trigger fires on release tag and substitutions resolve correctly