### PR TITLE
fix: patch Dockerfile libssl3 CVEs by bumping to Alpine 3.23 (v0.19.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.2] - 2026-04-13
+
 ### Fixed
 
 - Bump Dockerfile base images to Alpine 3.23 (builder: `rust:1.94-alpine3.23`, runtime: `alpine:3.23`) to pick up patched `libssl3`, addressing CVE-2026-28387, CVE-2026-31790, CVE-2026-28388, and related openssl vulnerabilities reported by Snyk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Bump Dockerfile base images to Alpine 3.23 (builder: `rust:1.94-alpine3.23`, runtime: `alpine:3.23`) to pick up patched `libssl3`, addressing CVE-2026-28387, CVE-2026-31790, CVE-2026-28388, and related openssl vulnerabilities reported by Snyk
+- Pin dashboard build image to `oven/bun:1-alpine` instead of the floating `oven/bun:alpine` tag
+
 ## [0.19.1] - 2026-04-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "netcidr"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netcidr"
-version = "0.19.1"
+version = "0.19.2"
 edition = "2024"
 license = "MIT"
 description = "A fast IPv4 and IPv6 subnet calculator CLI and API"

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,14 @@ ARG FEATURES=default
 ARG WITH_DASHBOARD=true
 
 # ---------- Dashboard build (skipped when WITH_DASHBOARD=false) -----------
-FROM oven/bun:alpine AS dashboard-build
+FROM oven/bun:1-alpine AS dashboard-build
 WORKDIR /app/dashboard
 COPY dashboard/package.json dashboard/bun.lock ./
 RUN bun install --frozen-lockfile
 COPY dashboard/ ./
 RUN bun run build
 
-FROM alpine:3.21 AS dashboard-false
+FROM alpine:3.23 AS dashboard-false
 RUN mkdir -p /app/dashboard/dist
 
 FROM dashboard-build AS dashboard-true
@@ -28,7 +28,7 @@ FROM dashboard-build AS dashboard-true
 FROM dashboard-${WITH_DASHBOARD} AS dashboard
 
 # ---------- Rust build ---------------------------------------------------
-FROM rust:1.88-alpine AS builder
+FROM rust:1.94-alpine3.23 AS builder
 
 ARG FEATURES
 
@@ -57,7 +57,7 @@ RUN touch src/main.rs && \
     cargo build --release --no-default-features --features "${FEATURES}"
 
 # ---------- Runtime -------------------------------------------------------
-FROM alpine:3.21
+FROM alpine:3.23
 
 RUN apk add --no-cache ca-certificates
 


### PR DESCRIPTION
## Summary

Snyk flagged three `openssl/libssl3 3.3.6-r0` CVEs (CVE-2026-28387, CVE-2026-31790, CVE-2026-28388, plus 3 more) against the Dockerfile. The underlying cause is that all three base images pinned to Alpine 3.21, which ships the vulnerable libssl3.

- Builder: `rust:1.88-alpine` → `rust:1.94-alpine3.23`
- Runtime: `alpine:3.21` → `alpine:3.23`
- Dashboard builder: `oven/bun:alpine` (floating) → `oven/bun:1-alpine` (pinned major)

Bumps version to `0.19.2` and moves the CHANGELOG entry to a dated section.

## Test plan

- [ ] CI green (fmt, lint, test, test-tui, test-mcp, semgrep)
- [ ] Docker image builds successfully on CI
- [ ] Release workflow triggered after merge