### PR TITLE
ci: auto-trigger release on Cargo.toml version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,10 @@
 name: Release
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - Cargo.toml
   workflow_dispatch:
     inputs:
       release_version:
@@ -9,13 +13,63 @@ on:
         type: string
 
 jobs:
+  detect:
+    name: Detect version bump
+    runs-on: ubuntu-latest
+    outputs:
+      release_version: ${{ steps.out.outputs.release_version }}
+      should_release: ${{ steps.out.outputs.should_release }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - id: out
+        name: Decide whether to release
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VER="${{ inputs.release_version }}"
+            echo "release_version=$VER" >> "$GITHUB_OUTPUT"
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            echo "Manual dispatch: releasing $VER"
+            exit 0
+          fi
+
+          NEW=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          OLD=$(git show HEAD~1:Cargo.toml 2>/dev/null | grep '^version' | head -1 | sed 's/.*"\(.*\)".*/\1/' || echo "")
+
+          if [ "$NEW" = "$OLD" ]; then
+            echo "Cargo.toml version unchanged ($NEW); skipping release."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! echo "$NEW" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Version '$NEW' is not X.Y.Z; skipping release."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git ls-remote --tags origin "refs/tags/v$NEW" | grep -q "refs/tags/v$NEW"; then
+            echo "Tag v$NEW already exists on origin; skipping release."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Detected version bump: $OLD -> $NEW; releasing."
+          echo "release_version=$NEW" >> "$GITHUB_OUTPUT"
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
+
   release:
     name: Build and Release
+    needs: detect
+    if: needs.detect.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
     env:
-      RELEASE_VERSION: ${{ inputs.release_version }}
+      RELEASE_VERSION: ${{ needs.detect.outputs.release_version }}
     steps:
       - uses: actions/checkout@v6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Release workflow now auto-triggers on pushes to `main` that bump the `Cargo.toml` version, in addition to the existing manual `workflow_dispatch`. A new `detect` job compares the old and new versions and skips release if the version is unchanged, malformed, or the tag already exists.
+
 ## [0.19.2] - 2026-04-13
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,10 +82,9 @@ Every task is only "done" when ALL of the following are true:
 
 ## Release Process
 
-Releases use a manual GitHub Actions workflow dispatch. After merging a PR that includes a version bump:
+Releases auto-trigger when a PR merged to `main` changes `Cargo.toml`. The workflow's `detect` job compares the old and new version; if the version bumped to a new `X.Y.Z` and no `vX.Y.Z` tag exists yet, the `release` job runs automatically. Manual `workflow_dispatch` is still available as a fallback (Actions → Release → Run workflow, enter the version without leading `v`).
 
-1. Go to **Actions → Release → Run workflow**, enter the version (e.g. `0.19.0`, no leading `v`)
-2. The workflow validates `Cargo.toml` version matches, confirms a CHANGELOG entry exists, extracts release notes, creates a GitHub release with tag `vX.Y.Z`, and builds the release binary
+The release job validates `Cargo.toml` version matches, confirms a CHANGELOG entry exists, extracts release notes, builds the release binary, and creates a GitHub release with tag `vX.Y.Z`. So the full release flow for a maintainer is: bump `Cargo.toml` + CHANGELOG in the PR, merge, done.
 
 ## Build & Development Commands
 


### PR DESCRIPTION
## Summary

Adds a `push` trigger to `.github/workflows/release.yml` so that a merged PR which bumps `Cargo.toml` automatically releases — no more manual workflow dispatch needed for the common case.

- New `detect` job reads the old version (from `HEAD~1:Cargo.toml`) and the new version (from `Cargo.toml`)
- Skips release if the version is unchanged, malformed, or `vX.Y.Z` tag already exists on origin
- Existing `release` job now depends on `detect` and runs only when `should_release == 'true'`
- `workflow_dispatch` retained as a fallback
- CLAUDE.md updated to describe the new flow

## Test plan

- [ ] CI green on this PR (no release should fire — Cargo.toml isn't changed here)
- [ ] Next version bump PR should auto-release on merge
- [ ] Manual dispatch path still works (covered by existing validation steps)