### PR TITLE
release: v0.19.3 (first release containing the Dockerfile CVE fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.3] - 2026-04-13
+
+### Fixed
+
+- Bump Dockerfile base images to Alpine 3.23 (builder: `rust:1.94-alpine3.23`, runtime: `alpine:3.23`) to pick up patched `libssl3`, addressing CVE-2026-28387, CVE-2026-31790, CVE-2026-28388, and related openssl vulnerabilities reported by Snyk
+- Pin dashboard build image to `oven/bun:1-alpine` instead of the floating `oven/bun:alpine` tag
+
 ### Changed
 
 - Release workflow now auto-triggers on pushes to `main` that bump the `Cargo.toml` version, in addition to the existing manual `workflow_dispatch`. A new `detect` job compares the old and new versions and skips release if the version is unchanged, malformed, or the tag already exists.
+
+### Note
+
+- `v0.19.2` was skipped because a release tag was previously published against an unrelated commit before the Dockerfile CVE patches landed. This release (`v0.19.3`) is the first tag that actually contains the libssl3 fixes.
 
 ## [0.19.2] - 2026-04-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "netcidr"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netcidr"
-version = "0.19.2"
+version = "0.19.3"
 edition = "2024"
 license = "MIT"
 description = "A fast IPv4 and IPv6 subnet calculator CLI and API"


### PR DESCRIPTION
## Summary

Bumps to `0.19.3` so the Dockerfile libssl3 CVE patches (merged in #47) can actually ship — the `v0.19.2` tag was already published against an unrelated earlier commit, so the fixes never got released under that version.

This is the first exercise of the auto-release trigger added in #48 — merging this PR should automatically create and publish `v0.19.3` with the Dockerfile CVE fix as the release note.

## Test plan

- [ ] CI green
- [ ] On merge, Release workflow's `detect` job fires and creates tag `v0.19.3`
- [ ] Release notes extracted from the `[0.19.3]` CHANGELOG section