### PR TITLE
ci: switch CodeQL to advanced setup with paths-ignore

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
           - language: javascript-typescript
             build-mode: none
           - language: rust
-            build-mode: manual
+            build-mode: none
     steps:
       - uses: actions/checkout@v6
 
@@ -50,20 +50,6 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
-
-      - uses: dtolnay/rust-toolchain@stable
-        if: matrix.language == 'rust'
-
-      - uses: oven-sh/setup-bun@v2
-        if: matrix.language == 'rust'
-
-      - name: Build dashboard
-        if: matrix.language == 'rust'
-        run: cd dashboard && bun install --frozen-lockfile && bun run build
-
-      - name: Build Rust
-        if: matrix.language == 'rust'
-        run: cargo build --all-features --locked
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,71 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "doc/**"
+      - "LICENSE"
+      - ".gitignore"
+      - ".editorconfig"
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "doc/**"
+      - "LICENSE"
+      - ".gitignore"
+      - ".editorconfig"
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: rust
+            build-mode: manual
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        if: matrix.language == 'rust'
+
+      - uses: oven-sh/setup-bun@v2
+        if: matrix.language == 'rust'
+
+      - name: Build dashboard
+        if: matrix.language == 'rust'
+        run: cd dashboard && bun install --frozen-lockfile && bun run build
+
+      - name: Build Rust
+        if: matrix.language == 'rust'
+        run: cargo build --all-features --locked
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Release workflow now auto-triggers on pushes to `main` that bump the `Cargo.toml` version, in addition to the existing manual `workflow_dispatch`. A new `detect` job compares the old and new versions and skips release if the version is unchanged, malformed, or the tag already exists.
+- Move CodeQL from GitHub default setup to an advanced workflow (`.github/workflows/codeql.yml`) so docs-only changes (`**/*.md`, `doc/**`, `LICENSE`) skip scans via `paths-ignore`. Scans still run weekly on schedule.
 
 ## [0.19.2] - 2026-04-13
 


### PR DESCRIPTION
## Summary
- Disables GitHub's default CodeQL setup and replaces it with `.github/workflows/codeql.yml` so we can apply `paths-ignore` filters.
- Scans skip on docs-only changes (`**/*.md`, `doc/**`, `LICENSE`, `.gitignore`, `.editorconfig`).
- Preserves weekly scheduled scan and covers the same languages as before (actions, javascript-typescript, rust).

Closes #51

## Test plan
- [ ] CI green on this PR (CodeQL runs because workflow files changed)
- [ ] After merge, push a docs-only change and confirm CodeQL does not run