### PR TITLE
ci: add least-privilege default permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   detect:
     name: Detect version bump

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Add top-level `permissions: contents: read` to `.github/workflows/release.yml` so the `detect` job runs with a least-privilege `GITHUB_TOKEN`. The `release` job retains its explicit `contents: write` override. Resolves CodeQL alert `actions/missing-workflow-permissions`.
+
 ### Fixed
 
 - Bump `rustls-webpki` to 0.103.12 to address RUSTSEC-2026-0098 (URI name constraint bypass) and RUSTSEC-2026-0099 (wildcard name constraint bypass)

--- a/src/api.rs
+++ b/src/api.rs
@@ -386,27 +386,27 @@ pub fn create_router(config: RouterConfig) -> Router {
     // Per-IP rate limiting via tower-governor (disabled when rate_limit_per_second == 0).
     // Requires ConnectInfo<SocketAddr> — the server must use
     // `into_make_service_with_connect_info::<SocketAddr>()`.
-    let router = if config.server.rate_limit_per_second > 0 {
-        let replenish_ms = 1000u64 / config.server.rate_limit_per_second;
-        match GovernorConfigBuilder::default()
-            .per_millisecond(replenish_ms)
-            .burst_size(config.server.rate_limit_burst)
-            .finish()
-        {
-            Some(governor_config) => router.layer(GovernorLayer::new(governor_config)),
-            None => {
-                // burst_size = 0 makes the config invalid; disable rate limiting and warn.
-                warn!(
-                    rate_limit_per_second = config.server.rate_limit_per_second,
-                    rate_limit_burst = config.server.rate_limit_burst,
-                    "invalid rate limit config (burst_size must be > 0); rate limiting disabled"
-                );
-                router
+    let router =
+        if let Some(replenish_ms) = 1000u64.checked_div(config.server.rate_limit_per_second) {
+            match GovernorConfigBuilder::default()
+                .per_millisecond(replenish_ms)
+                .burst_size(config.server.rate_limit_burst)
+                .finish()
+            {
+                Some(governor_config) => router.layer(GovernorLayer::new(governor_config)),
+                None => {
+                    // burst_size = 0 makes the config invalid; disable rate limiting and warn.
+                    warn!(
+                        rate_limit_per_second = config.server.rate_limit_per_second,
+                        rate_limit_burst = config.server.rate_limit_burst,
+                        "invalid rate limit config (burst_size must be > 0); rate limiting disabled"
+                    );
+                    router
+                }
             }
-        }
-    } else {
-        router
-    };
+        } else {
+            router
+        };
 
     router
         .layer(cors)


### PR DESCRIPTION
## Summary
- Add top-level `permissions: contents: read` to `.github/workflows/release.yml` so the `detect` job inherits a read-only `GITHUB_TOKEN`. The `release` job keeps its explicit `contents: write` override.
- Resolves CodeQL alert `actions/missing-workflow-permissions` (medium) on `release.yml:17`.
- Drive-by: switch `1000u64 / rate_limit_per_second` to `checked_div` in `src/api.rs:389` to satisfy the new `clippy::manual_checked_ops` lint introduced in Rust 1.95 (was breaking CI on this branch).

## Test plan
- [ ] CI passes on the PR
- [ ] After merge, confirm CodeQL alert #14 auto-closes on next scan
- [ ] Next version bump still triggers the auto-release flow end-to-end
