### PR TITLE
security: tighten dependabot-automerge workflow token permissions

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 jobs:
   automerge:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Add top-level `permissions: contents: read` to `.github/workflows/release.yml` so the `detect` job runs with a least-privilege `GITHUB_TOKEN`. The `release` job retains its explicit `contents: write` override. Resolves CodeQL alert `actions/missing-workflow-permissions`.
+- Drop top-level permissions in `.github/workflows/dependabot-automerge.yml` to `contents: read` + `pull-requests: read`. The auto-merge step uses `DEPENDABOT_PAT`, so the workflow's `GITHUB_TOKEN` does not need write access. Resolves Scorecard `TokenPermissionsID` alert (#68).
 
 ### Fixed
 


### PR DESCRIPTION
Closes #68.

## Summary
- Drop top-level permissions in `.github/workflows/dependabot-automerge.yml` from `contents: write` + `pull-requests: write` to `contents: read` + `pull-requests: read`.
- The auto-merge step uses `DEPENDABOT_PAT`, not `GITHUB_TOKEN`, so the workflow's `GITHUB_TOKEN` does not need write access.
- Resolves Scorecard `TokenPermissionsID` alert #17.

## Notes on related alerts
- Scorecard alert #16 on `release.yml` (job-level `contents: write`) is required for `gh release create` and should be dismissed as won't-fix rather than worked around.
- `cargo audit` open items are both unfixable at this time:
  - `RUSTSEC-2025-0069` (daemonize unmaintained) — 0.5.0 is the latest version
  - `RUSTSEC-2026-0097` (rand 0.8.5 unsound) — transitive via sqlx-postgres and phf_generator; needs upstream bumps

## Test plan
- [x] YAML parses / lints clean
- [ ] Next dependabot PR still auto-merges after this lands