### PR TITLE
security: replace unmaintained `daemonize` with `daemonize-me`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add top-level `permissions: contents: read` to `.github/workflows/release.yml` so the `detect` job runs with a least-privilege `GITHUB_TOKEN`. The `release` job retains its explicit `contents: write` override. Resolves CodeQL alert `actions/missing-workflow-permissions`.
 - Drop top-level permissions in `.github/workflows/dependabot-automerge.yml` to `contents: read` + `pull-requests: read`. The auto-merge step uses `DEPENDABOT_PAT`, so the workflow's `GITHUB_TOKEN` does not need write access. Resolves Scorecard `TokenPermissionsID` alert (#68).
+- Replace the unmaintained `daemonize` crate with the actively maintained `daemonize-me` 2.x fork. Resolves RUSTSEC-2025-0069. No user-visible change — `--daemonize` behavior is preserved.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,12 +644,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "daemonize"
-version = "0.5.0"
+name = "daemonize-me"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8bfdaacb3c887a54d41bdf48d3af8873b3f5566469f8ba21b92057509f116e"
+checksum = "5d7e7dc0363f9af1531fb2d20d257551c971d2da608d37b785901163ca20985f"
 dependencies = [
  "libc",
+ "nix",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1912,7 +1914,7 @@ dependencies = [
  "clap_complete",
  "crossterm",
  "csv",
- "daemonize",
+ "daemonize-me",
  "dirs",
  "http-body-util",
  "ipnet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ anyhow = "1"
 async-trait = "0.1"
 dirs = "6"
 rmcp = { version = "1.3", features = ["server", "transport-io", "transport-streamable-http-server", "macros"], optional = true }
-daemonize = "0.5"
+daemonize-me = "2"
 tokio-util = { version = "0.7", features = ["rt"], optional = true }
 schemars = { version = "1", optional = true }
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "query"], optional = true }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -7,7 +7,7 @@
 /// Fork the current process into the background, write a PID file, and
 /// redirect output to a log file (or /dev/null).
 pub fn daemonize_process(pid_file: &str, log_file: Option<&str>) -> crate::error::Result<()> {
-    let mut daemon = daemonize::Daemonize::new().pid_file(pid_file);
+    let mut daemon = daemonize_me::Daemon::new().pid_file(pid_file, Some(false));
 
     if let Some(path) = log_file {
         let stdout = std::fs::OpenOptions::new()


### PR DESCRIPTION
Closes #70. Resolves RUSTSEC-2025-0069.

## Summary
- Swap `daemonize = "0.5"` for `daemonize-me = "2"` — `daemonize-me` is an actively maintained fork of the original crate.
- Only code change: `pid_file(path)` → `pid_file(path, Some(false))` (new second arg controls chown-to-user behavior; `false` matches prior behavior).
- No user-visible change — `netcidr serve --daemonize` and `netcidr mcp-serve --daemonize` behave identically.

## Verification
- `cargo build` — clean
- `cargo test --lib` — 220/220 pass
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo audit` — RUSTSEC-2025-0069 resolved; only remaining advisory is RUSTSEC-2026-0097 (transitive `rand` unsound via `sqlx-postgres` + `phf_generator`), which requires upstream bumps.

## Test plan
- [x] Unit tests pass
- [x] Clippy clean
- [x] `cargo audit` no longer reports daemonize advisory
- [ ] Smoke-test `netcidr serve --daemonize` on Linux (CI)