### PR TITLE
fix: bump rustls-webpki to 0.103.13 (RUSTSEC-2026-0104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Bump `rustls-webpki` to 0.103.12 to address RUSTSEC-2026-0098 (URI name constraint bypass) and RUSTSEC-2026-0099 (wildcard name constraint bypass)
+- Bump `rustls-webpki` to 0.103.13 to address RUSTSEC-2026-0104 (reachable panic in certificate revocation list parsing). Supersedes the earlier 0.103.12 bump for RUSTSEC-2026-0098/0099.
 - Cap audit log `LIMIT` at 10,000 and bind it as a typed parameter in both SQLite and Postgres backends, preventing a full-table-scan DoS via `u32::MAX` (closes #53)
 - Validate `AuditFilter` fields (`entity_type`, `entity_id`, `action`) through the shared validation layer before reaching the store, consistent with all other IPAM operations (closes #53)
 - Sanitize `DatabaseError` responses in the HTTP API: raw DB messages (table names, file paths, constraint names) are now logged internally and replaced with generic strings for clients (closes #53)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2932,9 +2932,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary
- Updates transitive `rustls-webpki` 0.103.12 → 0.103.13 to fix RUSTSEC-2026-0104 (reachable panic in CRL parsing)
- CHANGELOG entry updated — supersedes the prior 0.103.12 bump note

## Test plan
- [x] `cargo build`
- [x] `cargo test --lib` (220 passed)
- [x] `cargo audit` — RUSTSEC-2026-0104 cleared; only remaining finding is the known-benign rand 0.8 warning (transitive via sqlx-postgres, not the vulnerable `rand::rng()` pattern)