### PR TITLE
refactor: migrate Dockerfile runtime to Chainguard static base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Migrate Dockerfile runtime to Chainguard's distroless `cgr.dev/chainguard/static` image (digest-pinned). Produces a statically-linked musl binary on a near-zero-CVE runtime. The Alpine-based Rust builder is retained because Chainguard's `rust:latest-dev` does not ship a musl `rust-std` target. Image has no shell; container-level `HEALTHCHECK` is removed — orchestrators (Kubernetes probe, docker-compose TCP/HTTP probe on `:8080/health`) now own health checking. The builder stage also installs `curl`, which is required by the `utoipa-swagger-ui` build script.
+- Migrate Dockerfile runtime to Chainguard's distroless `cgr.dev/chainguard/static` image (digest-pinned), producing a statically-linked musl binary on a near-zero-CVE rootfs. The Alpine-based Rust builder is retained because Chainguard's `rust:latest-dev` does not ship a musl `rust-std` target; the builder stage now also installs `curl`, which the `utoipa-swagger-ui` build script requires.
+- Remove the container-level `HEALTHCHECK` directive — the distroless runtime has no shell, so in-container probes are delegated to the orchestrator (Kubernetes `httpGet` probe or a host-run check against `/health`).
+- Rework the README Docker section for the shell-less runtime: docker-compose ordering now uses `depends_on: { condition: service_started }` plus a host-run `curl http://localhost:8080/health`, with a Kubernetes `httpGet` probe snippet as the production-grade example.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Migrate Dockerfile runtime to Chainguard's distroless `cgr.dev/chainguard/static` image (digest-pinned). Produces a statically-linked musl binary on a near-zero-CVE runtime. The Alpine-based Rust builder is retained because Chainguard's `rust:latest-dev` does not ship a musl `rust-std` target. Image has no shell; container-level `HEALTHCHECK` is removed — orchestrators (Kubernetes probe, docker-compose TCP/HTTP probe on `:8080/health`) now own health checking. The builder stage also installs `curl`, which is required by the `utoipa-swagger-ui` build script.
+
 ### Security
 
 - Add top-level `permissions: contents: read` to `.github/workflows/release.yml` so the `detect` job runs with a least-privilege `GITHUB_TOKEN`. The `release` job retains its explicit `contents: write` override. Resolves CodeQL alert `actions/missing-workflow-permissions`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
 # syntax=docker/dockerfile:1
 #
 # Build args:
-#   FEATURES  - Cargo feature flags (default: "default" which includes swagger + dashboard)
+#   FEATURES       - Cargo feature flags (default: "default" which includes swagger + dashboard)
+#   WITH_DASHBOARD - "true" builds the React dashboard; "false" skips it (default: true)
 #
 # Examples:
 #   docker build .                                          # full build with dashboard
 #   docker build --build-arg FEATURES=swagger .             # no dashboard
 #   docker build --build-arg FEATURES="" .                  # slim: no swagger, no dashboard
+#
+# Runtime is Chainguard's distroless `static` image: no shell, no package manager,
+# minimal CVE surface. Because there is no shell, HEALTHCHECK is delegated to the
+# orchestrator (Kubernetes probe, docker-compose healthcheck with TCP probe, etc.).
 #
 ARG FEATURES=default
 ARG WITH_DASHBOARD=true
@@ -19,7 +24,9 @@ RUN bun install --frozen-lockfile
 COPY dashboard/ ./
 RUN bun run build
 
-FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS dashboard-false
+# When dashboards are disabled, use the same Rust builder image to create an empty
+# placeholder directory. Chainguard/static has no shell, so we can't `mkdir` there.
+FROM rust:1.95-alpine3.23@sha256:606fd313a0f49743ee2a7bd49a0914bab7deedb12791f3a846a34a4711db7ed2 AS dashboard-false
 RUN mkdir -p /app/dashboard/dist
 
 FROM dashboard-build AS dashboard-true
@@ -28,11 +35,17 @@ FROM dashboard-build AS dashboard-true
 FROM dashboard-${WITH_DASHBOARD} AS dashboard
 
 # ---------- Rust build ---------------------------------------------------
+# Alpine's official Rust image produces a fully statically-linked musl binary.
+# Chainguard's `rust:latest-dev` (Wolfi) does not ship a musl rust-std target,
+# so we keep Alpine for the build stage and rely on Chainguard only for the
+# runtime — the artifact copied into the final image is what matters for CVE
+# surface.
 FROM rust:1.95-alpine3.23@sha256:606fd313a0f49743ee2a7bd49a0914bab7deedb12791f3a846a34a4711db7ed2 AS builder
 
 ARG FEATURES
 
-RUN apk add --no-cache musl-dev
+# musl-dev: static linking; curl: required by utoipa-swagger-ui build script
+RUN apk add --no-cache musl-dev curl
 
 WORKDIR /app
 
@@ -57,23 +70,21 @@ RUN touch src/main.rs && \
     cargo build --release --no-default-features --features "${FEATURES}"
 
 # ---------- Runtime -------------------------------------------------------
-FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
-
-RUN apk add --no-cache ca-certificates
-
-RUN addgroup -g 1000 netcidr && \
-    adduser -u 1000 -G netcidr -s /bin/sh -D netcidr
-
-WORKDIR /app
+# cgr.dev/chainguard/static:latest — distroless, nonroot by default, CA bundle
+# bundled at /etc/ssl/certs/ca-certificates.crt, no shell, no package manager.
+FROM cgr.dev/chainguard/static@sha256:1f14279403150757d801f6308bb0f4b816b162fddce10b9bd342f10adc3cf7fa
 
 COPY --from=builder /app/target/release/netcidr /usr/local/bin/netcidr
 
-USER netcidr
+WORKDIR /app
+
+# Chainguard/static runs as uid 65532 (nonroot) by default.
+USER nonroot
 
 EXPOSE 8080
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD wget -qO- http://localhost:8080/health || exit 1
+# No HEALTHCHECK: the distroless runtime has no shell. Delegate to the
+# orchestrator (Kubernetes probe, docker-compose TCP/HTTP probe on :8080/health).
 
 ENTRYPOINT ["netcidr"]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -567,21 +567,31 @@ docker run --rm -p 8080:8080 netcidr serve --address 0.0.0.0
 
 The runtime image is [Chainguard's distroless `static`](https://images.chainguard.dev/directory/image/static) base:
 a statically-linked musl binary on a near-zero-CVE rootfs with **no shell and no package manager**. Because
-there is no shell, the Dockerfile does **not** declare a `HEALTHCHECK`. Health checking is delegated to the
-orchestrator — for example, a Kubernetes probe or docker-compose healthcheck using a TCP probe on `:8080` or an
-HTTP probe against `/health`:
+there is no shell, the Dockerfile does **not** declare a `HEALTHCHECK`, and docker-compose cannot run
+in-container healthchecks (`CMD`/`CMD-SHELL` both require a binary inside the image that the distroless
+runtime does not ship). Health checking is delegated to the orchestrator.
 
-```yaml
-# docker-compose excerpt
-services:
-  netcidr:
-    image: netcidr:latest
-    ports: ["8080:8080"]
-    healthcheck:
-      test: ["CMD-SHELL", "exit 0"]  # placeholder; use an external TCP/HTTP probe instead
+For local development, probe the service from the host:
+
+```bash
+curl http://localhost:8080/health
 ```
 
-For Kubernetes, use `httpGet` against `/health` on port 8080 for both liveness and readiness.
+If you need compose-level ordering, use `depends_on: { condition: service_started }` rather than
+`service_healthy`.
+
+For Kubernetes, use an `httpGet` probe against `/health` on port 8080 for both liveness and readiness:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8080
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 8080
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -565,6 +565,24 @@ docker run --rm netcidr 192.168.1.0/24
 docker run --rm -p 8080:8080 netcidr serve --address 0.0.0.0
 ```
 
+The runtime image is [Chainguard's distroless `static`](https://images.chainguard.dev/directory/image/static) base:
+a statically-linked musl binary on a near-zero-CVE rootfs with **no shell and no package manager**. Because
+there is no shell, the Dockerfile does **not** declare a `HEALTHCHECK`. Health checking is delegated to the
+orchestrator — for example, a Kubernetes probe or docker-compose healthcheck using a TCP probe on `:8080` or an
+HTTP probe against `/health`:
+
+```yaml
+# docker-compose excerpt
+services:
+  netcidr:
+    image: netcidr:latest
+    ports: ["8080:8080"]
+    healthcheck:
+      test: ["CMD-SHELL", "exit 0"]  # placeholder; use an external TCP/HTTP probe instead
+```
+
+For Kubernetes, use `httpGet` against `/health` on port 8080 for both liveness and readiness.
+
 ## Development
 
 ```bash


### PR DESCRIPTION
## Summary

- Runtime stage migrated to `cgr.dev/chainguard/static@sha256:1f14279403150757d801f6308bb0f4b816b162fddce10b9bd342f10adc3cf7fa` — distroless, nonroot by default, no shell, no package manager, near-zero-CVE baseline.
- Binary is still a fully statically-linked musl executable. `file` output:
  `ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, ... stripped`
- Alpine `rust:1.95-alpine3.23` builder retained (Chainguard `rust:latest-dev` / Wolfi does not ship a musl `rust-std` target; no musl cross toolchain is available in Wolfi repos). Builder also installs `curl` because the `utoipa-swagger-ui` build script shells out to it.
- `HEALTHCHECK` removed from the Dockerfile — Chainguard/static has no shell. CHANGELOG + README updated to document that health checking is now the orchestrator's responsibility (k8s probe, docker-compose TCP/HTTP probe on `:8080/health`).

## Image size delta (aarch64)

| Variant | Alpine (pre) | Chainguard (post) | Delta |
| --- | --- | --- | --- |
| default features | 11.94 MB | 8.08 MB | **-32%** |
| `FEATURES=""`, `WITH_DASHBOARD=false` | 8.35 MB | 4.49 MB | **-46%** |

## Smoke tests

```
$ docker run --rm netcidr:chainguard 192.168.1.0/24
{
  "input": "192.168.1.0/24",
  "network_address": "192.168.1.0",
  ...
  "is_private": true,
  "address_type": "Private (RFC 1918)"
}
$ docker run --rm netcidr:chainguard --version
netcidr 0.19.3
```

## Test plan

- [x] `docker build -t netcidr:chainguard .` succeeds
- [x] `docker build -t netcidr:chainguard-nodash --build-arg WITH_DASHBOARD=false --build-arg FEATURES="" .` succeeds
- [x] Extracted binary reports `statically linked` under `file(1)`
- [x] `docker run --rm netcidr:chainguard 192.168.1.0/24` returns valid JSON
- [x] `docker run --rm netcidr:chainguard --version` returns `netcidr 0.19.3`
- [ ] CI green