### PR TITLE
feat(ci): attest release binary provenance (Sigstore keyless)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
     steps:
@@ -65,6 +67,11 @@ jobs:
 
       - name: Build release binary
         run: cargo build --release
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: target/release/netcidr
 
       - name: Upload binary and publish release
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New `.github/workflows/image-scan.yml` — builds the Docker image on PRs touching `Dockerfile`/`Cargo.lock` and scans with Grype + Syft. Generates CycloneDX + SPDX SBOMs. Weekly cron detects new fixable CVEs in pinned base images and opens a tracking issue. Release events attach signed SBOM attestations via Sigstore (keyless — no signing keys required).
+- Release binaries now carry Sigstore-signed build provenance (`actions/attest-build-provenance`). Consumers verify with `gh attestation verify <binary> --owner wingnut128`. No signing keys — uses GitHub OIDC + Fulcio + Rekor.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,25 @@ The binary will be at `target/release/netcidr`.
 cargo install --path .
 ```
 
+## Verifying release artifacts
+
+Starting with the first post-2026-04-22 release, the `netcidr` binary and the container image SBOMs are signed with [Sigstore](https://www.sigstore.dev/) via GitHub's keyless attestation flow — no public keys to manage.
+
+Verify a downloaded binary:
+
+```bash
+gh attestation verify netcidr --owner wingnut128
+```
+
+Verify the SBOM attached to a release:
+
+```bash
+gh release download vX.Y.Z --pattern 'sbom.cyclonedx.json'
+gh attestation verify sbom.cyclonedx.json --owner wingnut128
+```
+
+Requires `gh` 2.50+.
+
 ## Usage
 
 ### Subnet Calculation


### PR DESCRIPTION
## What changed

- `.github/workflows/release.yml`: added `id-token: write` and `attestations: write` to the `build` job permissions, and a new `Attest build provenance` step using `actions/attest-build-provenance@v4.1.0` (SHA-pinned) with `subject-path: target/release/netcidr`. Step runs immediately before the binary upload so the published artifact is the same bytes that were attested.
- `README.md`: new "Verifying release artifacts" section showing `gh attestation verify netcidr --owner wingnut128` and the SBOM equivalent.
- `CHANGELOG.md`: entry under `[Unreleased]` → `Added`.

## How to verify (post next release)

```bash
gh release download vX.Y.Z --pattern 'netcidr'
gh attestation verify netcidr --owner wingnut128
```

The attestation is signed via GitHub OIDC → Fulcio → Rekor (keyless). No public keys to manage.

## Validation

- `actionlint .github/workflows/release.yml` — silent success.

End-to-end verification can only happen on the next tagged release, once the workflow actually runs with these permissions and produces a signed attestation.