### PR TITLE
feat(ci): enforce SHA pinning via pinact-action

### DIFF
--- a/.github/workflows/pin-check.yml
+++ b/.github/workflows/pin-check.yml
@@ -1,0 +1,28 @@
+name: Pin Check
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+
+permissions:
+  contents: read
+
+jobs:
+  pinact:
+    name: Verify all actions pinned by SHA
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run pinact
+        uses: suzuki-shunsuke/pinact-action@cf51507d80d4d6522a07348e3d58790290eaf0b6 # v2.0.0
+        with:
+          skip_push: true
+          fail_on_diff: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add top-level `permissions: contents: read` to `.github/workflows/release.yml` so the `detect` job runs with a least-privilege `GITHUB_TOKEN`. The `release` job retains its explicit `contents: write` override. Resolves CodeQL alert `actions/missing-workflow-permissions`.
 - Drop top-level permissions in `.github/workflows/dependabot-automerge.yml` to `contents: read` + `pull-requests: read`. The auto-merge step uses `DEPENDABOT_PAT`, so the workflow's `GITHUB_TOKEN` does not need write access. Resolves Scorecard `TokenPermissionsID` alert (#68).
 - Replace the unmaintained `daemonize` crate with the actively maintained `daemonize-me` 2.x fork. Resolves RUSTSEC-2025-0069. No user-visible change — `--daemonize` behavior is preserved.
+- New `.github/workflows/pin-check.yml` fails PRs that add tag-pinned GitHub Actions (e.g., `@v1` or `@main`). All `uses:` lines must be 40-char commit SHAs. Defense-in-depth against action-tag force-push attacks (c.f. aquasecurity/trivy-action, March 2026).
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

Adds `.github/workflows/pin-check.yml` as defense-in-depth against GitHub Actions tag force-push attacks (c.f. aquasecurity/trivy-action, March 2026).

- Runs `pinact` on every PR that touches `.github/workflows/**` or `.github/actions/**`.
- Fails the PR if any `uses:` line references a tag/branch instead of a 40-char commit SHA.
- Self-hosting: the workflow itself pins `harden-runner`, `checkout`, and `pinact-action` by SHA, so it passes the rule on this very PR.

## Test plan

- [ ] `actionlint` is silent on `.github/workflows/pin-check.yml`
- [ ] `pin-check` job runs green on this PR (all existing `uses:` lines in the repo are already SHA-pinned)
- [ ] Verify future PRs adding a tag-pinned action fail this check