### PR TITLE
refactor(pin-check): replace pinact-action with inline shell check

### DIFF
--- a/.github/workflows/pin-check.yml
+++ b/.github/workflows/pin-check.yml
@@ -1,3 +1,12 @@
+# ===================================================================
+# Pin Check — fails PRs that introduce tag-pinned GitHub Actions.
+#
+# Defense-in-depth against action-tag force-push attacks
+# (e.g., aquasecurity/trivy-action, March 2026).
+#
+# Note: runs on every PR (not just workflow-touching ones) so it can
+# serve as a required status check without hanging unrelated PRs.
+# ===================================================================
 name: Pin Check
 
 on:
@@ -18,8 +27,18 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Run pinact
-        uses: suzuki-shunsuke/pinact-action@cf51507d80d4d6522a07348e3d58790290eaf0b6 # v2.0.0
-        with:
-          skip_push: true
-          fail_on_diff: true
+      - name: Verify all actions pinned by SHA
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Find every `uses: owner/repo@ref` (excluding local `./` and docker:// refs)
+          # and fail if ref isn't a 40-char lowercase hex SHA. Inline commit comments
+          # like `# v1.2.3` are preserved by GitHub's parser and ignored here.
+          violations=$(grep -rHnE '^\s*-?\s*uses:\s*[^./@[:space:]][^@[:space:]]*@[^[:space:]#]+' .github/ \
+            | grep -vE '@[0-9a-f]{40}([[:space:]]|#|$)' || true)
+          if [ -n "$violations" ]; then
+            echo "::error::Actions must be pinned by 40-char commit SHA, not tag/branch:"
+            echo "$violations"
+            exit 1
+          fi
+          echo "All actions SHA-pinned."


### PR DESCRIPTION
## Summary

Drops `suzuki-shunsuke/pinact-action` from `pin-check.yml` in favor of an inline ~10-line `grep` check.

## Motivation

StepSecurity's action-advisor egress graph for `pinact-action` shows unexpected Azure blob egress (`tmaproduction.blob.core.windows.net`) on top of the expected GitHub + Sigstore endpoints — likely telemetry. Adding a third-party action to the workflow whose only job is supply-chain hygiene is exactly the wrong trade.

We use `skip_push: true` + `fail_on_diff: true` (verification-only, no auto-fix), which is trivially expressible in shell. Local auto-fix is still available via the `pinact` CLI binary if needed.

## Test plan

- [ ] `pin-check` workflow runs on this PR and passes (all existing workflows in netcidr are already SHA-pinned)
- [ ] Manually confirm the regex catches `@v1`, `@main`, `@latest` against a fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)