### PR TITLE
ci: free runner disk space before cargo/bun builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,11 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Free runner disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL >/dev/null 2>&1
+          sudo docker image prune -af >/dev/null 2>&1
+          df -h / | tail -1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt, clippy
@@ -81,6 +86,11 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Free runner disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL >/dev/null 2>&1
+          sudo docker image prune -af >/dev/null 2>&1
+          df -h / | tail -1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: taiki-e/install-action@dfd6a81ff1efc1c100332d760e0c9edfe2ae0a51 # nextest
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5


### PR DESCRIPTION
## Summary

Adds a `Free runner disk space` step to the `lint` and `test` jobs in `ci.yml`. Runs after `actions/checkout`, before anything disk-heavy (cache restore, cargo build, bun dashboard build).

```yaml
- name: Free runner disk space
  run: |
    sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
    sudo docker image prune -af
    df -h /
```

## Motivation

The Test job on #82 failed with `System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/...'`. That's the runner's own log directory — the root volume (14 GB free on `ubuntu-latest`) was completely full before `cargo nextest` could even start. Combination of `actions/cache` restoring target/ + cargo registry + the bun dashboard build pushed it over.

Removing .NET (~1.6 GB), Android SDK (~8 GB), GHC (~5 GB), CodeQL bundle (~8 GB), and any preloaded Docker images frees ~25 GB — comfortable headroom for the Rust + Node builds this repo needs. None of those paths are touched by this workflow.

## Scope

- Only added to jobs that actually use disk (`lint`, `test`)
- `changes` (paths-filter only) and `audit` (just `cargo audit`, no compile) left alone — they don't hit the ceiling
- No third-party actions added. Same reasoning as the pinact-action swap: supply-chain hygiene workflows shouldn't expand the supply-chain.

## Test plan

- [ ] Re-run #82's failed Test job on this branch — should pass (includes `df -h /` output to confirm headroom)
- [ ] Lint job passes
- [ ] No regression in cache-hit rate (cache key unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)