### PR TITLE
ci(image-scan): free runner disk space before docker build

### DIFF
--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -34,6 +34,12 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Free runner disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL >/dev/null 2>&1
+          sudo docker image prune -af >/dev/null 2>&1
+          df -h / | tail -1
+
       - name: Build image
         run: docker build -t netcidr:scan .
 


### PR DESCRIPTION
Same cleanup as #84, applied to the image-scan job before `docker build`. Removes .NET, Android SDK, GHC, CodeQL bundle, and preloaded Docker images (~25 GB) so the Chainguard base pulls and Grype scan have headroom.