### PR TITLE
chore(dependabot): group minor+patch updates for cargo and npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,19 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      cargo-minor-and-patch:
+        update-types: [minor, patch]
 
   - package-ecosystem: "npm"
     directory: "/dashboard"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      npm-minor-and-patch:
+        update-types: [minor, patch]
 
   - package-ecosystem: docker
     directory: /


### PR DESCRIPTION
Collapses noisy transitive bumps (e.g. #82 rand 0.8.5→0.8.6) into a single grouped PR per ecosystem per week.

- cargo: grouped `cargo-minor-and-patch`
- npm (/dashboard): grouped `npm-minor-and-patch`
- github-actions, docker: ungrouped (rare, worth reviewing individually)

Closes #82.