### PR TITLE
release: v0.20.0 + disable release-plz semver_check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-04-23
+
 ### Added
 
 - New `.github/workflows/image-scan.yml` — builds the Docker image on PRs touching `Dockerfile`/`Cargo.lock` and scans with Grype + Syft. Generates CycloneDX + SPDX SBOMs. Weekly cron detects new fixable CVEs in pinned base images and opens a tracking issue. Release events attach signed SBOM attestations via Sigstore (keyless — no signing keys required).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,7 +1904,7 @@ dependencies = [
 
 [[package]]
 name = "netcidr"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netcidr"
-version = "0.19.3"
+version = "0.20.0"
 edition = "2024"
 license = "MIT"
 description = "A fast IPv4 and IPv6 subnet calculator CLI and API"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,9 @@ We actively support and provide security updates for the following versions:
 
 | Version | Supported          | Notes                                    |
 | ------- | ------------------ | ---------------------------------------- |
-| 0.19.x  | :white_check_mark: | Current stable release (recommended)     |
-| 0.18.x  | :white_check_mark: | Supported                                |
-| < 0.18  | :x:                | No longer supported                      |
+| 0.20.x  | :white_check_mark: | Current stable release (recommended)     |
+| 0.19.x  | :white_check_mark: | Supported                                |
+| < 0.19  | :x:                | No longer supported                      |
 
 ## Reporting a Vulnerability
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -11,6 +11,15 @@ changelog_update = true
 # it to non-draft after upload.
 git_release_draft = true
 
+[[package]]
+name = "netcidr"
+# Bump version based on conventional commits alone. cargo-semver-checks
+# (release-plz default) only bumps on actual public-API changes, so
+# releases driven by CI/Docker/docs commits — which deliberately avoid
+# touching the public API — never get cut. Disabling the check lets
+# `feat:`/`fix:` conventional commits drive the bump directly.
+semver_check = false
+
 [changelog]
 header = """# Changelog
 


### PR DESCRIPTION
## Summary

Two coupled changes:

**1. Release v0.20.0** (the actual release)
- Bump `Cargo.toml` to 0.20.0
- Move `[Unreleased]` → `[0.20.0]` section in `CHANGELOG.md` with today's date
- Update `SECURITY.md` supported versions table (0.20.x current, 0.19.x supported, <0.19 dropped)
- Triggers the classic `release.yml` workflow on merge (detects Cargo.toml version diff → tag + draft GitHub Release → binary build workflow uploads artifacts and un-drafts)

**2. Configure release-plz to bump on conventional commits going forward**
- Add `semver_check = false` to a `[[package]]` block for `netcidr` in `release-plz.toml`
- Without this, release-plz uses `cargo-semver-checks` which only bumps on actual public-API changes. The commits in this release (CI hardening, Dockerfile migration, security patches, docs, build) all deliberately avoid public-API changes, so release-plz was silently skipping every release-plz-pr run with "next version is 0.19.3".
- With `semver_check = false`, `feat:`/`fix:` conventional commits alone drive the bump.

## What's in 0.20.0

Highlights from the `[0.20.0]` CHANGELOG section: image-scan workflow with Grype + signed SBOMs, release binary Sigstore attestations, Chainguard distroless runtime, `daemonize` → `daemonize-me` CVE fix, rustls-webpki CVE-2026-0104 patch, pin-check workflow, Dockerfile/HEALTHCHECK rework, several IPAM correctness fixes, justfile migration.

## Test plan
- [ ] CI green on this PR
- [ ] On merge: `release.yml` fires and creates draft release `v0.20.0`
- [ ] Binary build workflow uploads artifacts and un-drafts
- [ ] Next push to main after this doesn't get stuck on "already up-to-date" — release-plz sees 0.20.0 as the new baseline