### PR TITLE
ci: simplify validation and trim redundant CodeQL Rust scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,8 @@ jobs:
               - "Dockerfile"
               - ".github/workflows/**"
 
-  lint:
-    name: Format & Lint
+  verify:
+    name: Format, Lint & Test
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
@@ -60,38 +60,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt, clippy
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cargo/registry/
-            ~/.cargo/git/
-            target/
-          key: lint-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: lint-${{ runner.os }}-
-      - uses: step-security/setup-bun@c2c3ca3b28b446447c25a2a39061f4bd64b729c8 # v2.1.2
-      - name: Build dashboard
-        run: cd dashboard && bun install --frozen-lockfile && bun run build
-      - run: cargo fmt --all -- --check
-      - run: cargo clippy --all-targets --all-features -- -D warnings
-
-  test:
-    name: Test
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Free runner disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL >/dev/null 2>&1
-          sudo docker image prune -af >/dev/null 2>&1
-          df -h / | tail -1
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: taiki-e/install-action@dfd6a81ff1efc1c100332d760e0c9edfe2ae0a51 # nextest
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -99,11 +67,13 @@ jobs:
             ~/.cargo/registry/
             ~/.cargo/git/
             target/
-          key: test-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: test-${{ runner.os }}-
+          key: verify-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: verify-${{ runner.os }}-
       - uses: step-security/setup-bun@c2c3ca3b28b446447c25a2a39061f4bd64b729c8 # v2.1.2
       - name: Build dashboard
         run: cd dashboard && bun install --frozen-lockfile && bun run build
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --all-targets --all-features -- -D warnings
       - run: cargo nextest run --features mcp,tui
 
   audit:
@@ -122,4 +92,3 @@ jobs:
         with:
           tool: cargo-audit
       - run: cargo audit
-

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,8 +40,6 @@ jobs:
             build-mode: none
           - language: javascript-typescript
             build-mode: none
-          - language: rust
-            build-mode: none
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0


### PR DESCRIPTION
## Summary
- Removes Rust from the CodeQL matrix while keeping CodeQL coverage for GitHub Actions and dashboard JavaScript/TypeScript.
- Bundles format, full-feature clippy, dashboard build, and nextest into one CI validation job.
- Removes the duplicate dashboard install/build from the old separate lint/test jobs.

## Rationale
Rust already gets strong local and CI coverage from `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo nextest`, `cargo audit`, and Semgrep via `just check`. Given StepSecurity is also monitoring repo/workflow behavior, the Rust CodeQL job is the least valuable SAST layer relative to its cost and runtime.

## Operational note
This replaces the old `Format & Lint` and `Test` CI job names with `Format, Lint & Test`. If either old job name is configured as a required branch-protection check, update branch protection after this lands.

Closes #80.

## Testing
- `actionlint .github/workflows/ci.yml .github/workflows/codeql.yml`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`