### PR TITLE
ci: add CI Status aggregator job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,3 +92,26 @@ jobs:
         with:
           tool: cargo-audit
       - run: cargo audit
+
+  ci-status:
+    name: CI Status
+    needs: [changes, verify, audit]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate required job results
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          VERIFY_RESULT: ${{ needs.verify.result }}
+          AUDIT_RESULT: ${{ needs.audit.result }}
+        run: |
+          fail=0
+          for job in changes verify audit; do
+            var="${job^^}_RESULT"
+            result="${!var}"
+            case "$result" in
+              success|skipped) echo "$job: $result" ;;
+              *) echo "$job: $result (FAIL)"; fail=1 ;;
+            esac
+          done
+          exit "$fail"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Dashboard sidebar shows an "API Docs ↗" link to `/swagger-ui` when the server reports the `swagger` feature enabled (via `/features`).
+- New `CI Status` aggregator job in `.github/workflows/ci.yml` that always runs (even when `verify`/`audit` are skipped by the `Detect Changes` paths filter) and aggregates their results. This gives branch protection a single stable required-check name that handles the skipped-required-check trap, replacing the per-job names (`Format & Lint`, `Test`, `Analyze (rust)`) that were renamed/removed when the CI jobs were consolidated in #111.
 
 ## [0.20.0] - 2026-04-23
 


### PR DESCRIPTION
## Summary

Adds a single `CI Status` aggregator job in `.github/workflows/ci.yml` that always runs and aggregates the results of `changes`, `verify`, and `audit`.

After #111 consolidated the `lint`/`test` jobs into a single `verify` job and dropped the `rust` CodeQL matrix entry, the existing branch protection rules on `main` still required `Format & Lint`, `Test`, and `Analyze (rust)` — names that no longer report. Rather than recreating the old job names just to satisfy branch protection (which would undo the simplification), this introduces one stable required-check name that:

- Doesn't churn when CI jobs are split, merged, or renamed.
- Handles GitHub's "skipped required check" trap — when the `Detect Changes` paths filter skips `verify`/`audit`, the aggregator still reports success so docs-only PRs aren't permanently blocked.

After merge, branch protection on `main` should be updated:
- Remove required: `Format & Lint`, `Test`, `Analyze (rust)`.
- Add required: `CI Status`.

## Test plan

- [ ] CI on this PR shows `CI Status` reporting success (with `verify`/`audit` running because `.github/workflows/ci.yml` matches the paths filter).
- [ ] After merge, open a docs-only PR and confirm `CI Status` still reports success even though `verify`/`audit` are skipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_013vnnPVFGT8SX1WgW36QFtx)_