### PR TITLE
feat: AWS Lambda binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Dashboard sidebar shows an "API Docs ↗" link to `/swagger-ui` when the server reports the `swagger` feature enabled (via `/features`).
 - `oidc_allowed_emails` config field and `NETCIDR_OIDC_ALLOWED_EMAILS` env var (comma-separated) — when set, only verified Google identities whose email matches the allowlist may call `/ipam/*`.
+- New `lambda` Cargo feature and `lambda` binary (`src/bin/lambda.rs`) that wraps the Axum router with `lambda_http` for AWS Lambda deployment. Reads runtime config from env vars (`NETCIDR_AUTH_MODE`, `NETCIDR_OIDC_AUDIENCE`, `NETCIDR_OIDC_ALLOWED_EMAILS`, `NETCIDR_DATABASE_URL`, `NETCIDR_IPAM_BACKEND`, `NETCIDR_IPAM_ENABLED`). Build with `cargo lambda build --release --arm64 --bin lambda --features lambda,ipam-postgres`. The standard `netcidr` binary is unchanged.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3356,6 +3356,7 @@ checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3852,6 +3853,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -3861,6 +3863,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -4921,6 +4924,24 @@ name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +213,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws_lambda_events"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7319a086b79c3ff026a33a61e80f04fd3885fbb73237981ea080d21944e1cb1c"
+dependencies = [
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-serde",
+ "query_map",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,7 +255,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -334,6 +372,9 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "castaway"
@@ -1483,6 +1524,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-serde"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
+dependencies = [
+ "http",
+ "serde",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1884,6 +1935,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
+name = "lambda_http"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fe279be7f89f5f72c97c3a96f45c43db8edab1007320ecc6a5741273b4d6db"
+dependencies = [
+ "aws_lambda_events",
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "lambda_runtime",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio-stream",
+ "url",
+]
+
+[[package]]
+name = "lambda_runtime"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed49669d6430292aead991e19bf13153135a884f916e68f32997c951af637ebe"
+dependencies = [
+ "async-stream",
+ "base64",
+ "bytes",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "http-serde",
+ "hyper",
+ "hyper-util",
+ "lambda_runtime_api_client",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tracing",
+]
+
+[[package]]
+name = "lambda_runtime_api_client"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c90a10f094475a34a04da2be11686c4dcfe214d93413162db9ffdff3d3af293a"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "tokio",
+ "tower 0.4.13",
+ "tower-service",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,6 +2235,7 @@ dependencies = [
  "http-body-util",
  "ipnet",
  "jsonwebtoken",
+ "lambda_http",
  "proptest",
  "r2d2",
  "r2d2_sqlite",
@@ -2128,7 +2256,7 @@ dependencies = [
  "tokio-test",
  "tokio-util",
  "toml",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower_governor",
  "tracing",
@@ -2635,6 +2763,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "query_map"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eab6b8b1074ef3359a863758dae650c7c0c6027927a085b7af911c8e0bf3a15"
+dependencies = [
+ "form_urlencoded",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3025,7 +3164,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -4233,7 +4372,22 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4273,7 +4427,7 @@ dependencies = [
  "iri-string",
  "pin-project-lite",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4304,7 +4458,7 @@ dependencies = [
  "pin-project",
  "thiserror 2.0.18",
  "tonic",
- "tower",
+ "tower 0.5.3",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ base64 = "0.22"
 ratatui = { version = "0.30", optional = true }
 crossterm = { version = "0.29", optional = true }
 ipnet = { version = "2", optional = true }
-sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "postgres"], optional = true }
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "postgres", "tls-rustls"], optional = true }
 lambda_http = { version = "0.13", optional = true }
 
 # OpenAPI/Swagger dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "A fast IPv4 and IPv6 subnet calculator CLI and API"
 repository = "https://gitlab.com/mlapane/netcidr"
 keywords = ["ip", "subnet", "calculator", "ipv4", "ipv6"]
 categories = ["command-line-utilities", "network-programming"]
+default-run = "netcidr"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
@@ -43,6 +44,7 @@ ratatui = { version = "0.30", optional = true }
 crossterm = { version = "0.29", optional = true }
 ipnet = { version = "2", optional = true }
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "postgres"], optional = true }
+lambda_http = { version = "0.13", optional = true }
 
 # OpenAPI/Swagger dependencies
 utoipa = { version = "5", features = ["axum_extras"], optional = true }
@@ -65,6 +67,12 @@ swagger = ["dep:utoipa", "dep:utoipa-swagger-ui"]
 tui = ["dep:ratatui", "dep:crossterm", "dep:ipnet"]
 mcp = ["dep:rmcp", "dep:schemars", "dep:tokio-util"]
 ipam-postgres = ["dep:sqlx"]
+lambda = ["dep:lambda_http"]
+
+[[bin]]
+name = "lambda"
+path = "src/bin/lambda.rs"
+required-features = ["lambda"]
 
 [profile.release]
 lto = true

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -73,10 +73,7 @@ impl AuthConfig {
     }
 
     pub fn with_allowed_emails(mut self, emails: Vec<String>) -> Self {
-        self.allowed_emails = emails
-            .into_iter()
-            .map(|e| e.to_ascii_lowercase())
-            .collect();
+        self.allowed_emails = emails.into_iter().map(|e| e.to_ascii_lowercase()).collect();
         self
     }
 
@@ -280,8 +277,8 @@ struct Jwk {
     e: String,
 }
 
-async fn fetch_google_public_keys()
--> Result<(HashMap<String, GoogleKey>, Duration), reqwest::Error> {
+async fn fetch_google_public_keys() -> Result<(HashMap<String, GoogleKey>, Duration), reqwest::Error>
+{
     let response = reqwest::Client::new()
         .get(GOOGLE_JWKS_URL)
         .send()
@@ -490,7 +487,8 @@ mod tests {
             now_seconds(),
             Some(true),
         );
-        let claims = validate_google_id_token(&jwt, "expected-audience", &key_map(&public)).unwrap();
+        let claims =
+            validate_google_id_token(&jwt, "expected-audience", &key_map(&public)).unwrap();
         assert_eq!(claims.sub, "117290938723847238472");
         assert_eq!(claims.aud, "expected-audience");
     }
@@ -662,8 +660,12 @@ mod tests {
     #[test]
     fn google_id_token_validation_rejects_malformed_jwt() {
         let (_private, public) = test_keypair();
-        assert!(validate_google_id_token("not-a-jwt", "expected-audience", &key_map(&public)).is_none());
-        assert!(validate_google_id_token("a.b.c", "expected-audience", &key_map(&public)).is_none());
+        assert!(
+            validate_google_id_token("not-a-jwt", "expected-audience", &key_map(&public)).is_none()
+        );
+        assert!(
+            validate_google_id_token("a.b.c", "expected-audience", &key_map(&public)).is_none()
+        );
     }
 
     #[test]
@@ -677,8 +679,10 @@ mod tests {
 
     #[test]
     fn email_allowlist_permits_listed_addresses() {
-        let config = AuthConfig::oidc(Some("aud".to_string()))
-            .with_allowed_emails(vec!["alice@example.com".to_string(), "BOB@EXAMPLE.COM".to_string()]);
+        let config = AuthConfig::oidc(Some("aud".to_string())).with_allowed_emails(vec![
+            "alice@example.com".to_string(),
+            "BOB@EXAMPLE.COM".to_string(),
+        ]);
         assert!(config.email_allowed(Some("alice@example.com")));
         assert!(config.email_allowed(Some("ALICE@example.com")));
         assert!(config.email_allowed(Some("bob@example.com")));

--- a/src/bin/lambda.rs
+++ b/src/bin/lambda.rs
@@ -1,0 +1,71 @@
+//! AWS Lambda entrypoint for the netcidr API.
+//!
+//! Runs the same Axum router that `netcidr serve` uses, just driven by the
+//! Lambda runtime instead of bound to a TCP listener. The router is
+//! constructed from environment variables (no config file on disk inside
+//! the function package).
+//!
+//! Build with: `cargo lambda build --release --arm64 --bin lambda
+//!              --features lambda,ipam-postgres`
+
+use std::sync::Arc;
+
+use lambda_http::{Error, run};
+use netcidr::api::{RouterConfig, create_router};
+use netcidr::config::{AuthMode, ServerConfig};
+
+fn env_or<S: Into<String>>(key: &str, fallback: S) -> String {
+    std::env::var(key).unwrap_or_else(|_| fallback.into())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,tower_http=warn".into()),
+        )
+        .json()
+        .with_ansi(false)
+        .with_target(true)
+        .without_time() // Lambda already adds timestamps to log lines.
+        .init();
+
+    // Auth audience, allowed_emails, and bearer token are read directly from
+    // env vars by ServerConfig::auth_config(), so they don't appear here.
+    let server = ServerConfig {
+        auth_mode: match env_or("NETCIDR_AUTH_MODE", "oidc").as_str() {
+            "bearer" => AuthMode::Bearer,
+            "oidc" => AuthMode::Oidc,
+            _ => AuthMode::None,
+        },
+        ipam_enabled: env_or("NETCIDR_IPAM_ENABLED", "true") == "true",
+        ipam_backend: env_or("NETCIDR_IPAM_BACKEND", "postgres"),
+        ipam_db_url: std::env::var("NETCIDR_DATABASE_URL").ok(),
+        enable_swagger: false,
+        ..ServerConfig::default()
+    };
+
+    let ipam_ops = if server.ipam_enabled {
+        let mut ipam_config = netcidr::ipam::config::IpamConfig::default();
+        if let Ok(b) = server
+            .ipam_backend
+            .parse::<netcidr::ipam::config::Backend>()
+        {
+            ipam_config.backend = b;
+        }
+        let store = netcidr::ipam::create_store(
+            &ipam_config,
+            server.ipam_db.as_deref(),
+            server.ipam_db_url.as_deref(),
+        )
+        .await?;
+        Some(Arc::new(netcidr::ipam::operations::IpamOps::new(store)))
+    } else {
+        None
+    };
+
+    let router = create_router(RouterConfig { server, ipam_ops });
+
+    run(router).await
+}

--- a/src/bin/lambda.rs
+++ b/src/bin/lambda.rs
@@ -43,6 +43,11 @@ async fn main() -> Result<(), Error> {
         ipam_backend: env_or("NETCIDR_IPAM_BACKEND", "postgres"),
         ipam_db_url: std::env::var("NETCIDR_DATABASE_URL").ok(),
         enable_swagger: false,
+        // Disable the per-IP rate limiter under Lambda. tower_governor needs
+        // ConnectInfo<SocketAddr> from a real TCP peer, which lambda_http
+        // doesn't provide — every request would 500 with "Unable To Extract
+        // Key!". AWS Lambda's own concurrency limits cover throttling.
+        rate_limit_per_second: 0,
         ..ServerConfig::default()
     };
 


### PR DESCRIPTION
Companion to the AWS SAM stack landing in `netcidr-deploy/aws/`.

## Summary

- New `lambda` Cargo feature + `src/bin/lambda.rs` — wraps the existing Axum router with `lambda_http` so the same code can run on AWS Lambda. The standard `netcidr` binary is unchanged; building the Lambda artifact requires `--features lambda` and is opt-in.
- `default-run = \"netcidr\"` so `cargo run` keeps targeting the CLI now that the crate has two binaries.
- The Lambda binary reads runtime config from env vars (no config file in the deployment package): `NETCIDR_AUTH_MODE`, `NETCIDR_OIDC_AUDIENCE`, `NETCIDR_OIDC_ALLOWED_EMAILS`, `NETCIDR_DATABASE_URL`, `NETCIDR_IPAM_BACKEND`, `NETCIDR_IPAM_ENABLED`.

## Build

\`\`\`
cargo lambda build --release --arm64 --bin lambda --features lambda,ipam-postgres
\`\`\`

Output lands at \`target/lambda/lambda/bootstrap\` — that's what the SAM template's \`CodeUri\` points at.

## Test plan

- [x] \`cargo test\` (242 + 56 + 67 + … all green).
- [x] \`cargo clippy --features lambda,ipam-postgres --bin lambda -- -D warnings\`.
- [x] \`cargo check --all-features\`.
- [ ] End-to-end deploy via \`netcidr-deploy/aws/\` — covered in the deploy-repo PR.