### PR TITLE
feat(auth): allowlist onboarding flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Allowlist onboarding flow.** Three coordinated surfaces, all using the existing visual primitives:
+  - **Sign-in card** — entry point for anonymous users, unchanged content but now part of the gate.
+  - **Request-access card** — shown when a Google-authenticated user is *not* on the allowlist. Displays the user's verified email, a copy-able admin contact, and a clear sign-out path. Honest about the env-var-managed reality of the allowlist; no fake "pending approval" copy.
+  - **Allowlist admin page** at `/admin/allowlist` — viewable only by users in `NETCIDR_ADMIN_EMAILS`. Lists every allowlisted email, marks admins, and includes step-by-step instructions for adding/removing emails via `samconfig.toml.tpl` + redeploy. The sidebar shows an "Admin" section with a link to this page only when the signed-in user is an admin.
+- New `GET /me` HTTP endpoint — returns `{ email, is_allowlisted, is_admin, admin_contact }` for any authenticated principal (independent of the allowlist gate). Powers the new `unallowlisted` auth state in the dashboard so the UI can route to the request-access card without first failing every IPAM API call.
+- New `GET /admin/allowlist` HTTP endpoint — admin-only. Returns the configured allowlist + admin emails sourced from env vars / config.
+- `NETCIDR_ADMIN_EMAILS` env var (comma-separated) and `admin_emails` config field. Members of this list see the Admin section in the sidebar and can hit `/admin/allowlist`.
+
+### Changed
+
+- `AuthContext` adds two new states: `unallowlisted` (token valid, email not on list) and surfaces `isAdmin` + `adminContact` for downstream components. After sign-in, the context calls `/me` to determine the right state.
+- Ipam and Visualizer pages now use a shared `<AuthGate>` component instead of duplicating the routing logic. AuthGate routes by status: loading → spinner, anonymous/disabled → SignInCard, unallowlisted (or admin-only with non-admin) → RequestAccessCard, allowed → children.
+
 ## [0.21.0] - 2026-04-28
 
 ### Added

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -7,6 +7,7 @@ import { Summarize } from "./pages/Summarize";
 import { FromRange } from "./pages/FromRange";
 import { Ipam } from "./pages/Ipam";
 import { Visualizer } from "./pages/Visualizer";
+import { AllowlistAdmin } from "./pages/AllowlistAdmin";
 
 export function App() {
   return (
@@ -20,6 +21,7 @@ export function App() {
           <Route path="from-range" element={<FromRange />} />
           <Route path="visualizer" element={<Visualizer />} />
           <Route path="ipam" element={<Ipam />} />
+          <Route path="admin/allowlist" element={<AllowlistAdmin />} />
         </Route>
       </Routes>
     </HashRouter>

--- a/dashboard/src/auth/AuthContext.tsx
+++ b/dashboard/src/auth/AuthContext.tsx
@@ -14,10 +14,22 @@ import {
   setIdToken,
   type IdTokenClaims,
 } from "./oidc";
+import { fetchMe } from "./me";
 
+/**
+ * Auth lifecycle states.
+ *
+ * - `loading`        — checking cached credential / fetching /me.
+ * - `anonymous`      — no token, or token expired.
+ * - `unallowlisted`  — valid token, but email not on the backend's allowlist.
+ * - `authenticated`  — token valid + email allowlisted; IPAM is reachable.
+ * - `disabled`       — build was missing VITE_OAUTH_WEB_CLIENT_ID, sign-in
+ *                       cannot be initiated. The UI should explain how to fix.
+ */
 export type AuthStatus =
   | "loading"
   | "anonymous"
+  | "unallowlisted"
   | "authenticated"
   | "disabled";
 
@@ -26,6 +38,10 @@ interface AuthContextValue {
   email: string | null;
   name: string | null;
   picture: string | null;
+  /** True when the backend reports the signed-in user is an admin. */
+  isAdmin: boolean;
+  /** First admin email configured on the backend — for RequestAccessCard. */
+  adminContact: string | null;
   /** Most recent sign-in error, surfaced to the UI. */
   error: string | null;
   /** Called by the Google sign-in widget on success. */
@@ -42,54 +58,96 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [status, setStatus] = useState<AuthStatus>(
     isAuthConfigured ? "loading" : "disabled",
   );
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [adminContact, setAdminContact] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  // On mount: if we have a cached, non-expired token, mark authenticated.
-  useEffect(() => {
-    if (!isAuthConfigured) return;
-    const token = getCurrentIdToken();
-    if (token) {
-      const c = decodeClaims(token);
-      setClaims(c);
-      setStatus(c ? "authenticated" : "anonymous");
-    } else {
-      setStatus("anonymous");
+  /**
+   * Verify the current token against the backend by calling /me.
+   * Side-effect: sets status to authenticated / unallowlisted / anonymous
+   * depending on what /me returns. Runs on mount when there's a cached
+   * token and after every successful sign-in.
+   */
+  const verifyWithBackend = useCallback(async (token: string) => {
+    try {
+      const me = await fetchMe(token);
+      if (!me) {
+        setIdToken(null);
+        setClaims(null);
+        setIsAdmin(false);
+        setAdminContact(null);
+        setStatus("anonymous");
+        return;
+      }
+      setIsAdmin(me.is_admin);
+      setAdminContact(me.admin_contact);
+      setStatus(me.is_allowlisted ? "authenticated" : "unallowlisted");
+    } catch {
+      // Network error or non-200: fall back to "authenticated" so the
+      // user can still see public surfaces. /ipam/* will 401/403 if
+      // anything is actually broken — that surfaces as a separate error.
+      setStatus("authenticated");
     }
   }, []);
 
-  // Auto-expire: schedule a flip to anonymous when the current token's
-  // exp passes. Keeps the UI honest without polling.
+  // On mount: hydrate from localStorage, then verify with backend.
+  useEffect(() => {
+    if (!isAuthConfigured) return;
+    const token = getCurrentIdToken();
+    if (!token) {
+      setStatus("anonymous");
+      return;
+    }
+    const c = decodeClaims(token);
+    setClaims(c);
+    if (!c) {
+      setStatus("anonymous");
+      return;
+    }
+    void verifyWithBackend(token);
+  }, [verifyWithBackend]);
+
+  // Auto-expire: when the JWT's `exp` passes, drop everything to anonymous.
   useEffect(() => {
     if (!claims) return;
     const msUntilExpiry = claims.exp * 1000 - Date.now();
     if (msUntilExpiry <= 0) {
       setIdToken(null);
       setClaims(null);
+      setIsAdmin(false);
+      setAdminContact(null);
       setStatus("anonymous");
       return;
     }
     const id = window.setTimeout(() => {
       setIdToken(null);
       setClaims(null);
+      setIsAdmin(false);
+      setAdminContact(null);
       setStatus("anonymous");
     }, msUntilExpiry);
     return () => window.clearTimeout(id);
   }, [claims]);
 
-  const acceptCredential = useCallback((jwt: string) => {
-    const c = setIdToken(jwt);
-    if (!c) {
-      setError("Sign-in succeeded but the credential could not be parsed.");
-      return;
-    }
-    setClaims(c);
-    setStatus("authenticated");
-    setError(null);
-  }, []);
+  const acceptCredential = useCallback(
+    (jwt: string) => {
+      const c = setIdToken(jwt);
+      if (!c) {
+        setError("Sign-in succeeded but the credential could not be parsed.");
+        return;
+      }
+      setClaims(c);
+      setError(null);
+      setStatus("loading");
+      void verifyWithBackend(jwt);
+    },
+    [verifyWithBackend],
+  );
 
   const signOut = useCallback(() => {
     setIdToken(null);
     setClaims(null);
+    setIsAdmin(false);
     setStatus("anonymous");
     setError(null);
   }, []);
@@ -103,13 +161,25 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       email: claims?.email ?? null,
       name: claims?.name ?? null,
       picture: claims?.picture ?? null,
+      isAdmin,
+      adminContact,
       error,
       acceptCredential,
       signOut,
       reportError,
       clearError,
     }),
-    [status, claims, error, acceptCredential, signOut, reportError, clearError],
+    [
+      status,
+      claims,
+      isAdmin,
+      adminContact,
+      error,
+      acceptCredential,
+      signOut,
+      reportError,
+      clearError,
+    ],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/dashboard/src/auth/me.ts
+++ b/dashboard/src/auth/me.ts
@@ -1,0 +1,29 @@
+/**
+ * Calls the /me endpoint to discover whether the current ID token is
+ * accepted by the backend (passes both signature validation AND the email
+ * allowlist) and whether the user has administrative access.
+ *
+ * Distinct from raw IPAM API calls: /me returns a 200 even when the user
+ * is signed in but not allowlisted — the body's `is_allowlisted: false`
+ * is how the frontend differentiates anonymous (no token) from
+ * unallowlisted (valid token, email not on the allowlist).
+ */
+
+export interface MeResponse {
+  email: string | null;
+  is_allowlisted: boolean;
+  is_admin: boolean;
+  /** First configured admin email — used by RequestAccessCard. */
+  admin_contact: string | null;
+}
+
+export async function fetchMe(idToken: string): Promise<MeResponse | null> {
+  const res = await fetch("/me", {
+    headers: { Authorization: `Bearer ${idToken}` },
+  });
+  if (res.status === 401) return null;
+  if (!res.ok) {
+    throw new Error(`/me returned ${res.status}`);
+  }
+  return (await res.json()) as MeResponse;
+}

--- a/dashboard/src/components/auth/AuthGate.tsx
+++ b/dashboard/src/components/auth/AuthGate.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from "react";
+import { useAuth } from "../../auth/AuthContext";
+import { SignInCard } from "./SignInCard";
+import { RequestAccessCard } from "./RequestAccessCard";
+
+interface AuthGateProps {
+  /** Render this when the user is allowlisted. */
+  children: ReactNode;
+  /**
+   * If true, also require admin role. When the user is allowlisted but
+   * not admin, render the same RequestAccessCard rather than the
+   * children — clearest signal that this surface is admin-only.
+   */
+  requireAdmin?: boolean;
+}
+
+/**
+ * Wraps an IPAM-gated surface and routes by auth state:
+ *   - loading        → spinner
+ *   - anonymous      → SignInCard
+ *   - disabled       → SignInCard (which shows the "not configured" path)
+ *   - unallowlisted  → RequestAccessCard
+ *   - authenticated, requireAdmin && !isAdmin → RequestAccessCard
+ *   - authenticated, allowed → children
+ */
+export function AuthGate({ children, requireAdmin = false }: AuthGateProps) {
+  const auth = useAuth();
+
+  if (auth.status === "loading") {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh] text-text-muted text-xs">
+        Loading…
+      </div>
+    );
+  }
+
+  if (auth.status === "anonymous" || auth.status === "disabled") {
+    return <SignInCard />;
+  }
+
+  if (auth.status === "unallowlisted") {
+    return <RequestAccessCard adminEmail={auth.adminContact ?? undefined} />;
+  }
+
+  if (requireAdmin && !auth.isAdmin) {
+    return <RequestAccessCard adminEmail={auth.adminContact ?? undefined} />;
+  }
+
+  return <>{children}</>;
+}

--- a/dashboard/src/components/auth/RequestAccessCard.tsx
+++ b/dashboard/src/components/auth/RequestAccessCard.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+import { useAuth } from "../../auth/AuthContext";
+
+/**
+ * Shown when a user is signed in via Google but their email is not on the
+ * IPAM allowlist. Honest about the state of things — no fake "pending
+ * approval" copy, no link to file a ticket. The admin's email is exposed
+ * for direct contact.
+ */
+export function RequestAccessCard({ adminEmail }: { adminEmail?: string }) {
+  const auth = useAuth();
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    if (!adminEmail) return;
+    try {
+      await navigator.clipboard.writeText(adminEmail);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard.writeText can reject in non-secure contexts; the email
+      // is still visible in the UI for manual selection.
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-[60vh]">
+      <div className="bg-surface border border-border rounded-lg shadow-[0_1px_2px_rgba(15,23,42,0.04)] p-8 max-w-md w-full">
+        <h2 className="text-text text-lg font-semibold mb-2">
+          Access required
+        </h2>
+        <p className="text-text-muted text-sm mb-6 leading-relaxed">
+          You're signed in as{" "}
+          <span className="font-mono text-text">{auth.email}</span>, but
+          this email is not on the IPAM allowlist. The administrator must
+          add you before you can use the dashboard.
+        </p>
+
+        {adminEmail ? (
+          <div className="mb-6">
+            <p className="text-xs text-text-muted mb-1.5">
+              Contact the administrator:
+            </p>
+            <div className="flex items-center gap-2">
+              <code className="flex-1 font-mono text-sm bg-bg border border-border rounded-md px-3 py-2 text-text truncate">
+                {adminEmail}
+              </code>
+              <button
+                type="button"
+                onClick={() => void copy()}
+                className="text-xs font-medium px-3 py-2 border border-border text-text-muted hover:border-cyan hover:text-cyan rounded-md cursor-pointer transition-colors"
+              >
+                {copied ? "COPIED" : "COPY"}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <p className="text-xs text-text-muted mb-6">
+            No administrator email is configured. The deploy is missing
+            <code className="font-mono mx-1">NETCIDR_ADMIN_EMAILS</code>.
+          </p>
+        )}
+
+        <p className="text-xs text-text-muted mb-4 leading-relaxed">
+          The other tools (Calc, Split, Contains, Summarize, Range) remain
+          available without allowlist access.
+        </p>
+
+        <button
+          type="button"
+          onClick={() => auth.signOut()}
+          className="text-xs font-medium px-4 py-2 border border-border text-text-muted hover:border-text hover:text-text rounded-md cursor-pointer transition-colors"
+        >
+          SIGN OUT
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/layout/Sidebar.tsx
+++ b/dashboard/src/components/layout/Sidebar.tsx
@@ -37,6 +37,9 @@ export function Sidebar({ ipamEnabled, swaggerEnabled }: SidebarProps) {
   const navItems = ipamEnabled
     ? [...baseNavItems, { to: "/ipam", label: "IPAM" }]
     : baseNavItems;
+  const adminItems = auth.isAdmin
+    ? [{ to: "/admin/allowlist", label: "Allowlist" }]
+    : [];
 
   return (
     <nav className="fixed left-0 top-0 h-full w-52 bg-surface border-r border-border flex flex-col z-50">
@@ -63,6 +66,26 @@ export function Sidebar({ ipamEnabled, swaggerEnabled }: SidebarProps) {
             {item.label}
           </NavLink>
         ))}
+        {adminItems.length > 0 && (
+          <>
+            <p className="text-text-muted text-xs px-4 mt-4 mb-1">Admin</p>
+            {adminItems.map((item) => (
+              <NavLink
+                key={item.to}
+                to={item.to}
+                className={({ isActive }) =>
+                  `relative block pl-4 pr-3 py-2 text-sm rounded-md transition-colors ${
+                    isActive
+                      ? "text-text font-semibold bg-surface2 before:content-[''] before:absolute before:left-0 before:top-1.5 before:bottom-1.5 before:w-0.5 before:rounded-r before:bg-cyan"
+                      : "text-text-muted hover:text-text hover:bg-surface2/60"
+                  }`
+                }
+              >
+                {item.label}
+              </NavLink>
+            ))}
+          </>
+        )}
       </div>
 
       {auth.status === "authenticated" && auth.email && (

--- a/dashboard/src/pages/AllowlistAdmin.tsx
+++ b/dashboard/src/pages/AllowlistAdmin.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useState } from "react";
+import { PageHeader } from "../components/ui/PageHeader";
+import { Panel } from "../components/ui/Panel";
+import { ErrorBanner } from "../components/ui/ErrorBanner";
+import { AuthGate } from "../components/auth/AuthGate";
+import { TABLE_HEADER } from "../lib/styles";
+import { get } from "../api";
+
+interface AllowlistResponse {
+  emails: string[];
+  admins: string[];
+  /** "env" today; reserved for "db" once a mutable allowlist lands. */
+  management: string;
+}
+
+export function AllowlistAdmin() {
+  return (
+    <AuthGate requireAdmin>
+      <AllowlistAdminInner />
+    </AuthGate>
+  );
+}
+
+function AllowlistAdminInner() {
+  const [data, setData] = useState<AllowlistResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    get<AllowlistResponse>("/admin/allowlist")
+      .then((d) => {
+        if (!cancelled) setData(d);
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : String(e));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div>
+      <PageHeader
+        title="Allowlist"
+        subtitle="Email addresses authorized to use the IPAM dashboard."
+      />
+      <ErrorBanner message={error} onDismiss={() => setError(null)} />
+
+      <Panel title="Allowlisted emails">
+        {!data ? (
+          <p className="text-text-muted text-sm">Loading…</p>
+        ) : data.emails.length === 0 ? (
+          <p className="text-text-muted text-sm">
+            No emails allowlisted. Add one to get started — see the
+            instructions panel below.
+          </p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr>
+                <th className={TABLE_HEADER}>Email</th>
+                <th className={TABLE_HEADER}>Role</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.emails.map((email) => {
+                const isAdmin = data.admins.some(
+                  (a) => a.toLowerCase() === email.toLowerCase(),
+                );
+                return (
+                  <tr
+                    key={email}
+                    className="border-b border-border last:border-b-0 hover:bg-cyan/[0.03] transition-colors"
+                  >
+                    <td className="px-3 py-2 font-mono">{email}</td>
+                    <td className="px-3 py-2">
+                      {isAdmin ? (
+                        <span className="inline-block px-2 py-0.5 text-xs font-medium capitalize rounded-md border border-cyan/40 bg-cyan/10 text-cyan">
+                          admin
+                        </span>
+                      ) : (
+                        <span className="inline-block px-2 py-0.5 text-xs font-medium capitalize rounded-md border border-green/40 bg-green/10 text-green">
+                          member
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </Panel>
+
+      <Panel title="How to add or remove an email">
+        <p className="text-sm text-text-muted leading-relaxed mb-3">
+          The allowlist is currently sourced from the
+          <code className="font-mono mx-1">NETCIDR_OIDC_ALLOWED_EMAILS</code>
+          environment variable on the deployed Lambda. Changes require an
+          update + redeploy.
+        </p>
+        <ol className="list-decimal list-inside text-sm text-text-muted space-y-1.5 leading-relaxed mb-3">
+          <li>
+            Edit
+            <code className="font-mono mx-1">
+              netcidr-deploy/aws/samconfig.toml.tpl
+            </code>
+            and append the email to
+            <code className="font-mono mx-1">OidcAllowedEmails</code>
+            (comma-separated).
+          </li>
+          <li>
+            From
+            <code className="font-mono mx-1">netcidr-deploy/aws/</code>
+            run
+            <code className="font-mono mx-1">
+              op run --env-file=.env -- just deploy
+            </code>
+            to push the new env to Lambda.
+          </li>
+          <li>
+            Refresh this page — the new email shows up in the table above.
+          </li>
+        </ol>
+        <p className="text-xs text-text-muted">
+          A database-backed mutable allowlist (with add/remove + audit) is
+          on the roadmap. For now the source of truth is the env var.
+        </p>
+      </Panel>
+    </div>
+  );
+}

--- a/dashboard/src/pages/Ipam.tsx
+++ b/dashboard/src/pages/Ipam.tsx
@@ -11,23 +11,14 @@ import { CreateSupernetModal } from "../components/ipam/modals/CreateSupernetMod
 import { AllocateSpecificModal } from "../components/ipam/modals/AllocateSpecificModal";
 import { AutoAllocateModal } from "../components/ipam/modals/AutoAllocateModal";
 import { AllocationDetailModal } from "../components/ipam/modals/AllocationDetailModal";
-import { useAuth } from "../auth/AuthContext";
-import { SignInCard } from "../components/auth/SignInCard";
+import { AuthGate } from "../components/auth/AuthGate";
 
 export function Ipam() {
-  const auth = useAuth();
-
-  if (auth.status === "loading") {
-    return (
-      <div className="flex items-center justify-center min-h-[60vh] text-text-muted text-xs">
-        Loading…
-      </div>
-    );
-  }
-  if (auth.status !== "authenticated") {
-    return <SignInCard />;
-  }
-  return <IpamDashboard />;
+  return (
+    <AuthGate>
+      <IpamDashboard />
+    </AuthGate>
+  );
 }
 
 function IpamDashboard() {

--- a/dashboard/src/pages/Visualizer.tsx
+++ b/dashboard/src/pages/Visualizer.tsx
@@ -3,30 +3,20 @@ import { PageHeader } from "../components/ui/PageHeader";
 import { Panel } from "../components/ui/Panel";
 import { StatCard } from "../components/ui/StatCard";
 import { ErrorBanner } from "../components/ui/ErrorBanner";
-import { SignInCard } from "../components/auth/SignInCard";
+import { AuthGate } from "../components/auth/AuthGate";
 import { AllocationMap } from "../components/visualizer/AllocationMap";
 import { WhatIfPanel } from "../components/visualizer/WhatIfPanel";
 import { AllocationDetailModal } from "../components/ipam/modals/AllocationDetailModal";
 import { useIpam } from "../hooks/useIpam";
-import { useAuth } from "../auth/AuthContext";
 import type { Allocation } from "../types";
 import type { ParsedCidr } from "../lib/cidr";
 
 export function Visualizer() {
-  const auth = useAuth();
-
-  if (auth.status === "loading") {
-    return (
-      <div className="flex items-center justify-center min-h-[60vh] text-text-muted text-xs">
-        Loading…
-      </div>
-    );
-  }
-  if (auth.status !== "authenticated") {
-    return <SignInCard />;
-  }
-
-  return <VisualizerInner />;
+  return (
+    <AuthGate>
+      <VisualizerInner />
+    </AuthGate>
+  );
 }
 
 function VisualizerInner() {

--- a/src/api.rs
+++ b/src/api.rs
@@ -369,6 +369,14 @@ pub fn create_router(config: RouterConfig) -> Router {
         get(move || async move { Json(features.clone()) }),
     );
 
+    // /me + admin allowlist read endpoint. Both are auth-aware but live
+    // outside the /ipam middleware (so an unallowlisted user can hit /me
+    // and get a 200 with `is_allowlisted: false` instead of a 403).
+    let router = router
+        .route("/me", get(me_handler))
+        .route("/admin/allowlist", get(allowlist_handler))
+        .layer(Extension(auth_config.clone()));
+
     #[cfg(feature = "swagger")]
     let router = if config.server.enable_swagger {
         router.merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
@@ -972,6 +980,74 @@ async fn batch_handler(
 struct FeaturesResponse {
     ipam: bool,
     swagger: bool,
+}
+
+#[derive(Serialize)]
+struct MeResponse {
+    /// Verified email of the signed-in principal (may be null for bearer tokens).
+    email: Option<String>,
+    /// Whether the email passes the configured allowlist.
+    is_allowlisted: bool,
+    /// Whether the email matches the admin allowlist.
+    is_admin: bool,
+    /// First configured admin email — surfaced so unallowlisted users have
+    /// someone to contact for access. Null when no admins are configured.
+    admin_contact: Option<String>,
+}
+
+#[derive(Serialize)]
+struct AllowlistResponse {
+    /// Email addresses authorized to call /ipam/*.
+    emails: Vec<String>,
+    /// Email addresses with administrative access.
+    admins: Vec<String>,
+    /// How the allowlist is managed. Currently always "env" — sourced from
+    /// the NETCIDR_OIDC_ALLOWED_EMAILS environment variable / config file.
+    /// To add or remove an email, edit `samconfig.toml.tpl` (or the deploy
+    /// equivalent) and redeploy.
+    management: &'static str,
+}
+
+async fn me_handler(
+    Extension(auth_config): Extension<crate::auth::AuthConfig>,
+    request: axum::extract::Request,
+) -> Response {
+    let principal = match auth_config.authenticate(request.headers()).await {
+        Some(p) => p,
+        None => {
+            return (StatusCode::UNAUTHORIZED, "Unauthorized").into_response();
+        }
+    };
+    let email = principal.email.clone();
+    let is_allowlisted = auth_config.email_is_allowed(email.as_deref());
+    let is_admin = auth_config.is_admin(email.as_deref());
+    let admin_contact = auth_config.admin_emails().first().cloned();
+    Json(MeResponse {
+        email,
+        is_allowlisted,
+        is_admin,
+        admin_contact,
+    })
+    .into_response()
+}
+
+async fn allowlist_handler(
+    Extension(auth_config): Extension<crate::auth::AuthConfig>,
+    request: axum::extract::Request,
+) -> Response {
+    let principal = match auth_config.authenticate(request.headers()).await {
+        Some(p) => p,
+        None => return (StatusCode::UNAUTHORIZED, "Unauthorized").into_response(),
+    };
+    if !auth_config.is_admin(principal.email.as_deref()) {
+        return (StatusCode::FORBIDDEN, "Admin access required").into_response();
+    }
+    Json(AllowlistResponse {
+        emails: auth_config.allowed_emails().to_vec(),
+        admins: auth_config.admin_emails().to_vec(),
+        management: "env",
+    })
+    .into_response()
 }
 
 #[cfg(feature = "dashboard")]

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -40,6 +40,7 @@ pub struct AuthConfig {
     bearer_token: Option<String>,
     oidc_audience: Option<String>,
     allowed_emails: Vec<String>,
+    admin_emails: Vec<String>,
 }
 
 impl AuthConfig {
@@ -57,6 +58,7 @@ impl AuthConfig {
                 .into_iter()
                 .map(|e| e.to_ascii_lowercase())
                 .collect(),
+            admin_emails: Vec::new(),
         }
     }
 
@@ -75,6 +77,52 @@ impl AuthConfig {
     pub fn with_allowed_emails(mut self, emails: Vec<String>) -> Self {
         self.allowed_emails = emails.into_iter().map(|e| e.to_ascii_lowercase()).collect();
         self
+    }
+
+    pub fn with_admin_emails(mut self, emails: Vec<String>) -> Self {
+        self.admin_emails = emails.into_iter().map(|e| e.to_ascii_lowercase()).collect();
+        self
+    }
+
+    pub fn allowed_emails(&self) -> &[String] {
+        &self.allowed_emails
+    }
+
+    pub fn admin_emails(&self) -> &[String] {
+        &self.admin_emails
+    }
+
+    pub fn oidc_audience(&self) -> Option<&str> {
+        self.oidc_audience.as_deref()
+    }
+
+    pub fn is_admin(&self, email: Option<&str>) -> bool {
+        if self.admin_emails.is_empty() {
+            return false;
+        }
+        match email {
+            Some(addr) => {
+                let needle = addr.to_ascii_lowercase();
+                self.admin_emails.iter().any(|a| a == &needle)
+            }
+            None => false,
+        }
+    }
+
+    /// Validate the request's bearer token without enforcing the email
+    /// allowlist. Returns the principal on success, or None if the token is
+    /// missing/invalid. Callers (e.g. /me) use this when they want to know
+    /// "is this user signed in at all?" independent of allowlist status.
+    pub async fn authenticate(&self, headers: &HeaderMap) -> Option<AuthenticatedPrincipal> {
+        match self.mode {
+            AuthMode::None => None,
+            AuthMode::Bearer => authenticate_bearer(headers, self.bearer_token.as_deref()),
+            AuthMode::Oidc => authenticate_oidc(headers, self.oidc_audience.as_deref()).await,
+        }
+    }
+
+    pub fn email_is_allowed(&self, email: Option<&str>) -> bool {
+        self.email_allowed(email)
     }
 
     pub fn enabled(&self) -> bool {

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ const MAX_TIMEOUT_SECONDS: u64 = 300;
 const AUTH_TOKEN_ENV: &str = "NETCIDR_API_TOKEN";
 const OIDC_AUDIENCE_ENV: &str = "NETCIDR_OIDC_AUDIENCE";
 const OIDC_ALLOWED_EMAILS_ENV: &str = "NETCIDR_OIDC_ALLOWED_EMAILS";
+const ADMIN_EMAILS_ENV: &str = "NETCIDR_ADMIN_EMAILS";
 
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]
@@ -63,6 +64,10 @@ pub struct ServerConfig {
     /// Prefer NETCIDR_OIDC_ALLOWED_EMAILS (comma-separated) in production.
     #[serde(default)]
     pub oidc_allowed_emails: Vec<String>,
+    /// Email addresses with administrative access (e.g. allowlist viewer).
+    /// Prefer NETCIDR_ADMIN_EMAILS (comma-separated) in production.
+    #[serde(default)]
+    pub admin_emails: Vec<String>,
     /// Allow binding the HTTP API to a non-loopback address.
     pub allow_public_bind: bool,
     /// Require authentication when binding the HTTP API to a non-loopback address.
@@ -88,6 +93,7 @@ impl Default for ServerConfig {
             auth_token: None,
             oidc_audience: None,
             oidc_allowed_emails: Vec::new(),
+            admin_emails: Vec::new(),
             allow_public_bind: false,
             require_auth_for_public_bind: true,
         }
@@ -292,6 +298,26 @@ impl ServerConfig {
         raw.into_iter().map(|s| s.to_ascii_lowercase()).collect()
     }
 
+    pub fn admin_emails(&self) -> Vec<String> {
+        let from_env = std::env::var(ADMIN_EMAILS_ENV)
+            .ok()
+            .filter(|s| !s.trim().is_empty());
+        let raw = match from_env {
+            Some(v) => v
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<_>>(),
+            None => self
+                .admin_emails
+                .iter()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<_>>(),
+        };
+        raw.into_iter().map(|s| s.to_ascii_lowercase()).collect()
+    }
+
     pub fn auth_config(&self) -> crate::auth::AuthConfig {
         crate::auth::AuthConfig::new(
             self.auth_mode,
@@ -299,6 +325,7 @@ impl ServerConfig {
             self.oidc_audience(),
             self.oidc_allowed_emails(),
         )
+        .with_admin_emails(self.admin_emails())
     }
 
     pub fn validate_deployment(&self, bind_address: &str) -> Result<()> {


### PR DESCRIPTION
Three coordinated surfaces driven by a new \`/me\` endpoint, all built with existing UI primitives (Panel, hairline borders, sentence-case headings, uppercase action buttons) per the netcidr-design skill.

## Surfaces

| State | Surface | What the user sees |
|---|---|---|
| Anonymous (no token) | **SignInCard** (existing) | Google-branded sign-in button. |
| Authenticated, **not allowlisted** | **RequestAccessCard** (new) | Their verified email + a copy-able admin contact + sign-out. No fake "pending approval" copy. |
| Authenticated, allowlisted | IPAM dashboard / Visualizer / etc. | Existing flow. |
| Authenticated, **admin** | Sidebar shows new "Admin → Allowlist" link → **AllowlistAdmin** page (new) | Lists every allowlisted email, marks admins, instructions for adding/removing via \`samconfig.toml.tpl\` + redeploy. |

## Backend (Rust)

- \`GET /me\` — returns \`{ email, is_allowlisted, is_admin, admin_contact }\` for any signed-in principal. Lives outside the \`/ipam/*\` allowlist middleware so unallowlisted users get a 200 with \`is_allowlisted: false\` instead of a 403 cascade. This is the signal the dashboard uses to differentiate anonymous vs unallowlisted.
- \`GET /admin/allowlist\` — admin-only. Returns the configured allowlist + admin emails sourced from env vars.
- New \`NETCIDR_ADMIN_EMAILS\` env var (comma-separated) defines admin role. Reuses the same env-var pattern as \`NETCIDR_OIDC_ALLOWED_EMAILS\`.
- \`AuthConfig\` adds \`admin_emails\` field + \`is_admin()\` + \`authenticate()\` (validate-only, no allowlist check) + \`email_is_allowed()\` + \`oidc_audience()\` accessors.

## Frontend (TS / React)

- \`AuthContext\` gains a new \`unallowlisted\` status. After credential, calls \`/me\` to determine the right state. Exposes \`isAdmin\` and \`adminContact\` for the rest of the UI.
- New \`<AuthGate>\` component centralizes the routing logic shared by Ipam, Visualizer, and AllowlistAdmin pages. \`requireAdmin\` prop triggers the same RequestAccessCard fallback for non-admins on admin-only surfaces.
- Sidebar conditionally renders an "Admin" section with the allowlist link only when \`auth.isAdmin\`.

## Deferred

DB-backed mutable allowlist (with CRUD + audit log) is the follow-up. This PR delivers the UX flow against the current env-var-managed reality so users see the right surfaces today, and the AllowlistAdmin page is honest about how to make changes.

## Configuration

To use the admin features, add to your deploy:

\`\`\`toml
# samconfig.toml.tpl parameter_overrides
NETCIDR_ADMIN_EMAILS=\"admin@example.com\"
\`\`\`

Or as a SAM stack parameter (will need a small \`template.yaml\` addition in netcidr-deploy — separate PR).

## Test plan

- [x] \`cargo test\`, \`cargo clippy\`, \`cargo fmt\` clean (402 tests).
- [x] \`npm run typecheck\` and \`bun run build\` clean. Bundle ~318 kB gzipped (no change).
- [ ] After redeploy with NETCIDR_ADMIN_EMAILS set:
  - [ ] Anonymous /ipam → SignInCard.
  - [ ] Sign in with non-allowlisted Google account → RequestAccessCard with admin email.
  - [ ] Sign in with allowlisted-but-non-admin account → IPAM works; no Admin section in sidebar; /admin/allowlist shows RequestAccessCard.
  - [ ] Sign in with admin account → Admin section appears; /admin/allowlist lists emails with role badges.