### PR TITLE
chore(dashboard): align with netcidr-design audit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Dashboard audit pass against the `netcidr-design` skill. All mechanical drift fixes:
+  - `font-bold` swapped to `font-medium` (form labels, secondary headings) or `font-semibold` (table headers) to match the skill's typography hierarchy. ~22 occurrences across `Splitter`, `FromRange`, `Contains`, `Summarize`, `IpamSearch`, `Modal`, and `AllocationDetailModal`.
+  - Modal titles converted from Title Case to sentence case: "Create supernet", "Allocate specific block", "Auto-allocate", "Allocation detail".
+  - Panel titles converted: "Free blocks", "Audit log", "Bit visualization".
+  - SignInCard's `shadow-sm` replaced with the canonical hairline `shadow-[0_1px_2px_rgba(15,23,42,0.04)]` — the only ambient shadow the system uses.
+  - Modal inline error badges normalized to the system's tinted-background recipe (`border border-red/40 bg-red/10 text-red rounded-md`) to match StatusBadge and the Calculator scope pill.
+
 ### Added
 
 - **Allowlist onboarding flow.** Three coordinated surfaces, all using the existing visual primitives:

--- a/dashboard/src/components/auth/SignInCard.tsx
+++ b/dashboard/src/components/auth/SignInCard.tsx
@@ -9,7 +9,7 @@ export function SignInCard() {
 
   return (
     <div className="flex items-center justify-center min-h-[60vh]">
-      <div className="bg-surface border border-border rounded-lg shadow-sm p-8 max-w-md w-full text-center">
+      <div className="bg-surface border border-border rounded-lg shadow-[0_1px_2px_rgba(15,23,42,0.04)] p-8 max-w-md w-full text-center">
         <h2 className="text-text text-lg font-semibold mb-2">
           Sign in to IPAM
         </h2>

--- a/dashboard/src/components/ipam/AuditLog.tsx
+++ b/dashboard/src/components/ipam/AuditLog.tsx
@@ -4,7 +4,7 @@ import type { AuditEntry } from "../../types";
 
 export function AuditLog({ entries }: { entries: AuditEntry[] }) {
   return (
-    <Panel title="Audit Log" collapsible>
+    <Panel title="Audit log" collapsible>
       {entries.length === 0 ? (
         <p className="text-text-muted text-center py-4">No audit entries.</p>
       ) : (

--- a/dashboard/src/components/ipam/FreeBlocksList.tsx
+++ b/dashboard/src/components/ipam/FreeBlocksList.tsx
@@ -4,7 +4,7 @@ import type { FreeBlock } from "../../types";
 
 export function FreeBlocksList({ blocks }: { blocks: FreeBlock[] }) {
   return (
-    <Panel title="Free Blocks" collapsible>
+    <Panel title="Free blocks" collapsible>
       {blocks.length === 0 ? (
         <p className="text-text-muted text-center py-4">No free blocks.</p>
       ) : (

--- a/dashboard/src/components/ipam/IpamSearch.tsx
+++ b/dashboard/src/components/ipam/IpamSearch.tsx
@@ -69,7 +69,7 @@ export function IpamSearch({
 
       {searchResults.length > 0 && (
         <div>
-          <p className="text-xs font-bold text-text-muted mb-2">
+          <p className="text-xs font-medium text-text-muted mb-2">
             Search Results ({searchResults.length})
           </p>
           <table className="w-full border-collapse text-xs">

--- a/dashboard/src/components/ipam/modals/AllocateSpecificModal.tsx
+++ b/dashboard/src/components/ipam/modals/AllocateSpecificModal.tsx
@@ -83,10 +83,10 @@ export function AllocateSpecificModal({
   );
 
   return (
-    <Modal open={open} onClose={onClose} title="Allocate Specific">
+    <Modal open={open} onClose={onClose} title="Allocate specific block">
       <div className="space-y-3">
         {error && (
-          <div className="bg-red/10 border border-red text-red px-3 py-2 text-xs">
+          <div className="border border-red/40 bg-red/10 text-red rounded-md px-3 py-2 text-xs">
             {error}
           </div>
         )}

--- a/dashboard/src/components/ipam/modals/AllocationDetailModal.tsx
+++ b/dashboard/src/components/ipam/modals/AllocationDetailModal.tsx
@@ -37,7 +37,7 @@ export function AllocationDetailModal({
   };
 
   return (
-    <Modal open={open} onClose={onClose} title="Allocation Detail">
+    <Modal open={open} onClose={onClose} title="Allocation detail">
       <div className="space-y-1">
         <DataRow label="ID">
           <span className="text-xs text-text-muted">{allocation.id}</span>
@@ -71,7 +71,7 @@ export function AllocationDetailModal({
 
       {/* Tags */}
       <div className="mt-4 pt-4 border-t border-border">
-        <p className="text-xs font-bold text-text-muted mb-2">
+        <p className="text-xs font-medium text-text-muted mb-2">
           Tags
         </p>
         <div className="flex flex-wrap gap-1 mb-3">

--- a/dashboard/src/components/ipam/modals/AutoAllocateModal.tsx
+++ b/dashboard/src/components/ipam/modals/AutoAllocateModal.tsx
@@ -65,10 +65,10 @@ export function AutoAllocateModal({
   };
 
   return (
-    <Modal open={open} onClose={onClose} title="Auto-Allocate">
+    <Modal open={open} onClose={onClose} title="Auto-allocate">
       <div className="space-y-3">
         {error && (
-          <div className="bg-red/10 border border-red text-red px-3 py-2 text-xs">
+          <div className="border border-red/40 bg-red/10 text-red rounded-md px-3 py-2 text-xs">
             {error}
           </div>
         )}

--- a/dashboard/src/components/ipam/modals/CreateSupernetModal.tsx
+++ b/dashboard/src/components/ipam/modals/CreateSupernetModal.tsx
@@ -43,10 +43,10 @@ export function CreateSupernetModal({
   };
 
   return (
-    <Modal open={open} onClose={onClose} title="Create Supernet">
+    <Modal open={open} onClose={onClose} title="Create supernet">
       <div className="space-y-3">
         {error && (
-          <div className="bg-red/10 border border-red text-red px-3 py-2 text-xs">
+          <div className="border border-red/40 bg-red/10 text-red rounded-md px-3 py-2 text-xs">
             {error}
           </div>
         )}

--- a/dashboard/src/components/ipam/modals/Modal.tsx
+++ b/dashboard/src/components/ipam/modals/Modal.tsx
@@ -19,7 +19,7 @@ export function Modal({ open, onClose, title, children }: ModalProps) {
     >
       <div className="bg-surface border border-border w-full max-w-lg mx-4 max-h-[90vh] overflow-y-auto">
         <div className="flex items-center justify-between px-4 py-3 border-b-2 border-border bg-surface2">
-          <h3 className="text-xs font-bold text-text-muted">
+          <h3 className="text-xs font-medium text-text-muted">
             {title}
           </h3>
           <button

--- a/dashboard/src/pages/Calculator.tsx
+++ b/dashboard/src/pages/Calculator.tsx
@@ -68,7 +68,7 @@ export function Calculator() {
           {/* Bit Visualization */}
           {bitCount > 0 && (
             <Panel
-              title="Bit Visualization"
+              title="Bit visualization"
               actions={
                 <span className="text-xs text-text-muted">
                   <span className="text-cyan">NETWORK</span> /{" "}

--- a/dashboard/src/pages/Contains.tsx
+++ b/dashboard/src/pages/Contains.tsx
@@ -41,7 +41,7 @@ export function Contains() {
       <Panel title="Input">
         <div className="flex gap-3 items-end flex-wrap">
           <div className="flex-[2] min-w-[200px]">
-            <label className="block text-xs font-bold text-text-muted mb-1">
+            <label className="block text-xs font-medium text-text-muted mb-1">
               CIDR
             </label>
             <input
@@ -53,7 +53,7 @@ export function Contains() {
             />
           </div>
           <div className="flex-[2] min-w-[200px]">
-            <label className="block text-xs font-bold text-text-muted mb-1">
+            <label className="block text-xs font-medium text-text-muted mb-1">
               IP Address
             </label>
             <input

--- a/dashboard/src/pages/FromRange.tsx
+++ b/dashboard/src/pages/FromRange.tsx
@@ -55,7 +55,7 @@ export function FromRange() {
       <Panel title="Input">
         <div className="flex gap-3 items-end flex-wrap">
           <div className="flex-1 min-w-[200px]">
-            <label className="block text-xs font-bold text-text-muted mb-1">
+            <label className="block text-xs font-medium text-text-muted mb-1">
               Start IP
             </label>
             <input
@@ -67,7 +67,7 @@ export function FromRange() {
             />
           </div>
           <div className="flex-1 min-w-[200px]">
-            <label className="block text-xs font-bold text-text-muted mb-1">
+            <label className="block text-xs font-medium text-text-muted mb-1">
               End IP
             </label>
             <input
@@ -114,16 +114,16 @@ export function FromRange() {
               <table className="w-full border-collapse text-xs">
                 <thead>
                   <tr>
-                    <th className="text-left px-3 py-2 font-bold text-xs text-text-muted bg-surface2 border-b-2 border-border">
+                    <th className="text-left px-3 py-2 text-xs font-semibold text-text-muted bg-surface2 border-b-2 border-border">
                       #
                     </th>
-                    <th className="text-left px-3 py-2 font-bold text-xs text-text-muted bg-surface2 border-b-2 border-border">
+                    <th className="text-left px-3 py-2 text-xs font-semibold text-text-muted bg-surface2 border-b-2 border-border">
                       CIDR
                     </th>
-                    <th className="text-left px-3 py-2 font-bold text-xs text-text-muted bg-surface2 border-b-2 border-border">
+                    <th className="text-left px-3 py-2 text-xs font-semibold text-text-muted bg-surface2 border-b-2 border-border">
                       Network
                     </th>
-                    <th className="text-left px-3 py-2 font-bold text-xs text-text-muted bg-surface2 border-b-2 border-border">
+                    <th className="text-left px-3 py-2 text-xs font-semibold text-text-muted bg-surface2 border-b-2 border-border">
                       Total
                     </th>
                   </tr>

--- a/dashboard/src/pages/Splitter.tsx
+++ b/dashboard/src/pages/Splitter.tsx
@@ -53,7 +53,7 @@ export function Splitter() {
       <Panel title="Input">
         <div className="flex gap-3 items-end flex-wrap">
           <div className="flex-[3] min-w-[200px]">
-            <label className="block text-xs font-bold text-text-muted mb-1">
+            <label className="block text-xs font-medium text-text-muted mb-1">
               CIDR
             </label>
             <input
@@ -65,7 +65,7 @@ export function Splitter() {
             />
           </div>
           <div className="flex-1 min-w-[100px]">
-            <label className="block text-xs font-bold text-text-muted mb-1">
+            <label className="block text-xs font-medium text-text-muted mb-1">
               Target Prefix
             </label>
             <input
@@ -79,7 +79,7 @@ export function Splitter() {
             />
           </div>
           <div className="flex-1 min-w-[100px]">
-            <label className="block text-xs font-bold text-text-muted mb-1">
+            <label className="block text-xs font-medium text-text-muted mb-1">
               Count
             </label>
             <input
@@ -144,25 +144,25 @@ export function Splitter() {
               <table className="w-full border-collapse text-xs">
                 <thead>
                   <tr>
-                    <th className="text-left px-3 py-2 font-bold text-xs text-text-muted bg-surface2 border-b-2 border-border">
+                    <th className="text-left px-3 py-2 text-xs font-semibold text-text-muted bg-surface2 border-b-2 border-border">
                       #
                     </th>
-                    <th className="text-left px-3 py-2 font-bold text-xs text-text-muted bg-surface2 border-b-2 border-border">
+                    <th className="text-left px-3 py-2 text-xs font-semibold text-text-muted bg-surface2 border-b-2 border-border">
                       CIDR
                     </th>
-                    <th className="text-left px-3 py-2 font-bold text-xs text-text-muted bg-surface2 border-b-2 border-border">
+                    <th className="text-left px-3 py-2 text-xs font-semibold text-text-muted bg-surface2 border-b-2 border-border">
                       Network
                     </th>
                     {isV4 && (
-                      <th className="text-left px-3 py-2 font-bold text-xs text-text-muted bg-surface2 border-b-2 border-border">
+                      <th className="text-left px-3 py-2 text-xs font-semibold text-text-muted bg-surface2 border-b-2 border-border">
                         Broadcast
                       </th>
                     )}
-                    <th className="text-left px-3 py-2 font-bold text-xs text-text-muted bg-surface2 border-b-2 border-border">
+                    <th className="text-left px-3 py-2 text-xs font-semibold text-text-muted bg-surface2 border-b-2 border-border">
                       Total
                     </th>
                     {isV4 && (
-                      <th className="text-left px-3 py-2 font-bold text-xs text-text-muted bg-surface2 border-b-2 border-border">
+                      <th className="text-left px-3 py-2 text-xs font-semibold text-text-muted bg-surface2 border-b-2 border-border">
                         Usable
                       </th>
                     )}

--- a/dashboard/src/pages/Summarize.tsx
+++ b/dashboard/src/pages/Summarize.tsx
@@ -49,7 +49,7 @@ export function Summarize() {
       <ErrorBanner message={error} onDismiss={() => setError(null)} />
 
       <Panel title="Input CIDRs">
-        <label className="block text-xs font-bold text-text-muted mb-1">
+        <label className="block text-xs font-medium text-text-muted mb-1">
           One CIDR per line (or comma-separated)
         </label>
         <textarea


### PR DESCRIPTION
Mechanical sweep of drift surfaced by an audit pass against \`.claude/skills/netcidr-design/\`. No behavior changes, no new components, no new tokens — all fixes are className edits or string casing.

## Changes

| Drift | Fix | Files |
|---|---|---|
| \`font-bold\` on form labels / table headers / secondary headings | → \`font-medium\` (labels) or \`font-semibold\` (table headers). The skill prescribes a hierarchy of regular / medium / semibold; bold is reserved for BitGrid's 8px digits where readability needs it. | Splitter, FromRange, Contains, Summarize, IpamSearch, Modal, AllocationDetailModal |
| Modal titles in Title Case | → sentence case: \"Create supernet\", \"Allocate specific block\", \"Auto-allocate\", \"Allocation detail\" | 4 modal files |
| Panel titles in Title Case | → \"Free blocks\", \"Audit log\", \"Bit visualization\" | FreeBlocksList, AuditLog, Calculator |
| \`shadow-sm\` on SignInCard | → canonical hairline \`shadow-[0_1px_2px_rgba(15,23,42,0.04)]\` (the only ambient shadow the system uses) | SignInCard |
| Modal inline error badges using the bolder \`border border-red\` | → tinted-background recipe \`border border-red/40 bg-red/10 text-red rounded-md\` so they match StatusBadge and the Calculator scope pill | 3 modal files |

## Not changed (intentional per skill)

- \`border-2 border-dashed\` on AllocationMap what-if overlays — skill explicitly allows.
- \`border-b-2\` on Modal headers and split-table column headers — skill explicitly allows (\"CLI-table feel\").
- \`font-bold\` in BitGrid 8px digits — readability override.
- 'NETWORK' / 'HOST' inline UPPERCASE labels above BitGrid — skill explicitly lists these.
- Page titles like 'Subnet Calculator' / 'IPAM Dashboard' — listed as sentence-case examples in the skill (proper terminology and abbreviations stay capitalized).

## Test plan

- [x] \`npm run typecheck\` clean.
- [x] \`bun run build\` clean. Bundle unchanged at ~318 kB gzipped.
- [x] \`cargo test\` clean (242 + 56 + 67 + 16 + 21 = 402 tests).
- [ ] After deploy, eyeball the dashboard: form labels lighter weight, modal titles read more naturally, SignInCard shadow matches Panel cards.