### PR TITLE
fix(dashboard): SignInCard copy lists Visualize as gated

### DIFF
--- a/dashboard/src/components/auth/SignInCard.tsx
+++ b/dashboard/src/components/auth/SignInCard.tsx
@@ -14,9 +14,9 @@ export function SignInCard() {
           Sign in to IPAM
         </h2>
         <p className="text-text-muted text-sm mb-6 leading-relaxed">
-          The IPAM dashboard is restricted to allowlisted Google accounts.
-          The other tools (Calc, Split, Contains, Summarize, Range, Visualize)
-          are available without signing in.
+          The IPAM dashboard and the allocation Visualizer are restricted to
+          allowlisted Google accounts. The calculator tools (Calc, Split,
+          Contains, Summarize, Range) are available without signing in.
         </p>
         {isAuthConfigured ? (
           <div className="flex justify-center">


### PR DESCRIPTION
Visualize was repurposed in #123 (IPAM-aware allocation map), but SignInCard's copy still listed it among the public tools. Fixes the user-facing inconsistency: clicking Visualize → sign-in card said "Visualize is available without signing in".

```diff
-          The IPAM dashboard is restricted to allowlisted Google accounts.
-          The other tools (Calc, Split, Contains, Summarize, Range, Visualize)
-          are available without signing in.
+          The IPAM dashboard and the allocation Visualizer are restricted to
+          allowlisted Google accounts. The calculator tools (Calc, Split,
+          Contains, Summarize, Range) are available without signing in.
```

RequestAccessCard already had this wording correct.