### PR TITLE
ci(release): dispatch netcidr-deploy after publishing tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,3 +83,19 @@ jobs:
           # binary, then flip it to non-draft.
           gh release upload "$RELEASE_TAG" target/release/netcidr --clobber
           gh release edit "$RELEASE_TAG" --draft=false
+
+      - name: Dispatch netcidr-deploy
+        # Tell wingnut128/netcidr-deploy to roll out the new tag. The
+        # default GITHUB_TOKEN can't trigger workflows in other repos, so
+        # this uses a fine-grained PAT scoped to netcidr-deploy with
+        # Actions: read+write only. RELEASE_TAG is already validated to
+        # match ^v[0-9]+\.[0-9]+\.[0-9]+$ by the earlier step, and jq
+        # --arg encodes it safely into JSON.
+        env:
+          GH_TOKEN: ${{ secrets.DEPLOY_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+          jq -n --arg ref "$RELEASE_TAG" \
+            '{event_type: "netcidr-released", client_payload: {ref: $ref}}' \
+            | gh api -X POST repos/wingnut128/netcidr-deploy/dispatches --input -
+          echo "Dispatched netcidr-released for $RELEASE_TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Release workflow now dispatches a `repository_dispatch: netcidr-released` event at `wingnut128/netcidr-deploy` after a tag is published, auto-rolling out the new version to AWS. Uses a fine-grained PAT (`DEPLOY_DISPATCH_TOKEN`) scoped to that repo with `Actions: read+write`; payload is `{ ref: "vX.Y.Z" }`.
 - Sidebar footer now shows the build's short git SHA next to the version (e.g., `v0.21.0 · 39146f7a`). The SHA links to the commit on GitHub. New `build.rs` injects `GIT_SHA_SHORT` / `GIT_SHA_FULL` at compile time (falls back to `unknown` when `.git` is absent, e.g., source tarballs); `/version` exposes both as `commit` and `commit_full`. Closes #94.
 - **Allowlist onboarding flow.** Three coordinated surfaces, all using the existing visual primitives:
   - **Sign-in card** — entry point for anonymous users, unchanged content but now part of the gate.


### PR DESCRIPTION
## Summary
After release-plz cuts a tag and the release workflow publishes the binary, fire `repository_dispatch: netcidr-released` at `wingnut128/netcidr-deploy` with the tag as `client_payload.ref`. The deploy repo's Deploy workflow already accepts that event (PR #24), so a netcidr release now auto-rolls out to AWS.

## Auth
- `secrets.DEPLOY_DISPATCH_TOKEN` — fine-grained PAT scoped to `wingnut128/netcidr-deploy` only, with `Actions: read+write`. Already configured.

## Implementation notes
- No third-party action: uses `gh api` (preinstalled) + `jq --arg` for safe JSON construction.
- `RELEASE_TAG` is already format-validated upstream (`^v[0-9]+\.[0-9]+\.[0-9]+$`), and `jq --arg` JSON-encodes it, so there's no injection surface.

## Test plan
- [ ] Cut a small follow-up release (or amend release-plz to land 0.21.x) — confirm the deploy run starts in netcidr-deploy with the matching tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)