### PR TITLE
feat(ipam): multi-tenant isolation per OIDC identity (v0.24.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-05-02
+
+### Changed
+
+- **Multi-tenant IPAM isolation.** Every supernet, allocation, audit entry, and idempotency record is now scoped to the authenticated user's email. The `IpamStore` trait and `IpamOps` struct expose `tenant_id: &str` as an explicit parameter on every method, making per-tenant filtering unforgettable at the type level. HTTP middleware extracts the tenant from the OIDC principal's verified email and exposes it via Axum extensions; cross-tenant access returns 404 (not 403) to prevent existence enumeration. CLI invocations and stdio MCP both pass the literal `"local"`. Schema is destructive: migration `006` drops and recreates `supernets`, `allocations`, `audit_log`, `idempotency_keys`, and `allocation_tags` with `tenant_id` columns, `UNIQUE(tenant_id, cidr)` on supernets, composite tenant indexes, and triggers enforcing the cross-table invariant `allocations.tenant_id == supernets.tenant_id`. Five-test isolation matrix in `tests/ipam_isolation.rs` proves the guarantee end-to-end (supernets, same-CIDR-different-tenant, allocations, audit log, idempotency keys). Sub-project 1 of 3 toward a remote MCP endpoint.
+
 ## [0.23.0] - 2026-04-30
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2219,7 +2219,7 @@ dependencies = [
 
 [[package]]
 name = "netcidr"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netcidr"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2024"
 license = "MIT"
 description = "A fast IPv4 and IPv6 subnet calculator CLI and API"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,9 @@ We actively support and provide security updates for the following versions:
 
 | Version | Supported          | Notes                                    |
 | ------- | ------------------ | ---------------------------------------- |
-| 0.23.x  | :white_check_mark: | Current stable release (recommended)     |
-| 0.22.x  | :white_check_mark: | Supported                                |
-| < 0.22  | :x:                | No longer supported                      |
+| 0.24.x  | :white_check_mark: | Current stable release (recommended)     |
+| 0.23.x  | :white_check_mark: | Supported                                |
+| < 0.23  | :x:                | No longer supported                      |
 
 ## Reporting a Vulnerability
 

--- a/docs/superpowers/plans/2026-05-02-multi-tenant-isolation.md
+++ b/docs/superpowers/plans/2026-05-02-multi-tenant-isolation.md
@@ -1,0 +1,1460 @@
+# Multi-Tenant Isolation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add per-OIDC-identity isolation of IPAM data (supernets, allocations, audit log, idempotency keys), with `tenant_id` threaded explicitly through the storage and operations layers.
+
+**Architecture:** Destructive schema migration adds a `tenant_id TEXT NOT NULL` column to four tables. The `IpamStore` trait and `IpamOps` struct grow an explicit `tenant_id: &str` parameter on every tenant-scoped method. HTTP middleware extracts `tenant_id` from the authenticated principal's email and exposes it via Axum request extensions; handlers pass it explicitly into ops. CLI passes the literal `"local"`. Cross-tenant reads return `NotFound` (never `Forbidden`) to avoid existence leakage.
+
+**Tech Stack:** Rust, sqlx (SQLite + Postgres), Axum, tokio, async-trait. Tests: `cargo test` (unit + integration), `cargo test --features ipam-postgres` (Postgres path).
+
+**Spec:** `docs/superpowers/specs/2026-05-02-multi-tenant-isolation-design.md`
+
+---
+
+## File Map
+
+**Modified:**
+- `src/ipam/models.rs` — add `tenant_id` field to `Supernet`, `Allocation`, `AuditEntry`, `IdempotencyRecord`
+- `src/ipam/store.rs` — trait signatures gain `tenant_id: &str` parameter
+- `src/ipam/sqlite/migrations.rs` — add migration 006 (drop + recreate four tables with new schema)
+- `src/ipam/sqlite/mod.rs` — every query gains `WHERE tenant_id = ?` filter or `tenant_id` insert column
+- `src/ipam/postgres/migrations.rs` — add migration 006 (Postgres equivalent)
+- `src/ipam/postgres/mod.rs` — same query updates as SQLite
+- `src/ipam/operations.rs` — every public method gains `tenant_id: &str`; threads to store
+- `src/ipam/idempotency.rs` — `idempotent_post` reads tenant_id from request, passes to store
+- `src/ipam_api.rs` — HTTP handlers extract `tenant_id` from request extensions, pass to ops
+- `src/api.rs` — auth middleware sets `Tenant(email)` extension on request after allowlist check
+- `src/ipam_cli.rs` — every ops call passes `"local"`
+- `src/mcp.rs` — local IPAM backend defaults `tenant_id = "local"` for stdio MCP usage
+
+**Created:**
+- `src/tenant.rs` — small `Tenant(String)` newtype + Axum extractor
+- `tests/ipam_isolation.rs` — HTTP-level isolation matrix (two mock OIDC identities, every cross-tenant access path returns 404)
+
+**Test fixture sweep (mechanical):**
+- `tests/ipam_store_contract.rs`, `tests/ipam_api_tests.rs`, `tests/ipam_concurrency.rs`, `tests/ipam_idempotency.rs`, `tests/postgres_integration.rs`, `tests/integration_tests.rs` — every literal `Supernet { ... }` / `Allocation { ... }` / `IdempotencyRecord { ... }` and every `IpamOps::*` call needs the new field/parameter populated.
+
+---
+
+## Phase 1: Schema and Models
+
+### Task 1: Add `tenant_id` field to model structs
+
+**Files:**
+- Modify: `src/ipam/models.rs`
+
+Adds the field that the rest of the plan reads. No serde-skip needed because tenancy is enforced server-side and the dashboard already only sees its own data; if we ever want to suppress the field in JSON we can add `#[serde(skip_serializing)]` later.
+
+- [ ] **Step 1: Add `tenant_id` to `Supernet`**
+
+In `src/ipam/models.rs`, after `pub id: String,` in the `Supernet` struct (around line 10):
+
+```rust
+pub struct Supernet {
+    pub id: String,
+    pub tenant_id: String,
+    pub cidr: String,
+    // ... rest unchanged
+}
+```
+
+- [ ] **Step 2: Add `tenant_id` to `Allocation`**
+
+In the `Allocation` struct (around line 78):
+
+```rust
+pub struct Allocation {
+    pub id: String,
+    pub tenant_id: String,
+    pub supernet_id: String,
+    // ... rest unchanged
+}
+```
+
+- [ ] **Step 3: Add `tenant_id` to `AuditEntry`**
+
+In the `AuditEntry` struct (around line 189):
+
+```rust
+pub struct AuditEntry {
+    pub id: String,
+    pub tenant_id: String,
+    pub entity_type: String,
+    // ... rest unchanged
+}
+```
+
+- [ ] **Step 4: Add `tenant_id` to `IdempotencyRecord`**
+
+In `IdempotencyRecord` (around line 446):
+
+```rust
+pub struct IdempotencyRecord {
+    pub tenant_id: String,
+    pub key: String,
+    pub scope: String,
+    pub request_hash: String,
+    pub status_code: u16,
+    pub response_body: String,
+    pub created_at: String,
+    pub expires_at: String,
+}
+```
+
+- [ ] **Step 5: `cargo check` — expect many errors in `sqlite/mod.rs`, `postgres/mod.rs`, tests**
+
+```bash
+cargo check 2>&1 | head -40
+```
+
+Expected: errors about missing `tenant_id` field in struct literals across the codebase. This is intentional — Phases 2-6 fix them.
+
+- [ ] **Step 6: Commit (intermediate, broken build)**
+
+```bash
+git add src/ipam/models.rs
+git commit -m "refactor(ipam): add tenant_id field to core models
+
+Build is intentionally broken at this point — subsequent commits in this
+PR add the SQL columns, thread tenant_id through IpamStore + IpamOps, and
+update all call sites."
+```
+
+---
+
+### Task 2: Add SQLite migration 006 (destructive)
+
+**Files:**
+- Modify: `src/ipam/sqlite/migrations.rs`
+
+The migration drops `supernets`, `allocations`, `audit_log`, `idempotency_keys` and recreates them with `tenant_id`. `allocation_tags` references `allocations(id)` so we drop and recreate it too (no new column — inherits via FK).
+
+- [ ] **Step 1: Read existing migration array structure**
+
+```bash
+grep -n "MIGRATIONS\|version\|CREATE TABLE" src/ipam/sqlite/migrations.rs | head -30
+```
+
+This shows where the existing migrations array is defined and what version numbers are used.
+
+- [ ] **Step 2: Append migration 006 to the migrations array**
+
+In `src/ipam/sqlite/migrations.rs`, add a new entry after migration 005:
+
+```rust
+Migration {
+    version: 6,
+    description: "multi-tenant isolation: drop+recreate IPAM tables with tenant_id",
+    sql: r#"
+        DROP TABLE IF EXISTS allocation_tags;
+        DROP TABLE IF EXISTS allocations;
+        DROP TABLE IF EXISTS supernets;
+        DROP TABLE IF EXISTS audit_log;
+        DROP TABLE IF EXISTS idempotency_keys;
+
+        CREATE TABLE supernets (
+            id                TEXT PRIMARY KEY,
+            tenant_id         TEXT NOT NULL,
+            cidr              TEXT NOT NULL,
+            network_address   TEXT NOT NULL,
+            broadcast_address TEXT NOT NULL,
+            prefix_length     INTEGER NOT NULL,
+            total_hosts       TEXT NOT NULL,
+            name              TEXT,
+            description       TEXT,
+            ip_version        INTEGER NOT NULL,
+            created_at        TEXT NOT NULL,
+            updated_at        TEXT NOT NULL,
+            UNIQUE (tenant_id, cidr)
+        );
+        CREATE INDEX idx_supernets_tenant ON supernets(tenant_id);
+
+        CREATE TABLE allocations (
+            id                    TEXT PRIMARY KEY,
+            tenant_id             TEXT NOT NULL,
+            supernet_id           TEXT NOT NULL REFERENCES supernets(id),
+            cidr                  TEXT NOT NULL,
+            network_address       TEXT NOT NULL,
+            broadcast_address     TEXT NOT NULL,
+            prefix_length         INTEGER NOT NULL,
+            total_hosts           TEXT NOT NULL,
+            status                TEXT NOT NULL,
+            resource_id           TEXT,
+            resource_type         TEXT,
+            name                  TEXT,
+            description           TEXT,
+            environment           TEXT,
+            owner                 TEXT,
+            parent_allocation_id  TEXT REFERENCES allocations(id),
+            created_at            TEXT NOT NULL,
+            updated_at            TEXT NOT NULL,
+            released_at           TEXT,
+            expires_at            TEXT
+        );
+        CREATE INDEX idx_allocations_tenant     ON allocations(tenant_id);
+        CREATE INDEX idx_allocations_tenant_sn  ON allocations(tenant_id, supernet_id);
+        CREATE INDEX idx_allocations_supernet   ON allocations(supernet_id);
+        CREATE INDEX idx_allocations_status     ON allocations(status);
+        CREATE INDEX idx_allocations_cidr       ON allocations(cidr);
+
+        -- Cross-table invariant: allocations.tenant_id must match the parent supernet's.
+        CREATE TRIGGER trg_allocations_tenant_match_insert
+            BEFORE INSERT ON allocations
+            FOR EACH ROW
+            WHEN NEW.tenant_id != (SELECT tenant_id FROM supernets WHERE id = NEW.supernet_id)
+            BEGIN
+                SELECT RAISE(ABORT, 'allocation tenant_id must match parent supernet tenant_id');
+            END;
+        CREATE TRIGGER trg_allocations_tenant_match_update
+            BEFORE UPDATE OF tenant_id, supernet_id ON allocations
+            FOR EACH ROW
+            WHEN NEW.tenant_id != (SELECT tenant_id FROM supernets WHERE id = NEW.supernet_id)
+            BEGIN
+                SELECT RAISE(ABORT, 'allocation tenant_id must match parent supernet tenant_id');
+            END;
+
+        CREATE TABLE allocation_tags (
+            allocation_id TEXT NOT NULL REFERENCES allocations(id) ON DELETE CASCADE,
+            key           TEXT NOT NULL,
+            value         TEXT NOT NULL,
+            PRIMARY KEY (allocation_id, key)
+        );
+
+        CREATE TABLE audit_log (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            tenant_id     TEXT NOT NULL,
+            entity_type   TEXT NOT NULL,
+            entity_id     TEXT NOT NULL,
+            action        TEXT NOT NULL,
+            details       TEXT,
+            timestamp     TEXT NOT NULL,
+            caller_sub    TEXT,
+            caller_email  TEXT,
+            source_ip     TEXT,
+            request_id    TEXT
+        );
+        CREATE INDEX idx_audit_tenant         ON audit_log(tenant_id);
+        CREATE INDEX idx_audit_tenant_entity  ON audit_log(tenant_id, entity_type, entity_id);
+        CREATE INDEX idx_audit_request_id     ON audit_log(request_id);
+        CREATE INDEX idx_audit_caller_sub     ON audit_log(caller_sub);
+
+        CREATE TABLE idempotency_keys (
+            tenant_id     TEXT NOT NULL,
+            key           TEXT NOT NULL,
+            scope         TEXT NOT NULL,
+            request_hash  TEXT NOT NULL,
+            status_code   INTEGER NOT NULL,
+            response_body TEXT NOT NULL,
+            created_at    TEXT NOT NULL,
+            expires_at    TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, key, scope)
+        );
+        CREATE INDEX idx_idempotency_expires ON idempotency_keys(expires_at);
+    "#,
+},
+```
+
+Note: SQLite `INTEGER` columns hold the version number; the `version_pk` PRAGMA-driven scheme already in the file applies. `total_hosts` stays TEXT because Rust holds it as `u128` and SQLite has no native u128.
+
+- [ ] **Step 3: Write a unit test for the trigger**
+
+Add to `src/ipam/sqlite/migrations.rs` `#[cfg(test)] mod tests`:
+
+```rust
+#[tokio::test]
+async fn allocation_with_mismatched_tenant_id_is_rejected_by_trigger() {
+    let store = SqliteStore::in_memory().await.unwrap();
+    store.migrate().await.unwrap();
+
+    // Insert a supernet for tenant "a@x".
+    sqlx::query(
+        r#"INSERT INTO supernets
+           (id, tenant_id, cidr, network_address, broadcast_address,
+            prefix_length, total_hosts, ip_version, created_at, updated_at)
+           VALUES ('s1','a@x','10.0.0.0/8','10.0.0.0','10.255.255.255',
+                   8,'16777216',4,'2026-05-02T00:00:00Z','2026-05-02T00:00:00Z')"#,
+    )
+    .execute(store.pool())
+    .await
+    .unwrap();
+
+    // Attempt to insert allocation with mismatched tenant_id.
+    let result = sqlx::query(
+        r#"INSERT INTO allocations
+           (id, tenant_id, supernet_id, cidr, network_address, broadcast_address,
+            prefix_length, total_hosts, status, created_at, updated_at)
+           VALUES ('a1','b@x','s1','10.1.0.0/16','10.1.0.0','10.1.255.255',
+                   16,'65536','active','2026-05-02T00:00:00Z','2026-05-02T00:00:00Z')"#,
+    )
+    .execute(store.pool())
+    .await;
+
+    assert!(
+        result.is_err(),
+        "trigger should reject allocation whose tenant_id != supernet's tenant_id"
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("allocation tenant_id must match"),
+        "unexpected error: {}",
+        err
+    );
+}
+```
+
+If `SqliteStore::in_memory()` and `SqliteStore::pool()` don't exist, add them as test-only helpers (look for similar in the existing file).
+
+- [ ] **Step 4: Run only this test (will fail until SQLite impl is updated, but the migration test should pass)**
+
+```bash
+cargo test --lib --features ipam-postgres allocation_with_mismatched_tenant -- --nocapture
+```
+
+Expected: PASS. The migration runs without errors and the trigger rejects the bad insert.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ipam/sqlite/migrations.rs
+git commit -m "refactor(ipam/sqlite): migration 006 — multi-tenant schema
+
+Drops and recreates supernets, allocations, audit_log, idempotency_keys,
+and allocation_tags. Adds tenant_id columns, UNIQUE(tenant_id, cidr) on
+supernets, composite tenant indexes, and triggers enforcing the
+cross-table invariant allocations.tenant_id == supernets.tenant_id."
+```
+
+---
+
+### Task 3: Add Postgres migration 006
+
+**Files:**
+- Modify: `src/ipam/postgres/migrations.rs`
+
+Same shape as SQLite migration but in Postgres dialect (BIGSERIAL instead of AUTOINCREMENT, `RAISE EXCEPTION` instead of `RAISE(ABORT)`, etc.).
+
+- [ ] **Step 1: Read the existing Postgres migrations module**
+
+```bash
+grep -n "MIGRATIONS\|version\|CREATE TABLE" src/ipam/postgres/migrations.rs | head -40
+```
+
+- [ ] **Step 2: Append migration 006**
+
+```rust
+Migration {
+    version: 6,
+    description: "multi-tenant isolation: drop+recreate IPAM tables with tenant_id",
+    sql: r#"
+        DROP TABLE IF EXISTS allocation_tags CASCADE;
+        DROP TABLE IF EXISTS allocations CASCADE;
+        DROP TABLE IF EXISTS supernets CASCADE;
+        DROP TABLE IF EXISTS audit_log CASCADE;
+        DROP TABLE IF EXISTS idempotency_keys CASCADE;
+
+        CREATE TABLE supernets (
+            id                TEXT PRIMARY KEY,
+            tenant_id         TEXT NOT NULL,
+            cidr              TEXT NOT NULL,
+            network_address   TEXT NOT NULL,
+            broadcast_address TEXT NOT NULL,
+            prefix_length     SMALLINT NOT NULL,
+            total_hosts       TEXT NOT NULL,
+            name              TEXT,
+            description       TEXT,
+            ip_version        SMALLINT NOT NULL,
+            created_at        TEXT NOT NULL,
+            updated_at        TEXT NOT NULL,
+            UNIQUE (tenant_id, cidr)
+        );
+        CREATE INDEX idx_supernets_tenant ON supernets(tenant_id);
+
+        CREATE TABLE allocations (
+            id                    TEXT PRIMARY KEY,
+            tenant_id             TEXT NOT NULL,
+            supernet_id           TEXT NOT NULL REFERENCES supernets(id),
+            cidr                  TEXT NOT NULL,
+            network_address       TEXT NOT NULL,
+            broadcast_address     TEXT NOT NULL,
+            prefix_length         SMALLINT NOT NULL,
+            total_hosts           TEXT NOT NULL,
+            status                TEXT NOT NULL,
+            resource_id           TEXT,
+            resource_type         TEXT,
+            name                  TEXT,
+            description           TEXT,
+            environment           TEXT,
+            owner                 TEXT,
+            parent_allocation_id  TEXT REFERENCES allocations(id),
+            created_at            TEXT NOT NULL,
+            updated_at            TEXT NOT NULL,
+            released_at           TEXT,
+            expires_at            TEXT
+        );
+        CREATE INDEX idx_allocations_tenant    ON allocations(tenant_id);
+        CREATE INDEX idx_allocations_tenant_sn ON allocations(tenant_id, supernet_id);
+        CREATE INDEX idx_allocations_supernet  ON allocations(supernet_id);
+        CREATE INDEX idx_allocations_status    ON allocations(status);
+        CREATE INDEX idx_allocations_cidr      ON allocations(cidr);
+
+        CREATE OR REPLACE FUNCTION assert_alloc_tenant_match() RETURNS trigger AS $$
+        DECLARE
+            sn_tenant TEXT;
+        BEGIN
+            SELECT tenant_id INTO sn_tenant FROM supernets WHERE id = NEW.supernet_id;
+            IF sn_tenant IS NULL OR sn_tenant != NEW.tenant_id THEN
+                RAISE EXCEPTION 'allocation tenant_id must match parent supernet tenant_id';
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+
+        CREATE TRIGGER trg_allocations_tenant_match_insert
+            BEFORE INSERT ON allocations
+            FOR EACH ROW EXECUTE FUNCTION assert_alloc_tenant_match();
+        CREATE TRIGGER trg_allocations_tenant_match_update
+            BEFORE UPDATE OF tenant_id, supernet_id ON allocations
+            FOR EACH ROW EXECUTE FUNCTION assert_alloc_tenant_match();
+
+        CREATE TABLE allocation_tags (
+            allocation_id TEXT NOT NULL REFERENCES allocations(id) ON DELETE CASCADE,
+            key           TEXT NOT NULL,
+            value         TEXT NOT NULL,
+            PRIMARY KEY (allocation_id, key)
+        );
+
+        CREATE TABLE audit_log (
+            id            BIGSERIAL PRIMARY KEY,
+            tenant_id     TEXT NOT NULL,
+            entity_type   TEXT NOT NULL,
+            entity_id     TEXT NOT NULL,
+            action        TEXT NOT NULL,
+            details       TEXT,
+            timestamp     TEXT NOT NULL,
+            caller_sub    TEXT,
+            caller_email  TEXT,
+            source_ip     TEXT,
+            request_id    TEXT
+        );
+        CREATE INDEX idx_audit_tenant         ON audit_log(tenant_id);
+        CREATE INDEX idx_audit_tenant_entity  ON audit_log(tenant_id, entity_type, entity_id);
+        CREATE INDEX idx_audit_request_id     ON audit_log(request_id);
+        CREATE INDEX idx_audit_caller_sub     ON audit_log(caller_sub);
+
+        CREATE TABLE idempotency_keys (
+            tenant_id     TEXT NOT NULL,
+            key           TEXT NOT NULL,
+            scope         TEXT NOT NULL,
+            request_hash  TEXT NOT NULL,
+            status_code   INTEGER NOT NULL,
+            response_body TEXT NOT NULL,
+            created_at    TEXT NOT NULL,
+            expires_at    TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, key, scope)
+        );
+        CREATE INDEX idx_idempotency_expires ON idempotency_keys(expires_at);
+    "#,
+},
+```
+
+- [ ] **Step 3: Mirror the trigger test**
+
+Add a test at the bottom of the postgres migrations file (gated `#[cfg(all(test, feature = "ipam-postgres"))]`):
+
+```rust
+#[tokio::test]
+async fn pg_allocation_with_mismatched_tenant_id_is_rejected_by_trigger() {
+    // Skip if no NETCIDR_TEST_DATABASE_URL set.
+    let url = match std::env::var("NETCIDR_TEST_DATABASE_URL") {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    let store = PostgresStore::connect(&url).await.unwrap();
+    store.migrate().await.unwrap();
+
+    sqlx::query(
+        r#"INSERT INTO supernets
+           (id, tenant_id, cidr, network_address, broadcast_address,
+            prefix_length, total_hosts, ip_version, created_at, updated_at)
+           VALUES ('s1','a@x','10.0.0.0/8','10.0.0.0','10.255.255.255',
+                   8,'16777216',4,'2026-05-02T00:00:00Z','2026-05-02T00:00:00Z')"#,
+    )
+    .execute(store.pool())
+    .await
+    .unwrap();
+
+    let result = sqlx::query(
+        r#"INSERT INTO allocations
+           (id, tenant_id, supernet_id, cidr, network_address, broadcast_address,
+            prefix_length, total_hosts, status, created_at, updated_at)
+           VALUES ('a1','b@x','s1','10.1.0.0/16','10.1.0.0','10.1.255.255',
+                   16,'65536','active','2026-05-02T00:00:00Z','2026-05-02T00:00:00Z')"#,
+    )
+    .execute(store.pool())
+    .await;
+
+    assert!(result.is_err());
+    assert!(
+        result.unwrap_err().to_string().contains("must match parent"),
+    );
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ipam/postgres/migrations.rs
+git commit -m "refactor(ipam/postgres): migration 006 — multi-tenant schema
+
+Mirror the SQLite migration: drop and recreate IPAM tables with tenant_id,
+UNIQUE(tenant_id, cidr) on supernets, composite tenant indexes, and a
+plpgsql function + trigger enforcing the cross-table invariant."
+```
+
+---
+
+## Phase 2: Storage Layer
+
+### Task 4: Update `IpamStore` trait signatures
+
+**Files:**
+- Modify: `src/ipam/store.rs`
+
+This is the load-bearing change for the entire refactor. After this commit lands, every backend impl must follow.
+
+- [ ] **Step 1: Replace the trait body**
+
+Replace the contents of `src/ipam/store.rs` with:
+
+```rust
+use async_trait::async_trait;
+
+use crate::error::Result;
+use crate::ipam::models::*;
+
+/// Core storage abstraction for the IPAM persistence layer.
+///
+/// All tenant-scoped methods take an explicit `tenant_id: &str` parameter so
+/// the type system makes per-tenant filtering unforgettable. Backends must
+/// add `WHERE tenant_id = ?` to every query and refuse cross-tenant
+/// references with `IpamError::NotFound` (never `Forbidden`, to avoid
+/// leaking existence).
+#[async_trait]
+pub trait IpamStore: Send + Sync {
+    // --- lifecycle ---
+    async fn initialize(&self) -> Result<()>;
+    async fn migrate(&self) -> Result<()>;
+
+    // --- supernets ---
+    async fn create_supernet(
+        &self,
+        tenant_id: &str,
+        input: &CreateSupernet,
+    ) -> Result<Supernet>;
+    async fn get_supernet(&self, tenant_id: &str, id: &str) -> Result<Supernet>;
+    async fn list_supernets(&self, tenant_id: &str) -> Result<Vec<Supernet>>;
+    async fn delete_supernet(&self, tenant_id: &str, id: &str) -> Result<()>;
+
+    // --- allocations ---
+    async fn create_allocation(
+        &self,
+        tenant_id: &str,
+        input: &CreateAllocation,
+    ) -> Result<Allocation>;
+    async fn get_allocation(&self, tenant_id: &str, id: &str) -> Result<Allocation>;
+    async fn list_allocations(
+        &self,
+        tenant_id: &str,
+        filter: &AllocationFilter,
+    ) -> Result<Vec<Allocation>>;
+    async fn update_allocation(
+        &self,
+        tenant_id: &str,
+        id: &str,
+        input: &UpdateAllocation,
+    ) -> Result<Allocation>;
+    async fn release_allocation(
+        &self,
+        tenant_id: &str,
+        id: &str,
+    ) -> Result<Allocation>;
+    async fn find_allocations_in_supernet(
+        &self,
+        tenant_id: &str,
+        supernet_id: &str,
+        statuses: &[AllocationStatus],
+    ) -> Result<Vec<Allocation>>;
+
+    // --- tags ---
+    async fn set_tags(
+        &self,
+        tenant_id: &str,
+        allocation_id: &str,
+        tags: &[Tag],
+    ) -> Result<()>;
+    async fn get_tags(&self, tenant_id: &str, allocation_id: &str) -> Result<Vec<Tag>>;
+
+    // --- audit ---
+    /// `entry.tenant_id` is the source of truth (already populated by caller).
+    async fn append_audit(&self, entry: &AuditEntry) -> Result<()>;
+    async fn query_audit(
+        &self,
+        tenant_id: &str,
+        filter: &AuditFilter,
+    ) -> Result<Vec<AuditEntry>>;
+
+    // --- idempotency ---
+    async fn idempotency_get(
+        &self,
+        tenant_id: &str,
+        key: &str,
+        scope: &str,
+    ) -> Result<Option<IdempotencyRecord>>;
+    /// `record.tenant_id` is the source of truth.
+    async fn idempotency_put(&self, record: &IdempotencyRecord) -> Result<()>;
+    /// Tenant-agnostic: prunes expired rows across all tenants.
+    async fn idempotency_reap_expired(&self, now_rfc3339: &str) -> Result<u64>;
+}
+```
+
+- [ ] **Step 2: `cargo check` to confirm trait compiles in isolation**
+
+```bash
+cargo check --lib 2>&1 | grep -E "^error\[" | head -20
+```
+
+Expected: errors in `sqlite/mod.rs` and `postgres/mod.rs` because the impls no longer match the trait. That's correct — Tasks 5 and 6 fix them.
+
+- [ ] **Step 3: Commit (still broken build)**
+
+```bash
+git add src/ipam/store.rs
+git commit -m "refactor(ipam): IpamStore trait — explicit tenant_id parameter
+
+Every tenant-scoped method now takes tenant_id: &str explicitly. Backends
+will follow in subsequent commits."
+```
+
+---
+
+### Task 5: SQLite backend implementation
+
+**Files:**
+- Modify: `src/ipam/sqlite/mod.rs`
+
+Pattern: each method that took `(id)` becomes `(tenant_id, id)` and the SQL adds `WHERE tenant_id = ?`. Each insert adds `tenant_id` to the column list and `?` to the values. Show the pattern on `create_supernet` and `get_supernet`; the rest is mechanical.
+
+- [ ] **Step 1: Update `create_supernet`**
+
+Find the existing `create_supernet` impl (search for `async fn create_supernet` in the file). Replace its body with the tenant-aware version:
+
+```rust
+async fn create_supernet(
+    &self,
+    tenant_id: &str,
+    input: &CreateSupernet,
+) -> Result<Supernet> {
+    let id = uuid::Uuid::new_v4().to_string();
+    let now = chrono::Utc::now().to_rfc3339();
+    let parsed = parse_cidr(&input.cidr)?;
+
+    sqlx::query(
+        r#"INSERT INTO supernets
+           (id, tenant_id, cidr, network_address, broadcast_address,
+            prefix_length, total_hosts, name, description, ip_version,
+            created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
+    )
+    .bind(&id)
+    .bind(tenant_id)
+    .bind(&input.cidr)
+    .bind(&parsed.network_address)
+    .bind(&parsed.broadcast_address)
+    .bind(parsed.prefix_length as i64)
+    .bind(parsed.total_hosts.to_string())
+    .bind(&input.name)
+    .bind(&input.description)
+    .bind(parsed.ip_version as i64)
+    .bind(&now)
+    .bind(&now)
+    .execute(&self.pool)
+    .await
+    .map_err(map_sqlite_error)?;
+
+    self.get_supernet(tenant_id, &id).await
+}
+```
+
+(Adapt to the actual existing helper functions like `parse_cidr` / `map_sqlite_error` whose names you'll see in the file.)
+
+- [ ] **Step 2: Update `get_supernet`**
+
+```rust
+async fn get_supernet(&self, tenant_id: &str, id: &str) -> Result<Supernet> {
+    let row = sqlx::query_as::<_, SupernetRow>(
+        "SELECT * FROM supernets WHERE id = ? AND tenant_id = ?",
+    )
+    .bind(id)
+    .bind(tenant_id)
+    .fetch_optional(&self.pool)
+    .await
+    .map_err(map_sqlite_error)?;
+
+    row.map(Supernet::from)
+        .ok_or_else(|| crate::error::NetcidrError::IpamError(IpamError::NotFound {
+            entity: "supernet".to_string(),
+            id: id.to_string(),
+        }))
+}
+```
+
+`SupernetRow` is the existing sqlx::FromRow type. Add `tenant_id` to it. The `From<SupernetRow> for Supernet` conversion needs to copy the new field.
+
+- [ ] **Step 3: Apply the same pattern to remaining methods**
+
+For each method in this list, the change is mechanical:
+- `list_supernets` → `WHERE tenant_id = ?`
+- `delete_supernet` → `WHERE id = ? AND tenant_id = ?`
+- `create_allocation` → INSERT includes `tenant_id` (read from input — but our trait passes tenant_id separately; use the parameter, NOT input.tenant_id since CreateAllocation doesn't have one). The trigger enforces the supernet match; we can rely on it.
+- `get_allocation` → `WHERE id = ? AND tenant_id = ?`
+- `list_allocations` → `WHERE tenant_id = ?` plus existing filter clauses
+- `update_allocation` → `WHERE id = ? AND tenant_id = ?`
+- `release_allocation` → `WHERE id = ? AND tenant_id = ?`
+- `find_allocations_in_supernet` → `WHERE supernet_id = ? AND tenant_id = ?`
+- `set_tags` → first verify the allocation is in this tenant: `SELECT 1 FROM allocations WHERE id = ? AND tenant_id = ?`. If absent → `NotFound`. Then existing tag insert logic.
+- `get_tags` → same: verify allocation belongs to tenant, then read tags.
+- `append_audit` → INSERT includes `tenant_id` from `entry.tenant_id`
+- `query_audit` → `WHERE tenant_id = ?` plus existing filter clauses
+- `idempotency_get` → `WHERE tenant_id = ? AND key = ? AND scope = ?`
+- `idempotency_put` → INSERT with `record.tenant_id`
+- `idempotency_reap_expired` → unchanged (tenant-agnostic by design)
+
+For each, the key invariants:
+- Reads of unowned IDs return `IpamError::NotFound`, not `Forbidden`
+- `SELECT *` queries that map to `SupernetRow` / `AllocationRow` / `AuditEntryRow` need those Row types to include `tenant_id`
+
+- [ ] **Step 4: Update Row → Model conversions**
+
+Add `tenant_id: row.tenant_id,` to each `From<*Row> for *` conversion in this file.
+
+- [ ] **Step 5: Run lib unit tests for SQLite**
+
+```bash
+cargo test --lib ipam::sqlite -- --nocapture 2>&1 | tail -30
+```
+
+Expected: most tests still failing because callers haven't been updated yet, but the migration trigger test from Task 2 should pass now that the impl supports the new schema.
+
+- [ ] **Step 6: Commit (build still broken — operations.rs, ipam_api.rs, ipam_cli.rs not yet updated)**
+
+```bash
+git add src/ipam/sqlite/mod.rs
+git commit -m "refactor(ipam/sqlite): implement tenant_id-aware IpamStore"
+```
+
+---
+
+### Task 6: Postgres backend implementation
+
+**Files:**
+- Modify: `src/ipam/postgres/mod.rs`
+
+Same pattern as SQLite. The bind syntax is `$1, $2, ...` instead of `?`.
+
+- [ ] **Step 1: Update `create_supernet`** — `INSERT INTO supernets (id, tenant_id, cidr, ...) VALUES ($1, $2, $3, ...)`. Pattern shown in Task 5 Step 1.
+
+- [ ] **Step 2: Update `get_supernet`** — `SELECT * FROM supernets WHERE id = $1 AND tenant_id = $2`.
+
+- [ ] **Step 3: Apply same pattern to remaining methods** — same list as Task 5 Step 3.
+
+- [ ] **Step 4: Update Row→Model conversions to include tenant_id.**
+
+- [ ] **Step 5: Run Postgres tests (skip-if-no-DB)**
+
+```bash
+cargo test --features ipam-postgres --lib ipam::postgres 2>&1 | tail -20
+```
+
+Expected: tests that need a live Postgres skip cleanly if `NETCIDR_TEST_DATABASE_URL` is unset; otherwise they pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ipam/postgres/mod.rs
+git commit -m "refactor(ipam/postgres): implement tenant_id-aware IpamStore"
+```
+
+---
+
+## Phase 3: Operations Layer
+
+### Task 7: Update `IpamOps` to thread `tenant_id`
+
+**Files:**
+- Modify: `src/ipam/operations.rs`
+
+Every public method on `IpamOps` grows `tenant_id: &str`. The internal calls to `self.store.*` pass it through. Audit log entries get `tenant_id` populated from the parameter (NOT from `audit_context::current()`).
+
+- [ ] **Step 1: Update method signatures (mechanical sweep)**
+
+For every public `async fn` on `IpamOps`, add `tenant_id: &str` as the first parameter (after `&self`). Methods affected (roughly 15-20 — search for `pub async fn` in the file):
+
+```
+pub async fn create_supernet(&self, tenant_id: &str, ...) -> Result<Supernet>
+pub async fn get_supernet(&self, tenant_id: &str, id: &str) -> Result<Supernet>
+pub async fn list_supernets(&self, tenant_id: &str) -> Result<SupernetList>
+pub async fn delete_supernet(&self, tenant_id: &str, id: &str) -> Result<()>
+pub async fn allocate_specific(&self, tenant_id: &str, input: CreateAllocation) -> Result<Allocation>
+pub async fn allocate_auto(&self, tenant_id: &str, req: AutoAllocateRequest) -> Result<Vec<Allocation>>
+pub async fn get_allocation(&self, tenant_id: &str, id: &str) -> Result<Allocation>
+pub async fn list_allocations(&self, tenant_id: &str, filter: AllocationFilter) -> Result<AllocationList>
+pub async fn update_allocation(&self, tenant_id: &str, id: &str, input: UpdateAllocation) -> Result<Allocation>
+pub async fn release_allocation(&self, tenant_id: &str, id: &str) -> Result<Allocation>
+pub async fn batch_allocate(&self, tenant_id: &str, items: Vec<BatchAllocateItem>) -> Result<BatchAllocateResult>
+pub async fn batch_release(&self, tenant_id: &str, req: BatchReleaseRequest) -> Result<BatchReleaseResult>
+pub async fn utilization(&self, tenant_id: &str, supernet_id: &str) -> Result<UtilizationReport>
+pub async fn free_blocks(&self, tenant_id: &str, supernet_id: &str, ...) -> Result<FreeBlocksReport>
+pub async fn find_ip(&self, tenant_id: &str, ip: &str) -> Result<...>
+pub async fn find_resource(&self, tenant_id: &str, query: &str) -> Result<...>
+pub async fn audit_log(&self, tenant_id: &str, filter: AuditFilter) -> Result<...>
+```
+
+- [ ] **Step 2: Thread tenant_id through every call to `self.store.*`**
+
+Find every `self.store.METHOD(...)` and add `tenant_id` (or threaded variable) as the first arg.
+
+- [ ] **Step 3: Populate `entry.tenant_id` when constructing `AuditEntry`**
+
+Search for `AuditEntry {` literals in `operations.rs`. Add `tenant_id: tenant_id.to_string(),` to each.
+
+The existing `audit_context::current()` call (line 942) still provides `caller_sub`, `caller_email`, `source_ip`, `request_id`. Keep that; only `tenant_id` comes from the new parameter.
+
+- [ ] **Step 4: Update the per-supernet allocation lock map**
+
+The `HashMap<supernet_id, Arc<Mutex<()>>>` keys on supernet_id. Two tenants could have the same supernet_id... no, actually they can't — UUIDs are globally unique. Locking is fine as-is.
+
+- [ ] **Step 5: Update tests in `operations.rs` to pass `tenant_id`**
+
+Every `let ops = IpamOps::new(...); ops.METHOD(...)` in the file's `#[cfg(test)] mod tests` needs `tenant_id` threaded in. Use `"test-tenant"` as a constant.
+
+- [ ] **Step 6: `cargo check --lib` — should now pass for the library**
+
+```bash
+cargo check --lib 2>&1 | grep -E "^error" | head
+```
+
+Expected: no errors in `src/ipam/`. Errors remain in `src/ipam_api.rs`, `src/ipam_cli.rs`, `src/api.rs`, `src/mcp.rs`. Phases 4-5 fix those.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ipam/operations.rs
+git commit -m "refactor(ipam/operations): thread tenant_id through every public method"
+```
+
+---
+
+### Task 8: Update `idempotency.rs` wrapper
+
+**Files:**
+- Modify: `src/ipam/idempotency.rs`
+
+The `idempotent_post` helper builds an `IdempotencyRecord`. It needs to accept `tenant_id` from the handler.
+
+- [ ] **Step 1: Change `idempotent_post` signature**
+
+The function probably looks like `pub async fn idempotent_post<F, Fut, T>(store, key, scope, body_hash, handler) -> ...`. Add `tenant_id: &str` as a parameter. Pass it to `store.idempotency_get(tenant_id, ...)` and embed in the constructed `IdempotencyRecord { tenant_id: tenant_id.to_string(), ... }`.
+
+Show the exact new signature:
+
+```rust
+pub async fn idempotent_post<S, F, Fut, T>(
+    store: &S,
+    tenant_id: &str,
+    key: &str,
+    scope: &str,
+    request_body: &[u8],
+    handler: F,
+) -> Result<(StatusCode, HeaderMap, T)>
+where
+    S: IpamStore,
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<(StatusCode, T)>>,
+    T: Serialize,
+{
+    // ... existing logic, but every store.idempotency_* call uses tenant_id
+}
+```
+
+- [ ] **Step 2: Update call sites in `ipam_api.rs`** (Task 9 will pick these up; just leave them broken for now).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/ipam/idempotency.rs
+git commit -m "refactor(ipam/idempotency): scope idempotency keys by tenant_id"
+```
+
+---
+
+## Phase 4: HTTP Layer
+
+### Task 9: Tenant extractor and auth middleware integration
+
+**Files:**
+- Create: `src/tenant.rs`
+- Modify: `src/lib.rs` (add `pub mod tenant;`)
+- Modify: `src/auth.rs` — middleware sets `Tenant` extension after allowlist check
+
+- [ ] **Step 1: Create `src/tenant.rs`**
+
+```rust
+//! Per-request tenant identity, set by auth middleware.
+//!
+//! HTTP handlers extract [`Tenant`] from request extensions and pass its
+//! inner string to [`crate::ipam::operations::IpamOps`]. Unauthenticated
+//! routes never have it set; tenant-scoped routes are unreachable without
+//! it because [`crate::auth::require_auth`] runs first.
+
+use axum::{
+    extract::FromRequestParts,
+    http::{StatusCode, request::Parts},
+};
+
+#[derive(Debug, Clone)]
+pub struct Tenant(pub String);
+
+impl Tenant {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<S> FromRequestParts<S> for Tenant
+where
+    S: Send + Sync,
+{
+    type Rejection = (StatusCode, &'static str);
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        _state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        parts
+            .extensions
+            .get::<Tenant>()
+            .cloned()
+            .ok_or((StatusCode::UNAUTHORIZED, "tenant not set"))
+    }
+}
+```
+
+- [ ] **Step 2: Wire the module**
+
+In `src/lib.rs`, add:
+
+```rust
+pub mod tenant;
+```
+
+- [ ] **Step 3: Set `Tenant` extension in auth middleware**
+
+In `src/auth.rs`, find `require_auth` (~line 156). After the allowlist check passes — i.e., once we know the email is allowed — insert into request extensions:
+
+```rust
+// existing code that authenticated the principal and confirmed allowlist
+let tenant = crate::tenant::Tenant(
+    principal
+        .email
+        .clone()
+        .ok_or_else(|| (StatusCode::UNAUTHORIZED, "principal has no email"))?,
+);
+request.extensions_mut().insert(tenant);
+```
+
+- [ ] **Step 4: Write a unit test for the extractor**
+
+In `src/tenant.rs`, add at the bottom:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::Request;
+
+    #[tokio::test]
+    async fn extractor_returns_tenant_when_set() {
+        let mut req = Request::builder().body(()).unwrap();
+        req.extensions_mut().insert(Tenant("a@x".to_string()));
+        let (mut parts, _) = req.into_parts();
+        let extracted = Tenant::from_request_parts(&mut parts, &()).await.unwrap();
+        assert_eq!(extracted.as_str(), "a@x");
+    }
+
+    #[tokio::test]
+    async fn extractor_returns_401_when_missing() {
+        let req = Request::builder().body(()).unwrap();
+        let (mut parts, _) = req.into_parts();
+        let result = Tenant::from_request_parts(&mut parts, &()).await;
+        assert_eq!(result.unwrap_err().0, StatusCode::UNAUTHORIZED);
+    }
+}
+```
+
+- [ ] **Step 5: Run the new tests**
+
+```bash
+cargo test --lib tenant -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tenant.rs src/lib.rs src/auth.rs
+git commit -m "feat(http): Tenant extension + extractor; auth middleware sets it"
+```
+
+---
+
+### Task 10: Update HTTP handlers in `ipam_api.rs`
+
+**Files:**
+- Modify: `src/ipam_api.rs`
+
+Every handler that calls `IpamOps::*` extracts `Tenant` and passes its inner string.
+
+- [ ] **Step 1: Update one handler as the canonical example**
+
+Pick `list_supernets` (or whichever is simplest). Change:
+
+```rust
+async fn list_supernets(
+    Extension(ops): Extension<Arc<IpamOps>>,
+) -> Result<Json<SupernetList>, ApiError> {
+    let supernets = ops.list_supernets().await?;
+    Ok(Json(supernets))
+}
+```
+
+to:
+
+```rust
+async fn list_supernets(
+    Extension(ops): Extension<Arc<IpamOps>>,
+    tenant: crate::tenant::Tenant,
+) -> Result<Json<SupernetList>, ApiError> {
+    let supernets = ops.list_supernets(tenant.as_str()).await?;
+    Ok(Json(supernets))
+}
+```
+
+- [ ] **Step 2: Apply the same pattern to every handler in the file**
+
+Mechanical sweep. Add `tenant: crate::tenant::Tenant,` to the function signature; pass `tenant.as_str()` as the first argument to every `ops.*` call.
+
+- [ ] **Step 3: Update `idempotent_post` call sites**
+
+For the three idempotent handlers (`POST /ipam/supernets/{id}/allocate`, `POST /ipam/supernets/{id}/allocate-specific`, `POST /ipam/batch/allocate`), pass `tenant.as_str()` as the new `tenant_id` argument.
+
+- [ ] **Step 4: Run unit tests on the lib**
+
+```bash
+cargo test --lib 2>&1 | tail
+```
+
+Expected: build now compiles. Lib tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ipam_api.rs
+git commit -m "refactor(ipam_api): handlers extract Tenant and pass to ops"
+```
+
+---
+
+## Phase 5: CLI and MCP
+
+### Task 11: CLI passes literal `"local"`
+
+**Files:**
+- Modify: `src/ipam_cli.rs`
+
+The CLI doesn't authenticate. SQLite-only, always single-tenant.
+
+- [ ] **Step 1: Define a constant**
+
+At the top of `ipam_cli.rs`:
+
+```rust
+const CLI_TENANT_ID: &str = "local";
+```
+
+- [ ] **Step 2: Pass it to every `ops.*` call**
+
+Mechanical sweep. Wherever there's `ops.METHOD(args)`, change to `ops.METHOD(CLI_TENANT_ID, args)`.
+
+- [ ] **Step 3: Run CLI integration tests**
+
+```bash
+cargo test --test integration_tests 2>&1 | tail -10
+```
+
+Expected: PASS (after fixture sweep in Task 14).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ipam_cli.rs
+git commit -m "refactor(ipam_cli): pass tenant_id=\"local\" for CLI invocations"
+```
+
+---
+
+### Task 12: MCP local backend
+
+**Files:**
+- Modify: `src/mcp.rs`
+
+The local IPAM backend (when MCP runs over stdio with `--ipam-db`) is single-tenant — like the CLI, it operates on a private SQLite file. Use `"local"`. The remote backend (HTTP proxy) doesn't touch IpamOps directly so no change needed there.
+
+- [ ] **Step 1: Update local backend calls**
+
+Search for `McpIpamBackend::Local(ops).METHOD(...)` patterns or wherever the MCP tools call `ops.*`. Pass `"local"` as the tenant_id.
+
+Define a constant near the top of `mcp.rs`:
+
+```rust
+const MCP_LOCAL_TENANT_ID: &str = "local";
+```
+
+- [ ] **Step 2: Run lib tests including MCP**
+
+```bash
+cargo test --lib --features mcp 2>&1 | tail
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/mcp.rs
+git commit -m "refactor(mcp): local IPAM backend passes tenant_id=\"local\""
+```
+
+---
+
+## Phase 6: Tests
+
+### Task 13: HTTP isolation integration tests
+
+**Files:**
+- Create: `tests/ipam_isolation.rs`
+
+This is the single most important test in the PR — proves end-to-end that two OIDC identities cannot see each other's data.
+
+- [ ] **Step 1: Look at existing HTTP test scaffolding**
+
+```bash
+grep -n "OidcAudience\|mock_server\|test_jwt" tests/ipam_api_tests.rs | head -10
+```
+
+Reuse whatever JWT-mocking helper exists. If `tests/ipam_idempotency.rs` (PR #104) has a helper, copy its pattern.
+
+- [ ] **Step 2: Write the test file**
+
+```rust
+//! HTTP-level multi-tenant isolation matrix.
+//!
+//! Boots an in-memory netcidr API, signs two mock OIDC identities
+//! `a@example.com` and `b@example.com`, and asserts every cross-tenant
+//! access path returns 404 (not 403) so existence isn't leaked.
+
+use reqwest::StatusCode;
+use serde_json::json;
+
+mod common;
+use common::{spawn_test_server, mint_id_token, TestServer};
+
+#[tokio::test]
+async fn supernets_are_isolated_per_tenant() {
+    let server = spawn_test_server().await;
+    let token_a = mint_id_token(&server, "a@example.com");
+    let token_b = mint_id_token(&server, "b@example.com");
+
+    // A creates a supernet.
+    let resp = server
+        .post("/ipam/supernets")
+        .bearer_auth(&token_a)
+        .json(&json!({ "cidr": "10.0.0.0/8" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let s_a: serde_json::Value = resp.json().await.unwrap();
+    let s_a_id = s_a["id"].as_str().unwrap().to_string();
+
+    // B sees zero supernets.
+    let resp = server.get("/ipam/supernets").bearer_auth(&token_b).send().await.unwrap();
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["count"], 0);
+
+    // B requesting A's supernet by ID gets 404, not 403.
+    let resp = server
+        .get(&format!("/ipam/supernets/{}", s_a_id))
+        .bearer_auth(&token_b)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn same_cidr_in_two_tenants_both_succeed() {
+    let server = spawn_test_server().await;
+    let token_a = mint_id_token(&server, "a@example.com");
+    let token_b = mint_id_token(&server, "b@example.com");
+
+    for token in [&token_a, &token_b] {
+        let resp = server
+            .post("/ipam/supernets")
+            .bearer_auth(token)
+            .json(&json!({ "cidr": "10.0.0.0/8" }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED, "tenant should accept its own 10.0.0.0/8");
+    }
+}
+
+#[tokio::test]
+async fn allocations_are_isolated_per_tenant() {
+    let server = spawn_test_server().await;
+    let token_a = mint_id_token(&server, "a@example.com");
+    let token_b = mint_id_token(&server, "b@example.com");
+
+    // A creates supernet + allocation.
+    let s_a: serde_json::Value = server
+        .post("/ipam/supernets").bearer_auth(&token_a)
+        .json(&json!({ "cidr": "10.0.0.0/8" })).send().await.unwrap()
+        .json().await.unwrap();
+    let s_a_id = s_a["id"].as_str().unwrap();
+
+    let alloc: serde_json::Value = server
+        .post(&format!("/ipam/supernets/{}/allocate-specific", s_a_id))
+        .bearer_auth(&token_a)
+        .json(&json!({ "cidr": "10.1.0.0/16" })).send().await.unwrap()
+        .json().await.unwrap();
+    let alloc_id = alloc["id"].as_str().unwrap();
+
+    // B requesting A's allocation by ID gets 404.
+    let resp = server
+        .get(&format!("/ipam/allocations/{}", alloc_id))
+        .bearer_auth(&token_b).send().await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    // B trying to allocate inside A's supernet gets 404.
+    let resp = server
+        .post(&format!("/ipam/supernets/{}/allocate-specific", s_a_id))
+        .bearer_auth(&token_b)
+        .json(&json!({ "cidr": "10.2.0.0/16" })).send().await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn audit_log_is_isolated_per_tenant() {
+    let server = spawn_test_server().await;
+    let token_a = mint_id_token(&server, "a@example.com");
+    let token_b = mint_id_token(&server, "b@example.com");
+
+    // A creates a supernet (mutation -> audit row).
+    server.post("/ipam/supernets").bearer_auth(&token_a)
+        .json(&json!({ "cidr": "10.0.0.0/8" })).send().await.unwrap();
+
+    // B's audit log is empty.
+    let resp = server.get("/ipam/audit").bearer_auth(&token_b).send().await.unwrap();
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["entries"].as_array().unwrap().len(), 0);
+
+    // A's audit log has at least one entry.
+    let resp = server.get("/ipam/audit").bearer_auth(&token_a).send().await.unwrap();
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(body["entries"].as_array().unwrap().len() >= 1);
+}
+
+#[tokio::test]
+async fn idempotency_keys_are_isolated_per_tenant() {
+    let server = spawn_test_server().await;
+    let token_a = mint_id_token(&server, "a@example.com");
+    let token_b = mint_id_token(&server, "b@example.com");
+
+    // A creates supernet.
+    let s_a: serde_json::Value = server.post("/ipam/supernets").bearer_auth(&token_a)
+        .json(&json!({ "cidr": "10.0.0.0/8" })).send().await.unwrap()
+        .json().await.unwrap();
+    let s_a_id = s_a["id"].as_str().unwrap();
+
+    // B creates *its own* supernet (different namespace; same CIDR is OK).
+    let s_b: serde_json::Value = server.post("/ipam/supernets").bearer_auth(&token_b)
+        .json(&json!({ "cidr": "10.0.0.0/8" })).send().await.unwrap()
+        .json().await.unwrap();
+    let s_b_id = s_b["id"].as_str().unwrap();
+
+    // Both call allocate-specific with the same Idempotency-Key.
+    let key = "shared-key-1";
+    let resp_a = server
+        .post(&format!("/ipam/supernets/{}/allocate-specific", s_a_id))
+        .bearer_auth(&token_a)
+        .header("Idempotency-Key", key)
+        .json(&json!({ "cidr": "10.1.0.0/16" })).send().await.unwrap();
+    assert_eq!(resp_a.status(), StatusCode::CREATED);
+    assert!(resp_a.headers().get("Idempotent-Replay").is_none());
+
+    let resp_b = server
+        .post(&format!("/ipam/supernets/{}/allocate-specific", s_b_id))
+        .bearer_auth(&token_b)
+        .header("Idempotency-Key", key)
+        .json(&json!({ "cidr": "10.2.0.0/16" })).send().await.unwrap();
+    // B's request should EXECUTE FRESH (not replay A's response).
+    assert_eq!(resp_b.status(), StatusCode::CREATED);
+    assert!(resp_b.headers().get("Idempotent-Replay").is_none());
+}
+```
+
+If `tests/common/` doesn't exist, lift helpers from `tests/ipam_idempotency.rs`. The `mint_id_token` helper signs a JWT against the same JWKS the test server validates against.
+
+- [ ] **Step 3: Run isolation tests**
+
+```bash
+cargo test --test ipam_isolation -- --nocapture 2>&1 | tail -30
+```
+
+Expected: all five tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/ipam_isolation.rs tests/common/
+git commit -m "test(ipam): HTTP isolation matrix — five-test cross-tenant guarantee"
+```
+
+---
+
+### Task 14: Test fixture sweep
+
+**Files:**
+- Modify: `tests/ipam_store_contract.rs`, `tests/ipam_api_tests.rs`, `tests/ipam_concurrency.rs`, `tests/ipam_idempotency.rs`, `tests/postgres_integration.rs`, `tests/integration_tests.rs`
+- Modify: any `#[cfg(test)]` blocks in `src/` that construct fixture data
+
+Mechanical: every literal struct gets `tenant_id`; every `ops.METHOD(...)` call gets a tenant_id argument.
+
+- [ ] **Step 1: Update each test file**
+
+For tests not specifically about isolation, use a single constant:
+
+```rust
+const TEST_TENANT: &str = "test@example.com";
+```
+
+at the top of each test file. Pass it to every `ops.*` call.
+
+For struct literals: `Supernet { id, tenant_id: TEST_TENANT.to_string(), cidr, ... }`. Same for `Allocation`, `AuditEntry`, `IdempotencyRecord`.
+
+- [ ] **Step 2: Run the full test suite**
+
+```bash
+cargo test 2>&1 | tail -20
+cargo test --features ipam-postgres 2>&1 | tail -20
+```
+
+Expected: zero failures.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/ src/
+git commit -m "test: fixture sweep — every IPAM literal/call carries tenant_id"
+```
+
+---
+
+### Task 15: Final verification, docs, version bump
+
+**Files:**
+- Modify: `CHANGELOG.md`, `README.md`, `Cargo.toml`, `Cargo.lock`, `SECURITY.md`
+
+- [ ] **Step 1: Run the full check pipeline**
+
+```bash
+just check 2>&1 | tail -30
+```
+
+Expected: green across fmt, lint, test, test-tui, test-mcp, semgrep.
+
+- [ ] **Step 2: Update CHANGELOG.md**
+
+Add under `[Unreleased]`:
+
+```markdown
+### Changed
+
+- **Multi-tenant IPAM isolation.** Every supernet, allocation, audit entry, and idempotency record is now scoped to the authenticated user's email. The `IpamStore` trait and `IpamOps` struct expose `tenant_id: &str` as an explicit parameter on every method, making per-tenant filtering unforgettable at the type level. HTTP middleware extracts the tenant from the OIDC principal's verified email and exposes it via Axum extensions; cross-tenant access returns 404 (not 403) to prevent existence enumeration. CLI invocations and stdio MCP both pass the literal `"local"`. Schema is destructive: migration `006` drops and recreates `supernets`, `allocations`, `audit_log`, `idempotency_keys`, and `allocation_tags` with `tenant_id` columns, `UNIQUE(tenant_id, cidr)` on supernets, composite tenant indexes, and triggers enforcing the cross-table invariant `allocations.tenant_id == supernets.tenant_id`. Five-test isolation matrix in `tests/ipam_isolation.rs` proves the guarantee end-to-end (supernets, same-CIDR-different-tenant, allocations, audit log, idempotency keys). Sub-project 1 of 3 toward a remote MCP endpoint.
+```
+
+- [ ] **Step 3: Update README.md** if any user-facing CLI behavior changed (it didn't — `--db` SQLite usage stays single-tenant, just with a `local` row marker invisible to users).
+
+- [ ] **Step 4: Bump version**
+
+`Cargo.toml`: `version = "0.24.0"` (minor bump — schema break + new behavior).
+
+`SECURITY.md`: shift the supported-versions table to keep `0.24.x` current, `0.23.x` supported, `< 0.23` unsupported.
+
+`CHANGELOG.md`: insert `## [0.24.0] - YYYY-MM-DD` heading above the moved entries.
+
+`Cargo.lock` will be regenerated by `cargo build`.
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add CHANGELOG.md README.md Cargo.toml Cargo.lock SECURITY.md
+git commit -m "chore(release): v0.24.0 — multi-tenant IPAM isolation"
+```
+
+- [ ] **Step 6: Push branch and open PR**
+
+```bash
+git push -u origin <branch>
+gh pr create --title "feat(ipam): multi-tenant isolation per OIDC identity" --body "..."
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:** every section of the spec is covered.
+
+| Spec section | Tasks |
+|---|---|
+| Goal & non-goals | T1-T15 (whole plan) |
+| Tenancy model (email, "local" for CLI) | T9 (auth middleware), T11 (CLI), T12 (MCP) |
+| Schema changes (4 tables + tag inheritance) | T2 (SQLite), T3 (Postgres) |
+| Cross-table invariant | T2/T3 (DB triggers), T7 (app-level supernet check in `create_allocation`) |
+| Auth → tenant flow | T9 (extractor + middleware), T10 (handlers) |
+| IpamOps signature changes | T7 |
+| Cross-tenant 404 semantics | T5/T6 (NotFound on missing rows), T13 (integration test) |
+| Naming note (Allocation::owner unchanged) | T1 (only adds tenant_id; doesn't touch owner) |
+| Testing matrix | T13 (isolation), T14 (fixture sweep) |
+| Migration / deploy | T2/T3 (destructive migration) |
+
+**Type consistency check:**
+- `Tenant(pub String)` newtype, `as_str()` accessor — used consistently in T9 (definition), T10 (handler extraction).
+- `tenant_id: &str` on every `IpamStore` and `IpamOps` method — consistent across T4, T5, T6, T7.
+- `CLI_TENANT_ID = "local"` (T11) and `MCP_LOCAL_TENANT_ID = "local"` (T12) — same value, different constants per file for clarity.
+
+**Placeholder scan:** none. Every code step shows the code; mechanical sweeps reference exact files and patterns.
+
+**Order of operations correctness:** T1 (models) and T4 (trait) intentionally leave the build broken; T5+T6 (impls) restore the lib but break callers; T7 (ops), T8 (idempotency), T9 (extractor), T10 (handlers), T11 (CLI), T12 (MCP) restore the full build. Tests and fixtures (T13, T14) run last.

--- a/docs/superpowers/plans/2026-05-02-multi-tenant-isolation.md
+++ b/docs/superpowers/plans/2026-05-02-multi-tenant-isolation.md
@@ -46,7 +46,7 @@
 
 Adds the field that the rest of the plan reads. No serde-skip needed because tenancy is enforced server-side and the dashboard already only sees its own data; if we ever want to suppress the field in JSON we can add `#[serde(skip_serializing)]` later.
 
-- [ ] **Step 1: Add `tenant_id` to `Supernet`**
+- [x] **Step 1: Add `tenant_id` to `Supernet`**
 
 In `src/ipam/models.rs`, after `pub id: String,` in the `Supernet` struct (around line 10):
 
@@ -59,7 +59,7 @@ pub struct Supernet {
 }
 ```
 
-- [ ] **Step 2: Add `tenant_id` to `Allocation`**
+- [x] **Step 2: Add `tenant_id` to `Allocation`**
 
 In the `Allocation` struct (around line 78):
 
@@ -72,7 +72,7 @@ pub struct Allocation {
 }
 ```
 
-- [ ] **Step 3: Add `tenant_id` to `AuditEntry`**
+- [x] **Step 3: Add `tenant_id` to `AuditEntry`**
 
 In the `AuditEntry` struct (around line 189):
 
@@ -85,7 +85,7 @@ pub struct AuditEntry {
 }
 ```
 
-- [ ] **Step 4: Add `tenant_id` to `IdempotencyRecord`**
+- [x] **Step 4: Add `tenant_id` to `IdempotencyRecord`**
 
 In `IdempotencyRecord` (around line 446):
 
@@ -102,7 +102,7 @@ pub struct IdempotencyRecord {
 }
 ```
 
-- [ ] **Step 5: `cargo check` — expect many errors in `sqlite/mod.rs`, `postgres/mod.rs`, tests**
+- [x] **Step 5: `cargo check` — expect many errors in `sqlite/mod.rs`, `postgres/mod.rs`, tests**
 
 ```bash
 cargo check 2>&1 | head -40
@@ -110,7 +110,7 @@ cargo check 2>&1 | head -40
 
 Expected: errors about missing `tenant_id` field in struct literals across the codebase. This is intentional — Phases 2-6 fix them.
 
-- [ ] **Step 6: Commit (intermediate, broken build)**
+- [x] **Step 6: Commit (intermediate, broken build)**
 
 ```bash
 git add src/ipam/models.rs
@@ -130,7 +130,7 @@ update all call sites."
 
 The migration drops `supernets`, `allocations`, `audit_log`, `idempotency_keys` and recreates them with `tenant_id`. `allocation_tags` references `allocations(id)` so we drop and recreate it too (no new column — inherits via FK).
 
-- [ ] **Step 1: Read existing migration array structure**
+- [x] **Step 1: Read existing migration array structure**
 
 ```bash
 grep -n "MIGRATIONS\|version\|CREATE TABLE" src/ipam/sqlite/migrations.rs | head -30
@@ -138,7 +138,7 @@ grep -n "MIGRATIONS\|version\|CREATE TABLE" src/ipam/sqlite/migrations.rs | head
 
 This shows where the existing migrations array is defined and what version numbers are used.
 
-- [ ] **Step 2: Append migration 006 to the migrations array**
+- [x] **Step 2: Append migration 006 to the migrations array**
 
 In `src/ipam/sqlite/migrations.rs`, add a new entry after migration 005:
 
@@ -257,7 +257,7 @@ Migration {
 
 Note: SQLite `INTEGER` columns hold the version number; the `version_pk` PRAGMA-driven scheme already in the file applies. `total_hosts` stays TEXT because Rust holds it as `u128` and SQLite has no native u128.
 
-- [ ] **Step 3: Write a unit test for the trigger**
+- [x] **Step 3: Write a unit test for the trigger**
 
 Add to `src/ipam/sqlite/migrations.rs` `#[cfg(test)] mod tests`:
 
@@ -305,7 +305,7 @@ async fn allocation_with_mismatched_tenant_id_is_rejected_by_trigger() {
 
 If `SqliteStore::in_memory()` and `SqliteStore::pool()` don't exist, add them as test-only helpers (look for similar in the existing file).
 
-- [ ] **Step 4: Run only this test (will fail until SQLite impl is updated, but the migration test should pass)**
+- [x] **Step 4: Run only this test (will fail until SQLite impl is updated, but the migration test should pass)**
 
 ```bash
 cargo test --lib --features ipam-postgres allocation_with_mismatched_tenant -- --nocapture
@@ -313,7 +313,7 @@ cargo test --lib --features ipam-postgres allocation_with_mismatched_tenant -- -
 
 Expected: PASS. The migration runs without errors and the trigger rejects the bad insert.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/ipam/sqlite/migrations.rs
@@ -334,13 +334,13 @@ cross-table invariant allocations.tenant_id == supernets.tenant_id."
 
 Same shape as SQLite migration but in Postgres dialect (BIGSERIAL instead of AUTOINCREMENT, `RAISE EXCEPTION` instead of `RAISE(ABORT)`, etc.).
 
-- [ ] **Step 1: Read the existing Postgres migrations module**
+- [x] **Step 1: Read the existing Postgres migrations module**
 
 ```bash
 grep -n "MIGRATIONS\|version\|CREATE TABLE" src/ipam/postgres/migrations.rs | head -40
 ```
 
-- [ ] **Step 2: Append migration 006**
+- [x] **Step 2: Append migration 006**
 
 ```rust
 Migration {
@@ -458,7 +458,7 @@ Migration {
 },
 ```
 
-- [ ] **Step 3: Mirror the trigger test**
+- [x] **Step 3: Mirror the trigger test**
 
 Add a test at the bottom of the postgres migrations file (gated `#[cfg(all(test, feature = "ipam-postgres"))]`):
 
@@ -501,7 +501,7 @@ async fn pg_allocation_with_mismatched_tenant_id_is_rejected_by_trigger() {
 }
 ```
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add src/ipam/postgres/migrations.rs
@@ -523,7 +523,7 @@ plpgsql function + trigger enforcing the cross-table invariant."
 
 This is the load-bearing change for the entire refactor. After this commit lands, every backend impl must follow.
 
-- [ ] **Step 1: Replace the trait body**
+- [x] **Step 1: Replace the trait body**
 
 Replace the contents of `src/ipam/store.rs` with:
 
@@ -618,7 +618,7 @@ pub trait IpamStore: Send + Sync {
 }
 ```
 
-- [ ] **Step 2: `cargo check` to confirm trait compiles in isolation**
+- [x] **Step 2: `cargo check` to confirm trait compiles in isolation**
 
 ```bash
 cargo check --lib 2>&1 | grep -E "^error\[" | head -20
@@ -626,7 +626,7 @@ cargo check --lib 2>&1 | grep -E "^error\[" | head -20
 
 Expected: errors in `sqlite/mod.rs` and `postgres/mod.rs` because the impls no longer match the trait. That's correct — Tasks 5 and 6 fix them.
 
-- [ ] **Step 3: Commit (still broken build)**
+- [x] **Step 3: Commit (still broken build)**
 
 ```bash
 git add src/ipam/store.rs
@@ -645,7 +645,7 @@ will follow in subsequent commits."
 
 Pattern: each method that took `(id)` becomes `(tenant_id, id)` and the SQL adds `WHERE tenant_id = ?`. Each insert adds `tenant_id` to the column list and `?` to the values. Show the pattern on `create_supernet` and `get_supernet`; the rest is mechanical.
 
-- [ ] **Step 1: Update `create_supernet`**
+- [x] **Step 1: Update `create_supernet`**
 
 Find the existing `create_supernet` impl (search for `async fn create_supernet` in the file). Replace its body with the tenant-aware version:
 
@@ -688,7 +688,7 @@ async fn create_supernet(
 
 (Adapt to the actual existing helper functions like `parse_cidr` / `map_sqlite_error` whose names you'll see in the file.)
 
-- [ ] **Step 2: Update `get_supernet`**
+- [x] **Step 2: Update `get_supernet`**
 
 ```rust
 async fn get_supernet(&self, tenant_id: &str, id: &str) -> Result<Supernet> {
@@ -711,7 +711,7 @@ async fn get_supernet(&self, tenant_id: &str, id: &str) -> Result<Supernet> {
 
 `SupernetRow` is the existing sqlx::FromRow type. Add `tenant_id` to it. The `From<SupernetRow> for Supernet` conversion needs to copy the new field.
 
-- [ ] **Step 3: Apply the same pattern to remaining methods**
+- [x] **Step 3: Apply the same pattern to remaining methods**
 
 For each method in this list, the change is mechanical:
 - `list_supernets` → `WHERE tenant_id = ?`
@@ -734,11 +734,11 @@ For each, the key invariants:
 - Reads of unowned IDs return `IpamError::NotFound`, not `Forbidden`
 - `SELECT *` queries that map to `SupernetRow` / `AllocationRow` / `AuditEntryRow` need those Row types to include `tenant_id`
 
-- [ ] **Step 4: Update Row → Model conversions**
+- [x] **Step 4: Update Row → Model conversions**
 
 Add `tenant_id: row.tenant_id,` to each `From<*Row> for *` conversion in this file.
 
-- [ ] **Step 5: Run lib unit tests for SQLite**
+- [x] **Step 5: Run lib unit tests for SQLite**
 
 ```bash
 cargo test --lib ipam::sqlite -- --nocapture 2>&1 | tail -30
@@ -746,7 +746,7 @@ cargo test --lib ipam::sqlite -- --nocapture 2>&1 | tail -30
 
 Expected: most tests still failing because callers haven't been updated yet, but the migration trigger test from Task 2 should pass now that the impl supports the new schema.
 
-- [ ] **Step 6: Commit (build still broken — operations.rs, ipam_api.rs, ipam_cli.rs not yet updated)**
+- [x] **Step 6: Commit (build still broken — operations.rs, ipam_api.rs, ipam_cli.rs not yet updated)**
 
 ```bash
 git add src/ipam/sqlite/mod.rs
@@ -762,15 +762,15 @@ git commit -m "refactor(ipam/sqlite): implement tenant_id-aware IpamStore"
 
 Same pattern as SQLite. The bind syntax is `$1, $2, ...` instead of `?`.
 
-- [ ] **Step 1: Update `create_supernet`** — `INSERT INTO supernets (id, tenant_id, cidr, ...) VALUES ($1, $2, $3, ...)`. Pattern shown in Task 5 Step 1.
+- [x] **Step 1: Update `create_supernet`** — `INSERT INTO supernets (id, tenant_id, cidr, ...) VALUES ($1, $2, $3, ...)`. Pattern shown in Task 5 Step 1.
 
-- [ ] **Step 2: Update `get_supernet`** — `SELECT * FROM supernets WHERE id = $1 AND tenant_id = $2`.
+- [x] **Step 2: Update `get_supernet`** — `SELECT * FROM supernets WHERE id = $1 AND tenant_id = $2`.
 
-- [ ] **Step 3: Apply same pattern to remaining methods** — same list as Task 5 Step 3.
+- [x] **Step 3: Apply same pattern to remaining methods** — same list as Task 5 Step 3.
 
-- [ ] **Step 4: Update Row→Model conversions to include tenant_id.**
+- [x] **Step 4: Update Row→Model conversions to include tenant_id.**
 
-- [ ] **Step 5: Run Postgres tests (skip-if-no-DB)**
+- [x] **Step 5: Run Postgres tests (skip-if-no-DB)**
 
 ```bash
 cargo test --features ipam-postgres --lib ipam::postgres 2>&1 | tail -20
@@ -778,7 +778,7 @@ cargo test --features ipam-postgres --lib ipam::postgres 2>&1 | tail -20
 
 Expected: tests that need a live Postgres skip cleanly if `NETCIDR_TEST_DATABASE_URL` is unset; otherwise they pass.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add src/ipam/postgres/mod.rs
@@ -796,7 +796,7 @@ git commit -m "refactor(ipam/postgres): implement tenant_id-aware IpamStore"
 
 Every public method on `IpamOps` grows `tenant_id: &str`. The internal calls to `self.store.*` pass it through. Audit log entries get `tenant_id` populated from the parameter (NOT from `audit_context::current()`).
 
-- [ ] **Step 1: Update method signatures (mechanical sweep)**
+- [x] **Step 1: Update method signatures (mechanical sweep)**
 
 For every public `async fn` on `IpamOps`, add `tenant_id: &str` as the first parameter (after `&self`). Methods affected (roughly 15-20 — search for `pub async fn` in the file):
 
@@ -820,25 +820,25 @@ pub async fn find_resource(&self, tenant_id: &str, query: &str) -> Result<...>
 pub async fn audit_log(&self, tenant_id: &str, filter: AuditFilter) -> Result<...>
 ```
 
-- [ ] **Step 2: Thread tenant_id through every call to `self.store.*`**
+- [x] **Step 2: Thread tenant_id through every call to `self.store.*`**
 
 Find every `self.store.METHOD(...)` and add `tenant_id` (or threaded variable) as the first arg.
 
-- [ ] **Step 3: Populate `entry.tenant_id` when constructing `AuditEntry`**
+- [x] **Step 3: Populate `entry.tenant_id` when constructing `AuditEntry`**
 
 Search for `AuditEntry {` literals in `operations.rs`. Add `tenant_id: tenant_id.to_string(),` to each.
 
 The existing `audit_context::current()` call (line 942) still provides `caller_sub`, `caller_email`, `source_ip`, `request_id`. Keep that; only `tenant_id` comes from the new parameter.
 
-- [ ] **Step 4: Update the per-supernet allocation lock map**
+- [x] **Step 4: Update the per-supernet allocation lock map**
 
 The `HashMap<supernet_id, Arc<Mutex<()>>>` keys on supernet_id. Two tenants could have the same supernet_id... no, actually they can't — UUIDs are globally unique. Locking is fine as-is.
 
-- [ ] **Step 5: Update tests in `operations.rs` to pass `tenant_id`**
+- [x] **Step 5: Update tests in `operations.rs` to pass `tenant_id`**
 
 Every `let ops = IpamOps::new(...); ops.METHOD(...)` in the file's `#[cfg(test)] mod tests` needs `tenant_id` threaded in. Use `"test-tenant"` as a constant.
 
-- [ ] **Step 6: `cargo check --lib` — should now pass for the library**
+- [x] **Step 6: `cargo check --lib` — should now pass for the library**
 
 ```bash
 cargo check --lib 2>&1 | grep -E "^error" | head
@@ -846,7 +846,7 @@ cargo check --lib 2>&1 | grep -E "^error" | head
 
 Expected: no errors in `src/ipam/`. Errors remain in `src/ipam_api.rs`, `src/ipam_cli.rs`, `src/api.rs`, `src/mcp.rs`. Phases 4-5 fix those.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add src/ipam/operations.rs
@@ -862,7 +862,7 @@ git commit -m "refactor(ipam/operations): thread tenant_id through every public 
 
 The `idempotent_post` helper builds an `IdempotencyRecord`. It needs to accept `tenant_id` from the handler.
 
-- [ ] **Step 1: Change `idempotent_post` signature**
+- [x] **Step 1: Change `idempotent_post` signature**
 
 The function probably looks like `pub async fn idempotent_post<F, Fut, T>(store, key, scope, body_hash, handler) -> ...`. Add `tenant_id: &str` as a parameter. Pass it to `store.idempotency_get(tenant_id, ...)` and embed in the constructed `IdempotencyRecord { tenant_id: tenant_id.to_string(), ... }`.
 
@@ -887,9 +887,9 @@ where
 }
 ```
 
-- [ ] **Step 2: Update call sites in `ipam_api.rs`** (Task 9 will pick these up; just leave them broken for now).
+- [x] **Step 2: Update call sites in `ipam_api.rs`** (Task 9 will pick these up; just leave them broken for now).
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add src/ipam/idempotency.rs
@@ -907,7 +907,7 @@ git commit -m "refactor(ipam/idempotency): scope idempotency keys by tenant_id"
 - Modify: `src/lib.rs` (add `pub mod tenant;`)
 - Modify: `src/auth.rs` — middleware sets `Tenant` extension after allowlist check
 
-- [ ] **Step 1: Create `src/tenant.rs`**
+- [x] **Step 1: Create `src/tenant.rs`**
 
 ```rust
 //! Per-request tenant identity, set by auth middleware.
@@ -950,7 +950,7 @@ where
 }
 ```
 
-- [ ] **Step 2: Wire the module**
+- [x] **Step 2: Wire the module**
 
 In `src/lib.rs`, add:
 
@@ -958,7 +958,7 @@ In `src/lib.rs`, add:
 pub mod tenant;
 ```
 
-- [ ] **Step 3: Set `Tenant` extension in auth middleware**
+- [x] **Step 3: Set `Tenant` extension in auth middleware**
 
 In `src/auth.rs`, find `require_auth` (~line 156). After the allowlist check passes — i.e., once we know the email is allowed — insert into request extensions:
 
@@ -973,7 +973,7 @@ let tenant = crate::tenant::Tenant(
 request.extensions_mut().insert(tenant);
 ```
 
-- [ ] **Step 4: Write a unit test for the extractor**
+- [x] **Step 4: Write a unit test for the extractor**
 
 In `src/tenant.rs`, add at the bottom:
 
@@ -1002,7 +1002,7 @@ mod tests {
 }
 ```
 
-- [ ] **Step 5: Run the new tests**
+- [x] **Step 5: Run the new tests**
 
 ```bash
 cargo test --lib tenant -- --nocapture
@@ -1010,7 +1010,7 @@ cargo test --lib tenant -- --nocapture
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add src/tenant.rs src/lib.rs src/auth.rs
@@ -1026,7 +1026,7 @@ git commit -m "feat(http): Tenant extension + extractor; auth middleware sets it
 
 Every handler that calls `IpamOps::*` extracts `Tenant` and passes its inner string.
 
-- [ ] **Step 1: Update one handler as the canonical example**
+- [x] **Step 1: Update one handler as the canonical example**
 
 Pick `list_supernets` (or whichever is simplest). Change:
 
@@ -1051,15 +1051,15 @@ async fn list_supernets(
 }
 ```
 
-- [ ] **Step 2: Apply the same pattern to every handler in the file**
+- [x] **Step 2: Apply the same pattern to every handler in the file**
 
 Mechanical sweep. Add `tenant: crate::tenant::Tenant,` to the function signature; pass `tenant.as_str()` as the first argument to every `ops.*` call.
 
-- [ ] **Step 3: Update `idempotent_post` call sites**
+- [x] **Step 3: Update `idempotent_post` call sites**
 
 For the three idempotent handlers (`POST /ipam/supernets/{id}/allocate`, `POST /ipam/supernets/{id}/allocate-specific`, `POST /ipam/batch/allocate`), pass `tenant.as_str()` as the new `tenant_id` argument.
 
-- [ ] **Step 4: Run unit tests on the lib**
+- [x] **Step 4: Run unit tests on the lib**
 
 ```bash
 cargo test --lib 2>&1 | tail
@@ -1067,7 +1067,7 @@ cargo test --lib 2>&1 | tail
 
 Expected: build now compiles. Lib tests pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/ipam_api.rs
@@ -1085,7 +1085,7 @@ git commit -m "refactor(ipam_api): handlers extract Tenant and pass to ops"
 
 The CLI doesn't authenticate. SQLite-only, always single-tenant.
 
-- [ ] **Step 1: Define a constant**
+- [x] **Step 1: Define a constant**
 
 At the top of `ipam_cli.rs`:
 
@@ -1093,11 +1093,11 @@ At the top of `ipam_cli.rs`:
 const CLI_TENANT_ID: &str = "local";
 ```
 
-- [ ] **Step 2: Pass it to every `ops.*` call**
+- [x] **Step 2: Pass it to every `ops.*` call**
 
 Mechanical sweep. Wherever there's `ops.METHOD(args)`, change to `ops.METHOD(CLI_TENANT_ID, args)`.
 
-- [ ] **Step 3: Run CLI integration tests**
+- [x] **Step 3: Run CLI integration tests**
 
 ```bash
 cargo test --test integration_tests 2>&1 | tail -10
@@ -1105,7 +1105,7 @@ cargo test --test integration_tests 2>&1 | tail -10
 
 Expected: PASS (after fixture sweep in Task 14).
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add src/ipam_cli.rs
@@ -1121,7 +1121,7 @@ git commit -m "refactor(ipam_cli): pass tenant_id=\"local\" for CLI invocations"
 
 The local IPAM backend (when MCP runs over stdio with `--ipam-db`) is single-tenant — like the CLI, it operates on a private SQLite file. Use `"local"`. The remote backend (HTTP proxy) doesn't touch IpamOps directly so no change needed there.
 
-- [ ] **Step 1: Update local backend calls**
+- [x] **Step 1: Update local backend calls**
 
 Search for `McpIpamBackend::Local(ops).METHOD(...)` patterns or wherever the MCP tools call `ops.*`. Pass `"local"` as the tenant_id.
 
@@ -1131,7 +1131,7 @@ Define a constant near the top of `mcp.rs`:
 const MCP_LOCAL_TENANT_ID: &str = "local";
 ```
 
-- [ ] **Step 2: Run lib tests including MCP**
+- [x] **Step 2: Run lib tests including MCP**
 
 ```bash
 cargo test --lib --features mcp 2>&1 | tail
@@ -1139,7 +1139,7 @@ cargo test --lib --features mcp 2>&1 | tail
 
 Expected: PASS.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add src/mcp.rs
@@ -1157,7 +1157,7 @@ git commit -m "refactor(mcp): local IPAM backend passes tenant_id=\"local\""
 
 This is the single most important test in the PR — proves end-to-end that two OIDC identities cannot see each other's data.
 
-- [ ] **Step 1: Look at existing HTTP test scaffolding**
+- [x] **Step 1: Look at existing HTTP test scaffolding**
 
 ```bash
 grep -n "OidcAudience\|mock_server\|test_jwt" tests/ipam_api_tests.rs | head -10
@@ -1165,7 +1165,7 @@ grep -n "OidcAudience\|mock_server\|test_jwt" tests/ipam_api_tests.rs | head -10
 
 Reuse whatever JWT-mocking helper exists. If `tests/ipam_idempotency.rs` (PR #104) has a helper, copy its pattern.
 
-- [ ] **Step 2: Write the test file**
+- [x] **Step 2: Write the test file**
 
 ```rust
 //! HTTP-level multi-tenant isolation matrix.
@@ -1327,7 +1327,7 @@ async fn idempotency_keys_are_isolated_per_tenant() {
 
 If `tests/common/` doesn't exist, lift helpers from `tests/ipam_idempotency.rs`. The `mint_id_token` helper signs a JWT against the same JWKS the test server validates against.
 
-- [ ] **Step 3: Run isolation tests**
+- [x] **Step 3: Run isolation tests**
 
 ```bash
 cargo test --test ipam_isolation -- --nocapture 2>&1 | tail -30
@@ -1335,7 +1335,7 @@ cargo test --test ipam_isolation -- --nocapture 2>&1 | tail -30
 
 Expected: all five tests pass.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add tests/ipam_isolation.rs tests/common/
@@ -1352,7 +1352,7 @@ git commit -m "test(ipam): HTTP isolation matrix — five-test cross-tenant guar
 
 Mechanical: every literal struct gets `tenant_id`; every `ops.METHOD(...)` call gets a tenant_id argument.
 
-- [ ] **Step 1: Update each test file**
+- [x] **Step 1: Update each test file**
 
 For tests not specifically about isolation, use a single constant:
 
@@ -1364,7 +1364,7 @@ at the top of each test file. Pass it to every `ops.*` call.
 
 For struct literals: `Supernet { id, tenant_id: TEST_TENANT.to_string(), cidr, ... }`. Same for `Allocation`, `AuditEntry`, `IdempotencyRecord`.
 
-- [ ] **Step 2: Run the full test suite**
+- [x] **Step 2: Run the full test suite**
 
 ```bash
 cargo test 2>&1 | tail -20
@@ -1373,7 +1373,7 @@ cargo test --features ipam-postgres 2>&1 | tail -20
 
 Expected: zero failures.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add tests/ src/
@@ -1387,7 +1387,7 @@ git commit -m "test: fixture sweep — every IPAM literal/call carries tenant_id
 **Files:**
 - Modify: `CHANGELOG.md`, `README.md`, `Cargo.toml`, `Cargo.lock`, `SECURITY.md`
 
-- [ ] **Step 1: Run the full check pipeline**
+- [x] **Step 1: Run the full check pipeline**
 
 ```bash
 just check 2>&1 | tail -30
@@ -1395,7 +1395,7 @@ just check 2>&1 | tail -30
 
 Expected: green across fmt, lint, test, test-tui, test-mcp, semgrep.
 
-- [ ] **Step 2: Update CHANGELOG.md**
+- [x] **Step 2: Update CHANGELOG.md**
 
 Add under `[Unreleased]`:
 
@@ -1405,9 +1405,9 @@ Add under `[Unreleased]`:
 - **Multi-tenant IPAM isolation.** Every supernet, allocation, audit entry, and idempotency record is now scoped to the authenticated user's email. The `IpamStore` trait and `IpamOps` struct expose `tenant_id: &str` as an explicit parameter on every method, making per-tenant filtering unforgettable at the type level. HTTP middleware extracts the tenant from the OIDC principal's verified email and exposes it via Axum extensions; cross-tenant access returns 404 (not 403) to prevent existence enumeration. CLI invocations and stdio MCP both pass the literal `"local"`. Schema is destructive: migration `006` drops and recreates `supernets`, `allocations`, `audit_log`, `idempotency_keys`, and `allocation_tags` with `tenant_id` columns, `UNIQUE(tenant_id, cidr)` on supernets, composite tenant indexes, and triggers enforcing the cross-table invariant `allocations.tenant_id == supernets.tenant_id`. Five-test isolation matrix in `tests/ipam_isolation.rs` proves the guarantee end-to-end (supernets, same-CIDR-different-tenant, allocations, audit log, idempotency keys). Sub-project 1 of 3 toward a remote MCP endpoint.
 ```
 
-- [ ] **Step 3: Update README.md** if any user-facing CLI behavior changed (it didn't — `--db` SQLite usage stays single-tenant, just with a `local` row marker invisible to users).
+- [x] **Step 3: Update README.md** if any user-facing CLI behavior changed (it didn't — `--db` SQLite usage stays single-tenant, just with a `local` row marker invisible to users).
 
-- [ ] **Step 4: Bump version**
+- [x] **Step 4: Bump version**
 
 `Cargo.toml`: `version = "0.24.0"` (minor bump — schema break + new behavior).
 
@@ -1417,7 +1417,7 @@ Add under `[Unreleased]`:
 
 `Cargo.lock` will be regenerated by `cargo build`.
 
-- [ ] **Step 5: Final commit**
+- [x] **Step 5: Final commit**
 
 ```bash
 git add CHANGELOG.md README.md Cargo.toml Cargo.lock SECURITY.md

--- a/docs/superpowers/specs/2026-05-02-multi-tenant-isolation-design.md
+++ b/docs/superpowers/specs/2026-05-02-multi-tenant-isolation-design.md
@@ -1,0 +1,140 @@
+# Multi-Tenant Isolation for netcidr IPAM
+
+**Status:** Design approved, awaiting implementation plan
+**Date:** 2026-05-02
+**Sub-project of:** Personal Access Tokens + remote MCP endpoint (this is sub-project 1 of 3)
+
+## Goal
+
+Make IPAM data strictly isolated per OIDC identity (keyed by email). Every read and write is scoped to the caller's tenant. No admin escape hatches. No cross-tenant visibility anywhere. CLI and local SQLite use a constant `tenant_id = "local"` and behave as single-tenant.
+
+## Why
+
+The deployed netcidr Lambda is currently single-tenant: anyone allowed by `NETCIDR_OIDC_ALLOWED_EMAILS` sees and edits all IPAM data. To support multiple users (and as a prerequisite for personal access tokens and a remote `/mcp` endpoint), data must be partitioned by identity.
+
+This sub-project handles isolation only. Personal access tokens (sub-project 2) and `/mcp` mounting (sub-project 3) build on it.
+
+## Non-goals
+
+- Per-org / multi-user-per-tenant ("workspace") tenancy — deferred until usage demands it. Naming and indexing choices avoid painting us into a corner: `tenant_id` is a column whose value happens to be an email today and could become a `tenants.id` UUID later without renaming.
+- Admin cross-tenant view, impersonation, or "view as tenant X". Admin role stays scoped to the existing allowlist endpoint.
+- Tenant data export / import.
+- Soft-delete on allowlist removal. A tenant removed from `NETCIDR_OIDC_ALLOWED_EMAILS` simply can't authenticate; their rows remain in the DB and become accessible again if they're re-added.
+- Migrating existing data — there's nothing in production worth preserving; the migration drops and recreates tenant-scoped tables.
+
+## Design
+
+### Tenancy model
+
+- Unit of tenancy: one OIDC identity, keyed by **email** (matches the existing allowlist source of truth).
+- Column type: `TEXT NOT NULL` named `tenant_id`. Stores an email today; could store a UUID if per-org tenancy lands later. Callers never assume the format.
+- CLI / local SQLite: constant value `"local"` for every row. The schema is identical between deployed Postgres and local SQLite; only the values differ.
+
+### Schema changes
+
+Single migration file `006_multi_tenant_isolation.sql` for both backends. Migration is **destructive** — drops and recreates `supernets`, `allocations`, `audit_log`, `idempotency_keys`. No backfill.
+
+| Table | Change |
+|---|---|
+| `supernets` | Add `tenant_id TEXT NOT NULL`. Replace `UNIQUE (cidr)` with `UNIQUE (tenant_id, cidr)` so each tenant has its own RFC1918 namespace. |
+| `allocations` | Add `tenant_id TEXT NOT NULL`, denormalized from owning supernet. No CIDR uniqueness (allocation overlap is checked logically per-supernet). |
+| `audit_log` | Add `tenant_id TEXT NOT NULL` for read-side filtering. |
+| `idempotency_keys` (PR #104) | PK becomes `(tenant_id, key, scope)`. Tenant B can never replay tenant A's cached response. |
+| `allocation_tags` | **No new column.** Tags inherit tenancy via FK to `allocations`. Every tag read/write goes through the parent allocation's tenant check, so a tenant can never see or attach tags to another tenant's allocation. |
+
+Indexes: `(tenant_id)` on each table. Composite `(tenant_id, supernet_id)` on `allocations` and `audit_log` for per-tenant-per-supernet scans.
+
+### Cross-table invariant
+
+`allocations.tenant_id == supernets.tenant_id` for the linked supernet. Enforced two ways:
+
+1. **Application-level (primary):** `IpamOps::create_allocation` looks up the supernet, refuses if `request.tenant_id != supernet.tenant_id` (returns `IpamError::NotFound`, not `Forbidden` — see "Cross-tenant access" below).
+2. **DB-level (defense in depth):** trigger on `allocations` insert/update verifies the join. Same trigger pattern on both backends.
+
+### Auth → tenant flow
+
+Extends the audit-context plumbing from PR #103.
+
+1. `require_auth` middleware (`src/api.rs:372-379`) authenticates via OIDC; sets `caller_sub` and `caller_email` in the existing audit context task-local.
+2. After the allowlist check passes, the same middleware sets `tenant_id = principal.email` in the request state. Unallowlisted users never get a `tenant_id`.
+3. Handlers read `tenant_id` from request state and pass it as an **explicit argument** to every `IpamOps` method.
+4. Unauthenticated endpoints (`/healthz`, dashboard SPA, swagger) don't touch `IpamOps` and don't need a `tenant_id`.
+5. CLI instantiates `IpamOps` directly with literal `"local"`.
+
+### IpamOps signature changes
+
+Every method that touches a tenant-scoped table grows a `tenant_id: &str` parameter. No task-local magic from inside `IpamOps` — the type system makes the parameter unforgettable.
+
+**Reads (filter result by tenant):**
+`list_supernets`, `get_supernet`, `list_allocations`, `get_allocation`, `audit_log`, `utilization`, `free_blocks`, `find_ip`, `find_resource`.
+
+**Writes (insert/update tagged with tenant; cross-tenant refs rejected):**
+`create_supernet`, `create_allocation`, `update_allocation`, `release_allocation`, `batch_allocate`, `batch_release`, `auto_allocate`.
+
+**Idempotency helpers:**
+`idempotency_get`, `idempotency_put` — gain `tenant_id`. `idempotency_reap_expired` is tenant-agnostic (just deletes expired rows everywhere).
+
+The `IpamStore` trait (`src/ipam/store.rs`) gets the same signature changes. Both backends implement them with `WHERE tenant_id = ?` added to every query.
+
+### Cross-tenant access semantics
+
+Tenant A requesting a resource owned by tenant B never reveals that the resource exists.
+
+- `GET /ipam/supernets/{id}` for another tenant's UUID → **404 Not Found**, identical body to a non-existent UUID.
+- `POST /ipam/supernets/{id}/allocate` against another tenant's supernet → **404**.
+- `GET /ipam/allocations/{id}` for another tenant's allocation → **404**.
+- Audit log queries: `?supernet_id=<other-tenant's-id>` → empty page.
+- Idempotency: PK `(tenant_id, key, scope)` enforces isolation at the DB level.
+
+403 is rejected because it leaks existence — an attacker probing UUIDs would learn which ones are valid in some tenant.
+
+### Naming note
+
+`Allocation::owner` already exists as a free-text label (e.g., "Web team", "billing-prod-VM"). The new tenancy column is named `tenant_id` to avoid collision. Existing `owner` field is unchanged.
+
+## Testing
+
+### Unit tests (per backend)
+
+- **Two-tenant fixture:** supernet S_A under `a@x`, S_B under `b@x`. Assertions:
+  - `list_supernets("a@x")` returns only S_A.
+  - `get_supernet("a@x", S_B.id)` → `NotFound`.
+  - `create_allocation("a@x", S_B.id, ...)` → `NotFound`.
+- **Same-CIDR-different-tenant:** both tenants create `10.0.0.0/8`; both succeed. Confirms `UNIQUE (tenant_id, cidr)`.
+- **Allocation invariant:** `create_allocation("a@x", S_A.id, cidr)` succeeds; mismatched tenant returns `NotFound`. Direct DB write violating the invariant is rejected by the trigger.
+- **Audit isolation:** mutations under tenant A produce audit rows with `tenant_id = "a@x"`; `audit_log("b@x", ...)` returns none of them.
+- **Idempotency isolation:** tenant A POSTs with key `K`, response cached. Tenant B POSTs same supernet ID + key `K` with different body → executes fresh; no 409, no replay.
+
+### HTTP integration tests
+
+New file `tests/ipam_isolation.rs`. Two mock OIDC identities (separate JWTs against the test JWKS). Same matrix as unit tests but exercised end-to-end through middleware → handler → ops → DB. Verifies the `email → tenant_id` plumbing.
+
+Every cross-tenant access path returns **404 (not 403)**.
+
+### CLI tests
+
+Existing CLI integration tests stay green with `tenant_id = "local"` threaded in. No new CLI behaviors to test.
+
+### Test fixture sweep
+
+The destructive migration means existing test fixtures need updating. Mechanical sweep: every `Supernet { ... }` and `Allocation { ... }` literal in tests gets a `tenant_id` field. Same for SQL inserts in test setup.
+
+## Migration / deploy
+
+- Single migration file `006_multi_tenant_isolation.sql` per backend.
+- Pre-deploy: nothing to back up (no production data of value).
+- Post-deploy on cloudreaper.dev: re-create supernets via the dashboard. Trivial — there were only test entries.
+- Local development: `just db-reset` (or equivalent) drops and re-runs migrations.
+
+## Risks
+
+- **Forgetting tenant_id in a new query.** Mitigated by the explicit-parameter design — every method signature in `IpamOps` and `IpamStore` requires it; any new query that omits a `WHERE tenant_id = ?` is a code-review red flag rather than silent data leakage.
+- **Trigger drift between SQLite and Postgres.** The cross-table invariant trigger has different syntax on each backend. Both implementations are tested in the unit-test matrix; the integration tests run against both backends.
+- **CLI / API schema divergence.** Solved by both modes using the same migration file. CLI just passes a constant tenant_id at every call site.
+
+## Out of scope (deferred to follow-on sub-projects)
+
+- **Sub-project 2: Personal Access Tokens.** DB-backed PATs scoped to an OIDC identity. Mint/list/revoke from `/me/tokens`. Auth middleware tries PAT first then OIDC. Audit log records the real human's `sub`/`email` regardless of which mechanism authenticated the request.
+- **Sub-project 3: `/mcp` mounting.** Wire `StreamableHttpService` into `api::create_router`, gated by the same auth as `/ipam/*`. Reuses the IPAM ops the API already has, so all tenant filtering is automatic.
+
+Each is its own spec → plan → implementation cycle.

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -172,6 +172,24 @@ pub async fn require_auth(config: AuthConfig, mut request: Request, next: Next) 
         return forbidden();
     }
 
+    // Derive tenant identity from the authenticated principal. OIDC mode
+    // requires a verified email; bearer-token mode (single-operator deploys)
+    // falls back to the constant subject "bearer-token" so a single-tenant
+    // bucket still exists.
+    let tenant_id = match principal.kind {
+        PrincipalKind::Oidc => match principal.email.clone() {
+            Some(email) => email,
+            None => {
+                warn!("rejecting OIDC principal without verified email");
+                return unauthorized(config.mode);
+            }
+        },
+        PrincipalKind::BearerToken => principal.subject.clone(),
+    };
+    request
+        .extensions_mut()
+        .insert(crate::tenant::Tenant(tenant_id));
+
     let ctx = crate::audit_context::AuditContext {
         caller_sub: Some(principal.subject.clone()),
         caller_email: principal.email.clone(),

--- a/src/ipam/idempotency.rs
+++ b/src/ipam/idempotency.rs
@@ -70,8 +70,12 @@ pub fn hash_body(body: &[u8]) -> String {
 
 /// Decide whether to proceed with the operation, replay a cached
 /// response, or reject as a conflict.
+///
+/// `tenant_id` scopes the lookup so the same key reused by a different
+/// tenant is treated as a fresh request.
 pub async fn check(
     store: &dyn IpamStore,
+    tenant_id: &str,
     headers: &HeaderMap,
     scope: &str,
     body: &[u8],
@@ -82,7 +86,7 @@ pub async fn check(
 
     let request_hash = hash_body(body);
 
-    if let Some(existing) = store.idempotency_get(&key, scope).await? {
+    if let Some(existing) = store.idempotency_get(tenant_id, &key, scope).await? {
         if existing.request_hash == request_hash {
             return Ok(Outcome::Replay {
                 status: existing.status_code,
@@ -95,11 +99,12 @@ pub async fn check(
     Ok(Outcome::Proceed { key, request_hash })
 }
 
-/// Persist a `(key, scope, request_hash) -> response` mapping. Called
-/// after the operation succeeded *or* failed deterministically (e.g.
-/// 4xx) so retries return the same outcome.
+/// Persist a `(tenant_id, key, scope, request_hash) -> response` mapping.
+/// Called after the operation succeeded *or* failed deterministically
+/// (e.g. 4xx) so retries return the same outcome.
 pub async fn record(
     store: &dyn IpamStore,
+    tenant_id: &str,
     key: &str,
     scope: &str,
     request_hash: &str,
@@ -110,6 +115,7 @@ pub async fn record(
     let expires = now + TTL;
     store
         .idempotency_put(&IdempotencyRecord {
+            tenant_id: tenant_id.to_string(),
             key: key.to_string(),
             scope: scope.to_string(),
             request_hash: request_hash.to_string(),

--- a/src/ipam/mod.rs
+++ b/src/ipam/mod.rs
@@ -64,15 +64,6 @@ pub(crate) fn read_total_hosts(text: Option<String>, legacy_i64: i64) -> u128 {
         .unwrap_or(legacy_i64 as u128)
 }
 
-/// Clamp a u128 to i64::MAX for the legacy INTEGER column.
-pub(crate) fn total_hosts_as_i64(total: u128) -> i64 {
-    if total > i64::MAX as u128 {
-        i64::MAX
-    } else {
-        total as i64
-    }
-}
-
 /// Parse a CIDR string and return (network_address, broadcast_address, prefix_length, total_hosts, ip_version).
 /// Shared by all storage backends.
 pub(crate) fn parse_cidr_metadata(cidr: &str) -> Result<(String, String, u8, u128, u8)> {

--- a/src/ipam/models.rs
+++ b/src/ipam/models.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "swagger", derive(utoipa::ToSchema))]
 pub struct Supernet {
     pub id: String,
+    pub tenant_id: String,
     pub cidr: String,
     pub network_address: String,
     pub broadcast_address: String,
@@ -77,6 +78,7 @@ impl std::str::FromStr for AllocationStatus {
 #[cfg_attr(feature = "swagger", derive(utoipa::ToSchema))]
 pub struct Allocation {
     pub id: String,
+    pub tenant_id: String,
     pub supernet_id: String,
     pub cidr: String,
     pub network_address: String,
@@ -188,6 +190,7 @@ pub struct Tag {
 #[cfg_attr(feature = "swagger", derive(utoipa::ToSchema))]
 pub struct AuditEntry {
     pub id: String,
+    pub tenant_id: String,
     pub entity_type: String,
     pub entity_id: String,
     pub action: String,
@@ -444,6 +447,7 @@ pub struct IpamDump {
 /// the same result without re-executing.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IdempotencyRecord {
+    pub tenant_id: String,
     pub key: String,
     pub scope: String,
     pub request_hash: String,

--- a/src/ipam/operations.rs
+++ b/src/ipam/operations.rs
@@ -55,7 +55,11 @@ impl IpamOps {
     // Supernet operations
     // -----------------------------------------------------------------------
 
-    pub async fn create_supernet(&self, input: &CreateSupernet) -> Result<Supernet> {
+    pub async fn create_supernet(
+        &self,
+        tenant_id: &str,
+        input: &CreateSupernet,
+    ) -> Result<Supernet> {
         validation::validate_cidr(&input.cidr)?;
         validation::validate_optional_text(&input.name, 0)?;
         validation::validate_optional_text(&input.description, 0)?;
@@ -63,7 +67,7 @@ impl IpamOps {
         let candidate = parse_range(&input.cidr)?;
 
         // Check for overlap with existing supernets
-        let existing = self.store.list_supernets().await?;
+        let existing = self.store.list_supernets(tenant_id).await?;
         for sn in &existing {
             let existing_range = parse_range(&sn.cidr)?;
             if ranges_overlap(&candidate, &existing_range) {
@@ -74,8 +78,9 @@ impl IpamOps {
             }
         }
 
-        let supernet = self.store.create_supernet(input).await?;
+        let supernet = self.store.create_supernet(tenant_id, input).await?;
         self.audit(
+            tenant_id,
             "create_supernet",
             "supernet",
             &supernet.id,
@@ -85,20 +90,20 @@ impl IpamOps {
         Ok(supernet)
     }
 
-    pub async fn get_supernet(&self, id: &str) -> Result<Supernet> {
+    pub async fn get_supernet(&self, tenant_id: &str, id: &str) -> Result<Supernet> {
         validation::validate_identifier(id)?;
-        self.store.get_supernet(id).await
+        self.store.get_supernet(tenant_id, id).await
     }
 
-    pub async fn list_supernets(&self) -> Result<Vec<Supernet>> {
-        self.store.list_supernets().await
+    pub async fn list_supernets(&self, tenant_id: &str) -> Result<Vec<Supernet>> {
+        self.store.list_supernets(tenant_id).await
     }
 
-    pub async fn delete_supernet(&self, id: &str) -> Result<()> {
+    pub async fn delete_supernet(&self, tenant_id: &str, id: &str) -> Result<()> {
         validation::validate_identifier(id)?;
-        let sn = self.store.get_supernet(id).await?;
-        self.store.delete_supernet(id).await?;
-        self.audit("delete_supernet", "supernet", id, Some(&sn.cidr))
+        let sn = self.store.get_supernet(tenant_id, id).await?;
+        self.store.delete_supernet(tenant_id, id).await?;
+        self.audit(tenant_id, "delete_supernet", "supernet", id, Some(&sn.cidr))
             .await?;
         Ok(())
     }
@@ -108,13 +113,17 @@ impl IpamOps {
     // -----------------------------------------------------------------------
 
     /// Allocate a specific CIDR block within a supernet.
-    pub async fn allocate_specific(&self, input: &CreateAllocation) -> Result<Allocation> {
+    pub async fn allocate_specific(
+        &self,
+        tenant_id: &str,
+        input: &CreateAllocation,
+    ) -> Result<Allocation> {
         Self::validate_create_allocation(input)?;
 
         let lock = self.supernet_lock(&input.supernet_id);
         let _guard = lock.lock().await;
 
-        let supernet = self.store.get_supernet(&input.supernet_id).await?;
+        let supernet = self.store.get_supernet(tenant_id, &input.supernet_id).await?;
         let supernet_range = parse_range(&supernet.cidr)?;
         let candidate_range = parse_range(&input.cidr)?;
 
@@ -131,7 +140,7 @@ impl IpamOps {
 
         // Check for parent containment if specified
         if let Some(ref parent_id) = input.parent_allocation_id {
-            let parent = self.store.get_allocation(parent_id).await?;
+            let parent = self.store.get_allocation(tenant_id, parent_id).await?;
             let parent_range = parse_range(&parent.cidr)?;
             if !range_contains(&parent_range, &candidate_range) {
                 return Err(NetcidrError::AllocationConflict {
@@ -142,14 +151,18 @@ impl IpamOps {
         }
 
         // Check overlap with existing active/reserved allocations
-        self.check_overlap(&input.supernet_id, &candidate_range, &input.cidr)
+        self.check_overlap(tenant_id, &input.supernet_id, &candidate_range, &input.cidr)
             .await?;
 
         // If a released allocation exists with the exact same CIDR, reactivate
         // it instead of creating a duplicate record.
         let released = self
             .store
-            .find_allocations_in_supernet(&input.supernet_id, &[AllocationStatus::Released])
+            .find_allocations_in_supernet(
+                tenant_id,
+                &input.supernet_id,
+                &[AllocationStatus::Released],
+            )
             .await?;
         if let Some(existing) = released.iter().find(|a| a.cidr == input.cidr) {
             let update = UpdateAllocation {
@@ -164,20 +177,39 @@ impl IpamOps {
                 owner: input.owner.clone().or(existing.owner.clone()),
                 status: Some(input.status.clone().unwrap_or(AllocationStatus::Active)),
             };
-            let alloc = self.store.update_allocation(&existing.id, &update).await?;
-            self.audit("reactivate", "allocation", &alloc.id, Some(&alloc.cidr))
+            let alloc = self
+                .store
+                .update_allocation(tenant_id, &existing.id, &update)
                 .await?;
+            self.audit(
+                tenant_id,
+                "reactivate",
+                "allocation",
+                &alloc.id,
+                Some(&alloc.cidr),
+            )
+            .await?;
             return Ok(alloc);
         }
 
-        let alloc = self.store.create_allocation(input).await?;
-        self.audit("allocate", "allocation", &alloc.id, Some(&alloc.cidr))
-            .await?;
+        let alloc = self.store.create_allocation(tenant_id, input).await?;
+        self.audit(
+            tenant_id,
+            "allocate",
+            "allocation",
+            &alloc.id,
+            Some(&alloc.cidr),
+        )
+        .await?;
         Ok(alloc)
     }
 
     /// Auto-allocate the next available block(s) of a given prefix length.
-    pub async fn allocate_auto(&self, request: &AutoAllocateRequest) -> Result<Vec<Allocation>> {
+    pub async fn allocate_auto(
+        &self,
+        tenant_id: &str,
+        request: &AutoAllocateRequest,
+    ) -> Result<Vec<Allocation>> {
         validation::validate_identifier(&request.supernet_id)?;
         validation::validate_optional_text(&request.name, 0)?;
         validation::validate_optional_text(&request.description, 0)?;
@@ -189,7 +221,7 @@ impl IpamOps {
         let lock = self.supernet_lock(&request.supernet_id);
         let _guard = lock.lock().await;
 
-        let supernet = self.store.get_supernet(&request.supernet_id).await?;
+        let supernet = self.store.get_supernet(tenant_id, &request.supernet_id).await?;
         let supernet_range = parse_range(&supernet.cidr)?;
         let count = request.count.unwrap_or(1);
 
@@ -207,6 +239,7 @@ impl IpamOps {
         let existing = self
             .store
             .find_allocations_in_supernet(
+                tenant_id,
                 &request.supernet_id,
                 &[AllocationStatus::Active, AllocationStatus::Reserved],
             )
@@ -247,27 +280,38 @@ impl IpamOps {
                 tags: request.tags.clone(),
                 ttl_seconds: request.ttl_seconds,
             };
-            let alloc = self.store.create_allocation(&input).await?;
-            self.audit("allocate", "allocation", &alloc.id, Some(&alloc.cidr))
-                .await?;
+            let alloc = self.store.create_allocation(tenant_id, &input).await?;
+            self.audit(
+                tenant_id,
+                "allocate",
+                "allocation",
+                &alloc.id,
+                Some(&alloc.cidr),
+            )
+            .await?;
             allocations.push(alloc);
         }
         Ok(allocations)
     }
 
-    pub async fn get_allocation(&self, id: &str) -> Result<Allocation> {
+    pub async fn get_allocation(&self, tenant_id: &str, id: &str) -> Result<Allocation> {
         validation::validate_identifier(id)?;
-        self.store.get_allocation(id).await
+        self.store.get_allocation(tenant_id, id).await
     }
 
-    pub async fn list_allocations(&self, filter: &AllocationFilter) -> Result<Vec<Allocation>> {
+    pub async fn list_allocations(
+        &self,
+        tenant_id: &str,
+        filter: &AllocationFilter,
+    ) -> Result<Vec<Allocation>> {
         validation::validate_optional_identifier(&filter.supernet_id)?;
         validation::validate_optional_identifier(&filter.resource_id)?;
-        self.store.list_allocations(filter).await
+        self.store.list_allocations(tenant_id, filter).await
     }
 
     pub async fn update_allocation(
         &self,
+        tenant_id: &str,
         id: &str,
         input: &UpdateAllocation,
     ) -> Result<Allocation> {
@@ -280,7 +324,7 @@ impl IpamOps {
 
         // Resolve the parent supernet so we can serialize against concurrent
         // allocations into it.
-        let existing = self.store.get_allocation(id).await?;
+        let existing = self.store.get_allocation(tenant_id, id).await?;
         let lock = self.supernet_lock(&existing.supernet_id);
         let _guard = lock.lock().await;
 
@@ -291,27 +335,38 @@ impl IpamOps {
             && existing.status == AllocationStatus::Released
         {
             let candidate_range = parse_range(&existing.cidr)?;
-            self.check_overlap(&existing.supernet_id, &candidate_range, &existing.cidr)
-                .await?;
+            self.check_overlap(
+                tenant_id,
+                &existing.supernet_id,
+                &candidate_range,
+                &existing.cidr,
+            )
+            .await?;
         }
 
-        let alloc = self.store.update_allocation(id, input).await?;
-        self.audit("update", "allocation", id, None).await?;
+        let alloc = self.store.update_allocation(tenant_id, id, input).await?;
+        self.audit(tenant_id, "update", "allocation", id, None).await?;
         Ok(alloc)
     }
 
-    pub async fn release_allocation(&self, id: &str) -> Result<Allocation> {
+    pub async fn release_allocation(&self, tenant_id: &str, id: &str) -> Result<Allocation> {
         validation::validate_identifier(id)?;
 
         // Lock the parent supernet so a concurrent allocate_specific that
         // races a release sees a consistent snapshot.
-        let existing = self.store.get_allocation(id).await?;
+        let existing = self.store.get_allocation(tenant_id, id).await?;
         let lock = self.supernet_lock(&existing.supernet_id);
         let _guard = lock.lock().await;
 
-        let alloc = self.store.release_allocation(id).await?;
-        self.audit("release", "allocation", id, Some(&alloc.cidr))
-            .await?;
+        let alloc = self.store.release_allocation(tenant_id, id).await?;
+        self.audit(
+            tenant_id,
+            "release",
+            "allocation",
+            id,
+            Some(&alloc.cidr),
+        )
+        .await?;
         Ok(alloc)
     }
 
@@ -320,14 +375,19 @@ impl IpamOps {
     // -----------------------------------------------------------------------
 
     /// Calculate utilization for a supernet with per-status breakdown.
-    pub async fn utilization(&self, supernet_id: &str) -> Result<UtilizationReport> {
+    pub async fn utilization(
+        &self,
+        tenant_id: &str,
+        supernet_id: &str,
+    ) -> Result<UtilizationReport> {
         validation::validate_identifier(supernet_id)?;
-        let supernet = self.store.get_supernet(supernet_id).await?;
+        let supernet = self.store.get_supernet(tenant_id, supernet_id).await?;
 
         // Fetch active + reserved allocations (these consume space)
         let active_reserved = self
             .store
             .find_allocations_in_supernet(
+                tenant_id,
                 supernet_id,
                 &[AllocationStatus::Active, AllocationStatus::Reserved],
             )
@@ -336,7 +396,11 @@ impl IpamOps {
         // Fetch released allocations for the breakdown
         let released = self
             .store
-            .find_allocations_in_supernet(supernet_id, &[AllocationStatus::Released])
+            .find_allocations_in_supernet(
+                tenant_id,
+                supernet_id,
+                &[AllocationStatus::Released],
+            )
             .await?;
 
         let mut active_addresses: u128 = 0;
@@ -392,16 +456,18 @@ impl IpamOps {
     /// List free blocks in a supernet, optionally filtered by prefix length.
     pub async fn free_blocks(
         &self,
+        tenant_id: &str,
         supernet_id: &str,
         target_prefix: Option<u8>,
     ) -> Result<FreeBlocksReport> {
         validation::validate_identifier(supernet_id)?;
-        let supernet = self.store.get_supernet(supernet_id).await?;
+        let supernet = self.store.get_supernet(tenant_id, supernet_id).await?;
         let supernet_range = parse_range(&supernet.cidr)?;
 
         let active = self
             .store
             .find_allocations_in_supernet(
+                tenant_id,
                 supernet_id,
                 &[AllocationStatus::Active, AllocationStatus::Reserved],
             )
@@ -463,12 +529,12 @@ impl IpamOps {
     }
 
     /// Find allocations containing a given IP address.
-    pub async fn find_by_ip(&self, address: &str) -> Result<Vec<Allocation>> {
+    pub async fn find_by_ip(&self, tenant_id: &str, address: &str) -> Result<Vec<Allocation>> {
         validation::validate_ip_address(address)?;
         let ip = parse_ip(address)?;
 
         // Search all supernets
-        let supernets = self.store.list_supernets().await?;
+        let supernets = self.store.list_supernets(tenant_id).await?;
         let mut results = Vec::new();
 
         for sn in &supernets {
@@ -479,6 +545,7 @@ impl IpamOps {
             let allocs = self
                 .store
                 .find_allocations_in_supernet(
+                    tenant_id,
                     &sn.id,
                     &[AllocationStatus::Active, AllocationStatus::Reserved],
                 )
@@ -496,23 +563,34 @@ impl IpamOps {
     }
 
     /// Find allocations by resource ID.
-    pub async fn find_by_resource(&self, resource_id: &str) -> Result<Vec<Allocation>> {
+    pub async fn find_by_resource(
+        &self,
+        tenant_id: &str,
+        resource_id: &str,
+    ) -> Result<Vec<Allocation>> {
         validation::validate_identifier(resource_id)?;
         self.store
-            .list_allocations(&AllocationFilter {
-                resource_id: Some(resource_id.to_string()),
-                ..Default::default()
-            })
+            .list_allocations(
+                tenant_id,
+                &AllocationFilter {
+                    resource_id: Some(resource_id.to_string()),
+                    ..Default::default()
+                },
+            )
             .await
     }
 
     /// Query the audit log.
-    pub async fn query_audit(&self, filter: &AuditFilter) -> Result<Vec<AuditEntry>> {
+    pub async fn query_audit(
+        &self,
+        tenant_id: &str,
+        filter: &AuditFilter,
+    ) -> Result<Vec<AuditEntry>> {
         // Validate filter fields — consistent with all other string inputs.
         validation::validate_optional_identifier(&filter.entity_id)?;
         validation::validate_optional_text(&filter.entity_type, 0)?;
         validation::validate_optional_text(&filter.action, 0)?;
-        self.store.query_audit(filter).await
+        self.store.query_audit(tenant_id, filter).await
     }
 
     // -----------------------------------------------------------------------
@@ -521,15 +599,16 @@ impl IpamOps {
 
     /// Release all allocations whose `expires_at` has passed.
     /// Returns the number of expired allocations released.
-    pub async fn reap_expired(&self) -> Result<usize> {
+    pub async fn reap_expired(&self, tenant_id: &str) -> Result<usize> {
         let now = Utc::now().to_rfc3339();
-        let supernets = self.store.list_supernets().await?;
+        let supernets = self.store.list_supernets(tenant_id).await?;
         let mut reaped = 0;
 
         for sn in &supernets {
             let active = self
                 .store
                 .find_allocations_in_supernet(
+                    tenant_id,
                     &sn.id,
                     &[AllocationStatus::Active, AllocationStatus::Reserved],
                 )
@@ -539,9 +618,15 @@ impl IpamOps {
                 if let Some(ref expires) = alloc.expires_at
                     && expires.as_str() <= now.as_str()
                 {
-                    self.store.release_allocation(&alloc.id).await?;
-                    self.audit("expire", "allocation", &alloc.id, Some(&alloc.cidr))
-                        .await?;
+                    self.store.release_allocation(tenant_id, &alloc.id).await?;
+                    self.audit(
+                        tenant_id,
+                        "expire",
+                        "allocation",
+                        &alloc.id,
+                        Some(&alloc.cidr),
+                    )
+                    .await?;
                     reaped += 1;
                 }
             }
@@ -556,7 +641,11 @@ impl IpamOps {
     /// Batch allocate: process multiple allocation requests in a single call.
     /// Each item is processed sequentially (required for conflict detection).
     /// Per-item errors are captured rather than aborting the entire batch.
-    pub async fn batch_allocate(&self, items: &[BatchAllocateItem]) -> Result<BatchAllocateResult> {
+    pub async fn batch_allocate(
+        &self,
+        tenant_id: &str,
+        items: &[BatchAllocateItem],
+    ) -> Result<BatchAllocateResult> {
         const MAX_BATCH_SIZE: usize = 100;
         if items.len() > MAX_BATCH_SIZE {
             return Err(NetcidrError::InvalidInput(format!(
@@ -585,7 +674,7 @@ impl IpamOps {
                 ttl_seconds: None,
             };
 
-            match self.allocate_auto(&request).await {
+            match self.allocate_auto(tenant_id, &request).await {
                 Ok(allocs) => {
                     let compact: Vec<CompactAllocation> =
                         allocs.iter().map(CompactAllocation::from).collect();
@@ -615,7 +704,11 @@ impl IpamOps {
 
     /// Batch release: release multiple allocations in a single call.
     /// Supports release by explicit IDs, by resource_id, or by supernet_id.
-    pub async fn batch_release(&self, request: &BatchReleaseRequest) -> Result<BatchReleaseResult> {
+    pub async fn batch_release(
+        &self,
+        tenant_id: &str,
+        request: &BatchReleaseRequest,
+    ) -> Result<BatchReleaseResult> {
         const MAX_BATCH_RELEASE_ITEMS: usize = 10_000;
 
         if let Some(ref ids) = request.allocation_ids
@@ -632,7 +725,7 @@ impl IpamOps {
             // Explicit IDs — look up each to get the CIDR for the response
             let mut resolved = Vec::with_capacity(ids.len());
             for id in ids {
-                match self.store.get_allocation(id).await {
+                match self.store.get_allocation(tenant_id, id).await {
                     Ok(alloc) => resolved.push((alloc.id, alloc.cidr)),
                     Err(_) => resolved.push((id.clone(), "unknown".to_string())),
                 }
@@ -646,13 +739,17 @@ impl IpamOps {
                 status: Some(AllocationStatus::Active),
                 ..Default::default()
             };
-            let allocs = self.store.list_allocations(&filter).await?;
+            let allocs = self.store.list_allocations(tenant_id, &filter).await?;
             allocs.into_iter().map(|a| (a.id, a.cidr)).collect()
         } else if let Some(ref supernet_id) = request.supernet_id {
             // All active allocations in a supernet
             let allocs = self
                 .store
-                .find_allocations_in_supernet(supernet_id, &[AllocationStatus::Active])
+                .find_allocations_in_supernet(
+                    tenant_id,
+                    supernet_id,
+                    &[AllocationStatus::Active],
+                )
                 .await?;
             allocs.into_iter().map(|a| (a.id, a.cidr)).collect()
         } else {
@@ -667,7 +764,7 @@ impl IpamOps {
         let mut results = Vec::with_capacity(total_requested);
 
         for (id, cidr) in ids_to_release {
-            match self.release_allocation(&id).await {
+            match self.release_allocation(tenant_id, &id).await {
                 Ok(_) => {
                     total_released += 1;
                     results.push(BatchReleaseItemResult {
@@ -694,11 +791,15 @@ impl IpamOps {
     }
 
     /// Get a grouped allocation summary across all (or one) supernet(s).
-    pub async fn allocation_summary(&self, supernet_id: Option<&str>) -> Result<AllocationSummary> {
+    pub async fn allocation_summary(
+        &self,
+        tenant_id: &str,
+        supernet_id: Option<&str>,
+    ) -> Result<AllocationSummary> {
         let supernets = if let Some(id) = supernet_id {
-            vec![self.store.get_supernet(id).await?]
+            vec![self.store.get_supernet(tenant_id, id).await?]
         } else {
-            self.store.list_supernets().await?
+            self.store.list_supernets(tenant_id).await?
         };
 
         let mut total_allocations = 0usize;
@@ -709,6 +810,7 @@ impl IpamOps {
             let active = self
                 .store
                 .find_allocations_in_supernet(
+                    tenant_id,
                     &sn.id,
                     &[AllocationStatus::Active, AllocationStatus::Reserved],
                 )
@@ -771,11 +873,11 @@ impl IpamOps {
     // -----------------------------------------------------------------------
 
     /// Export all IPAM data as a serializable dump.
-    pub async fn dump(&self) -> Result<IpamDump> {
-        let supernets = self.store.list_supernets().await?;
+    pub async fn dump(&self, tenant_id: &str) -> Result<IpamDump> {
+        let supernets = self.store.list_supernets(tenant_id).await?;
         let allocations = self
             .store
-            .list_allocations(&AllocationFilter::default())
+            .list_allocations(tenant_id, &AllocationFilter::default())
             .await?;
 
         Ok(IpamDump {
@@ -787,9 +889,9 @@ impl IpamOps {
     }
 
     /// Import IPAM data from a dump. Fails if any supernets already exist.
-    pub async fn load(&self, dump: &IpamDump) -> Result<(usize, usize)> {
+    pub async fn load(&self, tenant_id: &str, dump: &IpamDump) -> Result<(usize, usize)> {
         // Check for existing data
-        let existing = self.store.list_supernets().await?;
+        let existing = self.store.list_supernets(tenant_id).await?;
         if !existing.is_empty() {
             return Err(NetcidrError::InvalidInput(
                 "cannot import into a non-empty store — existing supernets found".to_string(),
@@ -802,17 +904,20 @@ impl IpamOps {
         // Import supernets first (allocations depend on them)
         for sn in &dump.supernets {
             self.store
-                .create_supernet(&CreateSupernet {
-                    cidr: sn.cidr.clone(),
-                    name: sn.name.clone(),
-                    description: sn.description.clone(),
-                })
+                .create_supernet(
+                    tenant_id,
+                    &CreateSupernet {
+                        cidr: sn.cidr.clone(),
+                        name: sn.name.clone(),
+                        description: sn.description.clone(),
+                    },
+                )
                 .await?;
             sn_count += 1;
         }
 
         // Build a mapping from old supernet CIDR -> new supernet ID
-        let new_supernets = self.store.list_supernets().await?;
+        let new_supernets = self.store.list_supernets(tenant_id).await?;
         let cidr_to_id: std::collections::HashMap<&str, &str> = new_supernets
             .iter()
             .map(|sn| (sn.cidr.as_str(), sn.id.as_str()))
@@ -842,8 +947,10 @@ impl IpamOps {
                 })?;
 
             self.store
-                .create_allocation(&CreateAllocation {
-                    supernet_id: new_sn_id.to_string(),
+                .create_allocation(
+                    tenant_id,
+                    &CreateAllocation {
+                        supernet_id: new_sn_id.to_string(),
                     cidr: alloc.cidr.clone(),
                     status: Some(alloc.status.clone()),
                     resource_id: alloc.resource_id.clone(),
@@ -859,7 +966,8 @@ impl IpamOps {
                         Some(alloc.tags.clone())
                     },
                     ttl_seconds: None,
-                })
+                    },
+                )
                 .await?;
             alloc_count += 1;
         }
@@ -871,18 +979,23 @@ impl IpamOps {
     // Tags
     // -----------------------------------------------------------------------
 
-    pub async fn set_tags(&self, allocation_id: &str, tags: &[Tag]) -> Result<()> {
+    pub async fn set_tags(
+        &self,
+        tenant_id: &str,
+        allocation_id: &str,
+        tags: &[Tag],
+    ) -> Result<()> {
         validation::validate_identifier(allocation_id)?;
         for tag in tags {
             validation::validate_text_field(&tag.key, 0)?;
             validation::validate_text_field(&tag.value, 0)?;
         }
-        self.store.set_tags(allocation_id, tags).await
+        self.store.set_tags(tenant_id, allocation_id, tags).await
     }
 
-    pub async fn get_tags(&self, allocation_id: &str) -> Result<Vec<Tag>> {
+    pub async fn get_tags(&self, tenant_id: &str, allocation_id: &str) -> Result<Vec<Tag>> {
         validation::validate_identifier(allocation_id)?;
-        self.store.get_tags(allocation_id).await
+        self.store.get_tags(tenant_id, allocation_id).await
     }
 
     // -----------------------------------------------------------------------
@@ -907,6 +1020,7 @@ impl IpamOps {
 
     async fn check_overlap(
         &self,
+        tenant_id: &str,
         supernet_id: &str,
         candidate: &IpRange,
         candidate_cidr: &str,
@@ -914,6 +1028,7 @@ impl IpamOps {
         let existing = self
             .store
             .find_allocations_in_supernet(
+                tenant_id,
                 supernet_id,
                 &[AllocationStatus::Active, AllocationStatus::Reserved],
             )
@@ -934,6 +1049,7 @@ impl IpamOps {
 
     async fn audit(
         &self,
+        tenant_id: &str,
         action: &str,
         entity_type: &str,
         entity_id: &str,
@@ -943,6 +1059,7 @@ impl IpamOps {
         self.store
             .append_audit(&AuditEntry {
                 id: String::new(),
+                tenant_id: tenant_id.to_string(),
                 entity_type: entity_type.to_string(),
                 entity_id: entity_id.to_string(),
                 action: action.to_string(),
@@ -1178,6 +1295,8 @@ mod tests {
     use super::*;
     use crate::ipam::sqlite::SqliteStore;
 
+    const TEST_TENANT: &str = "test-tenant";
+
     async fn test_ops() -> IpamOps {
         let store = SqliteStore::in_memory().unwrap();
         store.initialize().await.unwrap();
@@ -1189,7 +1308,7 @@ mod tests {
     async fn test_create_supernet_overlap_rejected() {
         let ops = test_ops().await;
 
-        ops.create_supernet(&CreateSupernet {
+        ops.create_supernet(TEST_TENANT, &CreateSupernet {
             cidr: "10.0.0.0/8".to_string(),
             name: None,
             description: None,
@@ -1198,7 +1317,7 @@ mod tests {
         .unwrap();
 
         let err = ops
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "10.128.0.0/9".to_string(),
                 name: None,
                 description: None,
@@ -1214,7 +1333,7 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "10.0.0.0/8".to_string(),
                 name: None,
                 description: None,
@@ -1223,7 +1342,7 @@ mod tests {
             .unwrap();
 
         let a1 = ops
-            .allocate_specific(&CreateAllocation {
+            .allocate_specific(TEST_TENANT, &CreateAllocation {
                 supernet_id: sn.id.clone(),
                 cidr: "10.0.0.0/24".to_string(),
                 status: None,
@@ -1244,7 +1363,7 @@ mod tests {
 
         // Overlapping allocation should fail
         let err = ops
-            .allocate_specific(&CreateAllocation {
+            .allocate_specific(TEST_TENANT, &CreateAllocation {
                 supernet_id: sn.id.clone(),
                 cidr: "10.0.0.128/25".to_string(),
                 status: None,
@@ -1269,7 +1388,7 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "10.0.0.0/16".to_string(),
                 name: None,
                 description: None,
@@ -1278,7 +1397,7 @@ mod tests {
             .unwrap();
 
         // Allocate first /24
-        ops.allocate_specific(&CreateAllocation {
+        ops.allocate_specific(TEST_TENANT, &CreateAllocation {
             supernet_id: sn.id.clone(),
             cidr: "10.0.0.0/24".to_string(),
             status: None,
@@ -1297,7 +1416,7 @@ mod tests {
 
         // Auto-allocate next 3 /24s
         let allocs = ops
-            .allocate_auto(&AutoAllocateRequest {
+            .allocate_auto(TEST_TENANT, &AutoAllocateRequest {
                 supernet_id: sn.id.clone(),
                 prefix_length: 24,
                 count: Some(3),
@@ -1326,7 +1445,7 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "10.0.0.0/24".to_string(),
                 name: None,
                 description: None,
@@ -1334,7 +1453,7 @@ mod tests {
             .await
             .unwrap();
 
-        ops.allocate_specific(&CreateAllocation {
+        ops.allocate_specific(TEST_TENANT, &CreateAllocation {
             supernet_id: sn.id.clone(),
             cidr: "10.0.0.0/25".to_string(),
             status: None,
@@ -1351,7 +1470,7 @@ mod tests {
         .await
         .unwrap();
 
-        let util = ops.utilization(&sn.id).await.unwrap();
+        let util = ops.utilization(TEST_TENANT, &sn.id).await.unwrap();
         assert_eq!(util.total_addresses, 256);
         assert_eq!(util.allocated_addresses, 128);
         assert_eq!(util.free_addresses, 128);
@@ -1369,7 +1488,7 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "10.0.0.0/24".to_string(),
                 name: None,
                 description: None,
@@ -1377,7 +1496,7 @@ mod tests {
             .await
             .unwrap();
 
-        ops.allocate_specific(&CreateAllocation {
+        ops.allocate_specific(TEST_TENANT, &CreateAllocation {
             supernet_id: sn.id.clone(),
             cidr: "10.0.0.0/25".to_string(),
             status: None,
@@ -1394,7 +1513,7 @@ mod tests {
         .await
         .unwrap();
 
-        let report = ops.free_blocks(&sn.id, None).await.unwrap();
+        let report = ops.free_blocks(TEST_TENANT, &sn.id, None).await.unwrap();
         assert_eq!(report.blocks.len(), 1);
         assert_eq!(report.blocks[0].cidr, "10.0.0.128/25");
         assert_eq!(report.total_free, 128);
@@ -1405,7 +1524,7 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "10.0.0.0/8".to_string(),
                 name: None,
                 description: None,
@@ -1413,7 +1532,7 @@ mod tests {
             .await
             .unwrap();
 
-        ops.allocate_specific(&CreateAllocation {
+        ops.allocate_specific(TEST_TENANT, &CreateAllocation {
             supernet_id: sn.id.clone(),
             cidr: "10.0.1.0/24".to_string(),
             status: None,
@@ -1430,11 +1549,11 @@ mod tests {
         .await
         .unwrap();
 
-        let found = ops.find_by_ip("10.0.1.50").await.unwrap();
+        let found = ops.find_by_ip(TEST_TENANT,"10.0.1.50").await.unwrap();
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].cidr, "10.0.1.0/24");
 
-        let not_found = ops.find_by_ip("10.0.2.50").await.unwrap();
+        let not_found = ops.find_by_ip(TEST_TENANT,"10.0.2.50").await.unwrap();
         assert!(not_found.is_empty());
     }
 
@@ -1443,7 +1562,7 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "10.0.0.0/24".to_string(),
                 name: None,
                 description: None,
@@ -1452,7 +1571,7 @@ mod tests {
             .unwrap();
 
         let a1 = ops
-            .allocate_specific(&CreateAllocation {
+            .allocate_specific(TEST_TENANT, &CreateAllocation {
                 supernet_id: sn.id.clone(),
                 cidr: "10.0.0.0/25".to_string(),
                 status: None,
@@ -1469,7 +1588,7 @@ mod tests {
             .await
             .unwrap();
 
-        ops.allocate_specific(&CreateAllocation {
+        ops.allocate_specific(TEST_TENANT, &CreateAllocation {
             supernet_id: sn.id.clone(),
             cidr: "10.0.0.128/25".to_string(),
             status: None,
@@ -1487,15 +1606,15 @@ mod tests {
         .unwrap();
 
         // Supernet fully allocated
-        let util = ops.utilization(&sn.id).await.unwrap();
+        let util = ops.utilization(TEST_TENANT, &sn.id).await.unwrap();
         assert!((util.utilization_percent - 100.0).abs() < 0.1);
 
         // Release first block
-        ops.release_allocation(&a1.id).await.unwrap();
+        ops.release_allocation(TEST_TENANT, &a1.id).await.unwrap();
 
         // Now auto-allocate should find the freed space
         let allocs = ops
-            .allocate_auto(&AutoAllocateRequest {
+            .allocate_auto(TEST_TENANT, &AutoAllocateRequest {
                 supernet_id: sn.id.clone(),
                 prefix_length: 25,
                 count: Some(1),
@@ -1522,7 +1641,7 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "10.0.0.0/24".to_string(),
                 name: None,
                 description: None,
@@ -1532,7 +1651,7 @@ mod tests {
 
         // Active allocation
         let a1 = ops
-            .allocate_specific(&CreateAllocation {
+            .allocate_specific(TEST_TENANT, &CreateAllocation {
                 supernet_id: sn.id.clone(),
                 cidr: "10.0.0.0/26".to_string(),
                 status: None,
@@ -1550,7 +1669,7 @@ mod tests {
             .unwrap();
 
         // Reserved allocation
-        ops.allocate_specific(&CreateAllocation {
+        ops.allocate_specific(TEST_TENANT, &CreateAllocation {
             supernet_id: sn.id.clone(),
             cidr: "10.0.0.64/26".to_string(),
             status: Some(AllocationStatus::Reserved),
@@ -1568,9 +1687,9 @@ mod tests {
         .unwrap();
 
         // Release the first allocation
-        ops.release_allocation(&a1.id).await.unwrap();
+        ops.release_allocation(TEST_TENANT, &a1.id).await.unwrap();
 
-        let util = ops.utilization(&sn.id).await.unwrap();
+        let util = ops.utilization(TEST_TENANT, &sn.id).await.unwrap();
         // Only reserved counts as allocated (active was released)
         assert_eq!(util.allocated_addresses, 64);
         assert_eq!(util.free_addresses, 192);
@@ -1587,7 +1706,7 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "10.0.0.0/24".to_string(),
                 name: None,
                 description: None,
@@ -1597,7 +1716,7 @@ mod tests {
 
         // Allocate with TTL of 0 seconds (already expired)
         let alloc = ops
-            .allocate_specific(&CreateAllocation {
+            .allocate_specific(TEST_TENANT, &CreateAllocation {
                 supernet_id: sn.id.clone(),
                 cidr: "10.0.0.0/25".to_string(),
                 status: None,
@@ -1617,15 +1736,15 @@ mod tests {
         assert!(alloc.expires_at.is_some());
 
         // Reap expired — should release the allocation
-        let reaped = ops.reap_expired().await.unwrap();
+        let reaped = ops.reap_expired(TEST_TENANT).await.unwrap();
         assert_eq!(reaped, 1);
 
         // Verify it's released
-        let fetched = ops.get_allocation(&alloc.id).await.unwrap();
+        let fetched = ops.get_allocation(TEST_TENANT, &alloc.id).await.unwrap();
         assert_eq!(fetched.status, AllocationStatus::Released);
 
         // Reap again — nothing to reap
-        let reaped = ops.reap_expired().await.unwrap();
+        let reaped = ops.reap_expired(TEST_TENANT).await.unwrap();
         assert_eq!(reaped, 0);
     }
 
@@ -1634,7 +1753,7 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "10.0.0.0/8".to_string(),
                 name: Some("Corp".to_string()),
                 description: None,
@@ -1642,7 +1761,7 @@ mod tests {
             .await
             .unwrap();
 
-        ops.allocate_specific(&CreateAllocation {
+        ops.allocate_specific(TEST_TENANT, &CreateAllocation {
             supernet_id: sn.id.clone(),
             cidr: "10.0.0.0/24".to_string(),
             status: None,
@@ -1660,7 +1779,7 @@ mod tests {
         .unwrap();
 
         // Dump
-        let dump = ops.dump().await.unwrap();
+        let dump = ops.dump(TEST_TENANT).await.unwrap();
         assert_eq!(dump.supernets.len(), 1);
         assert_eq!(dump.allocations.len(), 1);
         assert_eq!(dump.version, 1);
@@ -1673,16 +1792,16 @@ mod tests {
 
         // Load into a fresh store
         let ops2 = test_ops().await;
-        let (sn_count, alloc_count) = ops2.load(&parsed).await.unwrap();
+        let (sn_count, alloc_count) = ops2.load(TEST_TENANT, &parsed).await.unwrap();
         assert_eq!(sn_count, 1);
         assert_eq!(alloc_count, 1);
 
         // Verify data
-        let supernets = ops2.list_supernets().await.unwrap();
+        let supernets = ops2.list_supernets(TEST_TENANT).await.unwrap();
         assert_eq!(supernets[0].cidr, "10.0.0.0/8");
 
         let allocs = ops2
-            .list_allocations(&AllocationFilter::default())
+            .list_allocations(TEST_TENANT, &AllocationFilter::default())
             .await
             .unwrap();
         assert_eq!(allocs[0].cidr, "10.0.0.0/24");
@@ -1693,7 +1812,7 @@ mod tests {
     async fn test_load_rejects_non_empty_store() {
         let ops = test_ops().await;
 
-        ops.create_supernet(&CreateSupernet {
+        ops.create_supernet(TEST_TENANT, &CreateSupernet {
             cidr: "10.0.0.0/8".to_string(),
             name: None,
             description: None,
@@ -1708,7 +1827,7 @@ mod tests {
             allocations: vec![],
         };
 
-        let err = ops.load(&dump).await.unwrap_err();
+        let err = ops.load(TEST_TENANT, &dump).await.unwrap_err();
         assert!(matches!(err, NetcidrError::InvalidInput(_)));
     }
 
@@ -1776,7 +1895,7 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "2001:db8::/32".to_string(),
                 name: None,
                 description: None,
@@ -1786,7 +1905,7 @@ mod tests {
 
         // Try to allocate an IPv4 CIDR in an IPv6 supernet
         let err = ops
-            .allocate_specific(&CreateAllocation {
+            .allocate_specific(TEST_TENANT, &CreateAllocation {
                 supernet_id: sn.id.clone(),
                 cidr: "10.0.0.0/24".to_string(),
                 status: None,
@@ -1813,7 +1932,7 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "10.0.0.0/8".to_string(),
                 name: None,
                 description: None,
@@ -1822,7 +1941,7 @@ mod tests {
             .unwrap();
 
         let err = ops
-            .allocate_specific(&CreateAllocation {
+            .allocate_specific(TEST_TENANT, &CreateAllocation {
                 supernet_id: sn.id.clone(),
                 cidr: "2001:db8::/48".to_string(),
                 status: None,
@@ -1847,7 +1966,7 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "10.0.0.0/8".to_string(),
                 name: None,
                 description: None,
@@ -1856,7 +1975,7 @@ mod tests {
             .unwrap();
 
         let err = ops
-            .allocate_auto(&AutoAllocateRequest {
+            .allocate_auto(TEST_TENANT, &AutoAllocateRequest {
                 supernet_id: sn.id.clone(),
                 prefix_length: 33,
                 count: Some(1),
@@ -1887,7 +2006,7 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "2001:db8::/32".to_string(),
                 name: Some("IPv6 Corp".to_string()),
                 description: Some("Test IPv6 supernet".to_string()),
@@ -1905,7 +2024,7 @@ mod tests {
     async fn test_ipv6_supernet_overlap_rejected() {
         let ops = test_ops().await;
 
-        ops.create_supernet(&CreateSupernet {
+        ops.create_supernet(TEST_TENANT, &CreateSupernet {
             cidr: "2001:db8::/32".to_string(),
             name: None,
             description: None,
@@ -1914,7 +2033,7 @@ mod tests {
         .unwrap();
 
         let err = ops
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "2001:db8:1000::/36".to_string(),
                 name: None,
                 description: None,
@@ -1930,7 +2049,7 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "2001:db8::/32".to_string(),
                 name: None,
                 description: None,
@@ -1939,7 +2058,7 @@ mod tests {
             .unwrap();
 
         let alloc = ops
-            .allocate_specific(&CreateAllocation {
+            .allocate_specific(TEST_TENANT, &CreateAllocation {
                 supernet_id: sn.id.clone(),
                 cidr: "2001:db8::/48".to_string(),
                 status: None,
@@ -1966,7 +2085,7 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "2001:db8::/32".to_string(),
                 name: None,
                 description: None,
@@ -1974,7 +2093,7 @@ mod tests {
             .await
             .unwrap();
 
-        ops.allocate_specific(&CreateAllocation {
+        ops.allocate_specific(TEST_TENANT, &CreateAllocation {
             supernet_id: sn.id.clone(),
             cidr: "2001:db8::/48".to_string(),
             status: None,
@@ -1993,7 +2112,7 @@ mod tests {
 
         // Overlapping: /64 within the /48
         let err = ops
-            .allocate_specific(&CreateAllocation {
+            .allocate_specific(TEST_TENANT, &CreateAllocation {
                 supernet_id: sn.id.clone(),
                 cidr: "2001:db8::/64".to_string(),
                 status: None,
@@ -2018,7 +2137,7 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "2001:db8::/32".to_string(),
                 name: None,
                 description: None,
@@ -2027,7 +2146,7 @@ mod tests {
             .unwrap();
 
         // Manually allocate first /48
-        ops.allocate_specific(&CreateAllocation {
+        ops.allocate_specific(TEST_TENANT, &CreateAllocation {
             supernet_id: sn.id.clone(),
             cidr: "2001:db8::/48".to_string(),
             status: None,
@@ -2046,7 +2165,7 @@ mod tests {
 
         // Auto-allocate next 3 /48s
         let allocs = ops
-            .allocate_auto(&AutoAllocateRequest {
+            .allocate_auto(TEST_TENANT, &AutoAllocateRequest {
                 supernet_id: sn.id.clone(),
                 prefix_length: 48,
                 count: Some(3),
@@ -2076,7 +2195,7 @@ mod tests {
 
         // Use a small /126 supernet (4 addresses) for easy math
         let sn = ops
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "2001:db8::/126".to_string(),
                 name: None,
                 description: None,
@@ -2084,7 +2203,7 @@ mod tests {
             .await
             .unwrap();
 
-        ops.allocate_specific(&CreateAllocation {
+        ops.allocate_specific(TEST_TENANT, &CreateAllocation {
             supernet_id: sn.id.clone(),
             cidr: "2001:db8::/127".to_string(),
             status: None,
@@ -2101,7 +2220,7 @@ mod tests {
         .await
         .unwrap();
 
-        let util = ops.utilization(&sn.id).await.unwrap();
+        let util = ops.utilization(TEST_TENANT, &sn.id).await.unwrap();
         assert_eq!(util.total_addresses, 4);
         assert_eq!(util.allocated_addresses, 2);
         assert_eq!(util.free_addresses, 2);
@@ -2113,7 +2232,7 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "2001:db8::/46".to_string(),
                 name: None,
                 description: None,
@@ -2122,7 +2241,7 @@ mod tests {
             .unwrap();
 
         // Allocate the first /48
-        ops.allocate_specific(&CreateAllocation {
+        ops.allocate_specific(TEST_TENANT, &CreateAllocation {
             supernet_id: sn.id.clone(),
             cidr: "2001:db8::/48".to_string(),
             status: None,
@@ -2139,7 +2258,7 @@ mod tests {
         .await
         .unwrap();
 
-        let report = ops.free_blocks(&sn.id, Some(48)).await.unwrap();
+        let report = ops.free_blocks(TEST_TENANT, &sn.id, Some(48)).await.unwrap();
         // /46 has 4 /48s; we allocated 1, so 3 free
         assert_eq!(report.blocks.len(), 3);
         assert_eq!(report.blocks[0].cidr, "2001:db8:1::/48");
@@ -2152,7 +2271,7 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "2001:db8::/32".to_string(),
                 name: None,
                 description: None,
@@ -2160,7 +2279,7 @@ mod tests {
             .await
             .unwrap();
 
-        ops.allocate_specific(&CreateAllocation {
+        ops.allocate_specific(TEST_TENANT, &CreateAllocation {
             supernet_id: sn.id.clone(),
             cidr: "2001:db8:1::/48".to_string(),
             status: None,
@@ -2177,11 +2296,11 @@ mod tests {
         .await
         .unwrap();
 
-        let found = ops.find_by_ip("2001:db8:1::50").await.unwrap();
+        let found = ops.find_by_ip(TEST_TENANT,"2001:db8:1::50").await.unwrap();
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].cidr, "2001:db8:1::/48");
 
-        let not_found = ops.find_by_ip("2001:db8:2::1").await.unwrap();
+        let not_found = ops.find_by_ip(TEST_TENANT,"2001:db8:2::1").await.unwrap();
         assert!(not_found.is_empty());
     }
 
@@ -2190,7 +2309,7 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "2001:db8::/126".to_string(),
                 name: None,
                 description: None,
@@ -2199,7 +2318,7 @@ mod tests {
             .unwrap();
 
         let a1 = ops
-            .allocate_specific(&CreateAllocation {
+            .allocate_specific(TEST_TENANT, &CreateAllocation {
                 supernet_id: sn.id.clone(),
                 cidr: "2001:db8::/127".to_string(),
                 status: None,
@@ -2216,7 +2335,7 @@ mod tests {
             .await
             .unwrap();
 
-        ops.allocate_specific(&CreateAllocation {
+        ops.allocate_specific(TEST_TENANT, &CreateAllocation {
             supernet_id: sn.id.clone(),
             cidr: "2001:db8::2/127".to_string(),
             status: None,
@@ -2234,15 +2353,15 @@ mod tests {
         .unwrap();
 
         // Fully allocated
-        let util = ops.utilization(&sn.id).await.unwrap();
+        let util = ops.utilization(TEST_TENANT, &sn.id).await.unwrap();
         assert!((util.utilization_percent - 100.0).abs() < 0.1);
 
         // Release first block
-        ops.release_allocation(&a1.id).await.unwrap();
+        ops.release_allocation(TEST_TENANT, &a1.id).await.unwrap();
 
         // Auto-allocate should reclaim it
         let allocs = ops
-            .allocate_auto(&AutoAllocateRequest {
+            .allocate_auto(TEST_TENANT, &AutoAllocateRequest {
                 supernet_id: sn.id.clone(),
                 prefix_length: 127,
                 count: Some(1),
@@ -2581,7 +2700,7 @@ mod tests {
 
                     let cidr = format!("10.0.0.0/{}", sn_prefix);
                     let sn = ops_engine
-                        .create_supernet(&CreateSupernet {
+                        .create_supernet(TEST_TENANT, &CreateSupernet {
                             cidr,
                             name: None,
                             description: None,
@@ -2595,7 +2714,7 @@ mod tests {
                         match op {
                             Op::AutoAllocate { prefix } => {
                                 if let Ok(allocs) = ops_engine
-                                    .allocate_auto(&AutoAllocateRequest {
+                                    .allocate_auto(TEST_TENANT, &AutoAllocateRequest {
                                         supernet_id: sn.id.clone(),
                                         prefix_length: *prefix,
                                         count: Some(1),
@@ -2622,7 +2741,7 @@ mod tests {
                                 if !allocation_ids.is_empty() {
                                     // Release the last allocation (deterministic given the sequence)
                                     let id = allocation_ids.pop().unwrap();
-                                    let _ = ops_engine.release_allocation(&id).await;
+                                    let _ = ops_engine.release_allocation(TEST_TENANT, &id).await;
                                 }
                             }
                         }
@@ -2632,6 +2751,7 @@ mod tests {
                     let active = ops_engine
                         .store()
                         .find_allocations_in_supernet(
+                            TEST_TENANT,
                             &sn.id,
                             &[AllocationStatus::Active, AllocationStatus::Reserved],
                         )
@@ -2655,7 +2775,7 @@ mod tests {
                     }
 
                     // Also verify address space conservation
-                    let util = ops_engine.utilization(&sn.id).await.unwrap();
+                    let util = ops_engine.utilization(TEST_TENANT, &sn.id).await.unwrap();
                     assert_eq!(
                         util.allocated_addresses + util.free_addresses,
                         util.total_addresses,
@@ -2692,7 +2812,7 @@ mod tests {
         let ops = test_ops_concurrent(db.to_str().unwrap()).await;
 
         let sn = ops
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "10.0.0.0/16".to_string(),
                 name: Some("concurrent-test".to_string()),
                 description: None,
@@ -2711,7 +2831,7 @@ mod tests {
 
             handles.push(tokio::spawn(async move {
                 barrier.wait().await;
-                ops.allocate_auto(&AutoAllocateRequest {
+                ops.allocate_auto(TEST_TENANT, &AutoAllocateRequest {
                     supernet_id: sn_id,
                     prefix_length: 24,
                     count: Some(1),
@@ -2781,7 +2901,7 @@ mod tests {
         let ops = test_ops_concurrent(db.to_str().unwrap()).await;
 
         let sn = ops
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "10.0.0.0/16".to_string(),
                 name: None,
                 description: None,
@@ -2800,7 +2920,7 @@ mod tests {
 
             handles.push(tokio::spawn(async move {
                 barrier.wait().await;
-                ops.allocate_specific(&CreateAllocation {
+                ops.allocate_specific(TEST_TENANT, &CreateAllocation {
                     supernet_id: sn_id,
                     cidr: "10.0.1.0/24".to_string(),
                     status: None,
@@ -2832,7 +2952,7 @@ mod tests {
         // before either writes, so we might get 2 successes (TOCTOU).
         // But the end state must be consistent: verify via the store.
         let allocs = ops
-            .list_allocations(&AllocationFilter {
+            .list_allocations(TEST_TENANT, &AllocationFilter {
                 supernet_id: Some(sn.id.clone()),
                 ..Default::default()
             })
@@ -2874,7 +2994,7 @@ mod tests {
         let ops = test_ops_concurrent(db.to_str().unwrap()).await;
 
         let sn = ops
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "10.0.0.0/24".to_string(),
                 name: None,
                 description: None,
@@ -2884,7 +3004,7 @@ mod tests {
 
         // Pre-allocate the first /25 block
         let existing = ops
-            .allocate_specific(&CreateAllocation {
+            .allocate_specific(TEST_TENANT, &CreateAllocation {
                 supernet_id: sn.id.clone(),
                 cidr: "10.0.0.0/25".to_string(),
                 status: None,
@@ -2909,7 +3029,7 @@ mod tests {
         let b1 = Arc::clone(&barrier);
         let free_handle = tokio::spawn(async move {
             b1.wait().await;
-            ops1.release_allocation(&alloc_id).await
+            ops1.release_allocation(TEST_TENANT, &alloc_id).await
         });
 
         // Task 2: allocate a new /25 block (the second half, which is always free)
@@ -2918,7 +3038,7 @@ mod tests {
         let b2 = Arc::clone(&barrier);
         let alloc_handle = tokio::spawn(async move {
             b2.wait().await;
-            ops2.allocate_specific(&CreateAllocation {
+            ops2.allocate_specific(TEST_TENANT, &CreateAllocation {
                 supernet_id: sn_id,
                 cidr: "10.0.0.128/25".to_string(),
                 status: None,
@@ -2949,7 +3069,7 @@ mod tests {
 
         // Verify final state: one released, one active
         let all = ops
-            .list_allocations(&AllocationFilter {
+            .list_allocations(TEST_TENANT, &AllocationFilter {
                 supernet_id: Some(sn.id.clone()),
                 ..Default::default()
             })
@@ -2992,7 +3112,7 @@ mod tests {
 
             handles.push(tokio::spawn(async move {
                 barrier.wait().await;
-                ops.create_supernet(&CreateSupernet {
+                ops.create_supernet(TEST_TENANT, &CreateSupernet {
                     cidr,
                     name: None,
                     description: None,
@@ -3012,7 +3132,7 @@ mod tests {
         }
 
         // Verify the supernet list is consistent
-        let supernets = ops.list_supernets().await.unwrap();
+        let supernets = ops.list_supernets(TEST_TENANT).await.unwrap();
 
         if conflict_count > 0 {
             // If a conflict was detected, exactly one should have succeeded
@@ -3031,7 +3151,7 @@ mod tests {
 
         // Regardless of how many succeeded, verify no panics occurred
         // and the store is in a queryable state
-        let list_result = ops.list_supernets().await;
+        let list_result = ops.list_supernets(TEST_TENANT).await;
         assert!(
             list_result.is_ok(),
             "store should remain queryable after concurrent operations"
@@ -3049,7 +3169,7 @@ mod tests {
             supernet_id: None,
         };
 
-        let err = ops.batch_release(&request).await.unwrap_err();
+        let err = ops.batch_release(TEST_TENANT, &request).await.unwrap_err();
         assert!(matches!(err, NetcidrError::InvalidInput(_)));
     }
 
@@ -3061,7 +3181,7 @@ mod tests {
     async fn test_query_audit_rejects_entity_id_with_path_traversal() {
         let ops = test_ops().await;
         let err = ops
-            .query_audit(&AuditFilter {
+            .query_audit(TEST_TENANT, &AuditFilter {
                 entity_id: Some("../etc/passwd".to_string()),
                 ..Default::default()
             })
@@ -3074,7 +3194,7 @@ mod tests {
     async fn test_query_audit_rejects_entity_id_with_null_byte() {
         let ops = test_ops().await;
         let err = ops
-            .query_audit(&AuditFilter {
+            .query_audit(TEST_TENANT, &AuditFilter {
                 entity_id: Some("id\x00injected".to_string()),
                 ..Default::default()
             })
@@ -3087,7 +3207,7 @@ mod tests {
     async fn test_query_audit_rejects_entity_type_with_control_char() {
         let ops = test_ops().await;
         let err = ops
-            .query_audit(&AuditFilter {
+            .query_audit(TEST_TENANT, &AuditFilter {
                 entity_type: Some("supernet\x01injected".to_string()),
                 ..Default::default()
             })
@@ -3100,7 +3220,7 @@ mod tests {
     async fn test_query_audit_rejects_action_with_control_char() {
         let ops = test_ops().await;
         let err = ops
-            .query_audit(&AuditFilter {
+            .query_audit(TEST_TENANT, &AuditFilter {
                 action: Some("create\x07bell".to_string()),
                 ..Default::default()
             })
@@ -3113,7 +3233,7 @@ mod tests {
     async fn test_query_audit_rejects_oversized_entity_type() {
         let ops = test_ops().await;
         let err = ops
-            .query_audit(&AuditFilter {
+            .query_audit(TEST_TENANT, &AuditFilter {
                 entity_type: Some("x".repeat(1025)),
                 ..Default::default()
             })
@@ -3127,7 +3247,7 @@ mod tests {
         let ops = test_ops().await;
         // No entries, but valid filter should not error.
         let entries = ops
-            .query_audit(&AuditFilter {
+            .query_audit(TEST_TENANT, &AuditFilter {
                 entity_type: Some("supernet".to_string()),
                 entity_id: Some("sn-abc123".to_string()),
                 action: Some("create_supernet".to_string()),

--- a/src/ipam/operations.rs
+++ b/src/ipam/operations.rs
@@ -123,7 +123,10 @@ impl IpamOps {
         let lock = self.supernet_lock(&input.supernet_id);
         let _guard = lock.lock().await;
 
-        let supernet = self.store.get_supernet(tenant_id, &input.supernet_id).await?;
+        let supernet = self
+            .store
+            .get_supernet(tenant_id, &input.supernet_id)
+            .await?;
         let supernet_range = parse_range(&supernet.cidr)?;
         let candidate_range = parse_range(&input.cidr)?;
 
@@ -221,7 +224,10 @@ impl IpamOps {
         let lock = self.supernet_lock(&request.supernet_id);
         let _guard = lock.lock().await;
 
-        let supernet = self.store.get_supernet(tenant_id, &request.supernet_id).await?;
+        let supernet = self
+            .store
+            .get_supernet(tenant_id, &request.supernet_id)
+            .await?;
         let supernet_range = parse_range(&supernet.cidr)?;
         let count = request.count.unwrap_or(1);
 
@@ -345,7 +351,8 @@ impl IpamOps {
         }
 
         let alloc = self.store.update_allocation(tenant_id, id, input).await?;
-        self.audit(tenant_id, "update", "allocation", id, None).await?;
+        self.audit(tenant_id, "update", "allocation", id, None)
+            .await?;
         Ok(alloc)
     }
 
@@ -359,14 +366,8 @@ impl IpamOps {
         let _guard = lock.lock().await;
 
         let alloc = self.store.release_allocation(tenant_id, id).await?;
-        self.audit(
-            tenant_id,
-            "release",
-            "allocation",
-            id,
-            Some(&alloc.cidr),
-        )
-        .await?;
+        self.audit(tenant_id, "release", "allocation", id, Some(&alloc.cidr))
+            .await?;
         Ok(alloc)
     }
 
@@ -396,11 +397,7 @@ impl IpamOps {
         // Fetch released allocations for the breakdown
         let released = self
             .store
-            .find_allocations_in_supernet(
-                tenant_id,
-                supernet_id,
-                &[AllocationStatus::Released],
-            )
+            .find_allocations_in_supernet(tenant_id, supernet_id, &[AllocationStatus::Released])
             .await?;
 
         let mut active_addresses: u128 = 0;
@@ -745,11 +742,7 @@ impl IpamOps {
             // All active allocations in a supernet
             let allocs = self
                 .store
-                .find_allocations_in_supernet(
-                    tenant_id,
-                    supernet_id,
-                    &[AllocationStatus::Active],
-                )
+                .find_allocations_in_supernet(tenant_id, supernet_id, &[AllocationStatus::Active])
                 .await?;
             allocs.into_iter().map(|a| (a.id, a.cidr)).collect()
         } else {
@@ -951,21 +944,21 @@ impl IpamOps {
                     tenant_id,
                     &CreateAllocation {
                         supernet_id: new_sn_id.to_string(),
-                    cidr: alloc.cidr.clone(),
-                    status: Some(alloc.status.clone()),
-                    resource_id: alloc.resource_id.clone(),
-                    resource_type: alloc.resource_type.clone(),
-                    name: alloc.name.clone(),
-                    description: alloc.description.clone(),
-                    environment: alloc.environment.clone(),
-                    owner: alloc.owner.clone(),
-                    parent_allocation_id: None,
-                    tags: if alloc.tags.is_empty() {
-                        None
-                    } else {
-                        Some(alloc.tags.clone())
-                    },
-                    ttl_seconds: None,
+                        cidr: alloc.cidr.clone(),
+                        status: Some(alloc.status.clone()),
+                        resource_id: alloc.resource_id.clone(),
+                        resource_type: alloc.resource_type.clone(),
+                        name: alloc.name.clone(),
+                        description: alloc.description.clone(),
+                        environment: alloc.environment.clone(),
+                        owner: alloc.owner.clone(),
+                        parent_allocation_id: None,
+                        tags: if alloc.tags.is_empty() {
+                            None
+                        } else {
+                            Some(alloc.tags.clone())
+                        },
+                        ttl_seconds: None,
                     },
                 )
                 .await?;
@@ -979,12 +972,7 @@ impl IpamOps {
     // Tags
     // -----------------------------------------------------------------------
 
-    pub async fn set_tags(
-        &self,
-        tenant_id: &str,
-        allocation_id: &str,
-        tags: &[Tag],
-    ) -> Result<()> {
+    pub async fn set_tags(&self, tenant_id: &str, allocation_id: &str, tags: &[Tag]) -> Result<()> {
         validation::validate_identifier(allocation_id)?;
         for tag in tags {
             validation::validate_text_field(&tag.key, 0)?;
@@ -1308,20 +1296,26 @@ mod tests {
     async fn test_create_supernet_overlap_rejected() {
         let ops = test_ops().await;
 
-        ops.create_supernet(TEST_TENANT, &CreateSupernet {
-            cidr: "10.0.0.0/8".to_string(),
-            name: None,
-            description: None,
-        })
+        ops.create_supernet(
+            TEST_TENANT,
+            &CreateSupernet {
+                cidr: "10.0.0.0/8".to_string(),
+                name: None,
+                description: None,
+            },
+        )
         .await
         .unwrap();
 
         let err = ops
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "10.128.0.0/9".to_string(),
-                name: None,
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "10.128.0.0/9".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
             .await
             .unwrap_err();
 
@@ -1333,16 +1327,85 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "10.0.0.0/8".to_string(),
-                name: None,
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "10.0.0.0/8".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
         let a1 = ops
-            .allocate_specific(TEST_TENANT, &CreateAllocation {
+            .allocate_specific(
+                TEST_TENANT,
+                &CreateAllocation {
+                    supernet_id: sn.id.clone(),
+                    cidr: "10.0.0.0/24".to_string(),
+                    status: None,
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(a1.cidr, "10.0.0.0/24");
+
+        // Overlapping allocation should fail
+        let err = ops
+            .allocate_specific(
+                TEST_TENANT,
+                &CreateAllocation {
+                    supernet_id: sn.id.clone(),
+                    cidr: "10.0.0.128/25".to_string(),
+                    status: None,
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: None,
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, NetcidrError::AllocationConflict { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_auto_allocate() {
+        let ops = test_ops().await;
+
+        let sn = ops
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "10.0.0.0/16".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Allocate first /24
+        ops.allocate_specific(
+            TEST_TENANT,
+            &CreateAllocation {
                 supernet_id: sn.id.clone(),
                 cidr: "10.0.0.0/24".to_string(),
                 status: None,
@@ -1355,82 +1418,31 @@ mod tests {
                 parent_allocation_id: None,
                 tags: None,
                 ttl_seconds: None,
-            })
-            .await
-            .unwrap();
-
-        assert_eq!(a1.cidr, "10.0.0.0/24");
-
-        // Overlapping allocation should fail
-        let err = ops
-            .allocate_specific(TEST_TENANT, &CreateAllocation {
-                supernet_id: sn.id.clone(),
-                cidr: "10.0.0.128/25".to_string(),
-                status: None,
-                resource_id: None,
-                resource_type: None,
-                name: None,
-                description: None,
-                environment: None,
-                owner: None,
-                parent_allocation_id: None,
-                tags: None,
-                ttl_seconds: None,
-            })
-            .await
-            .unwrap_err();
-
-        assert!(matches!(err, NetcidrError::AllocationConflict { .. }));
-    }
-
-    #[tokio::test]
-    async fn test_auto_allocate() {
-        let ops = test_ops().await;
-
-        let sn = ops
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "10.0.0.0/16".to_string(),
-                name: None,
-                description: None,
-            })
-            .await
-            .unwrap();
-
-        // Allocate first /24
-        ops.allocate_specific(TEST_TENANT, &CreateAllocation {
-            supernet_id: sn.id.clone(),
-            cidr: "10.0.0.0/24".to_string(),
-            status: None,
-            resource_id: None,
-            resource_type: None,
-            name: None,
-            description: None,
-            environment: None,
-            owner: None,
-            parent_allocation_id: None,
-            tags: None,
-            ttl_seconds: None,
-        })
+            },
+        )
         .await
         .unwrap();
 
         // Auto-allocate next 3 /24s
         let allocs = ops
-            .allocate_auto(TEST_TENANT, &AutoAllocateRequest {
-                supernet_id: sn.id.clone(),
-                prefix_length: 24,
-                count: Some(3),
-                status: None,
-                resource_id: None,
-                resource_type: None,
-                name: None,
-                description: None,
-                environment: None,
-                owner: None,
-                parent_allocation_id: None,
-                tags: None,
-                ttl_seconds: None,
-            })
+            .allocate_auto(
+                TEST_TENANT,
+                &AutoAllocateRequest {
+                    supernet_id: sn.id.clone(),
+                    prefix_length: 24,
+                    count: Some(3),
+                    status: None,
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: None,
+                },
+            )
             .await
             .unwrap();
 
@@ -1445,28 +1457,34 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "10.0.0.0/24".to_string(),
-                name: None,
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "10.0.0.0/24".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
-        ops.allocate_specific(TEST_TENANT, &CreateAllocation {
-            supernet_id: sn.id.clone(),
-            cidr: "10.0.0.0/25".to_string(),
-            status: None,
-            resource_id: None,
-            resource_type: None,
-            name: None,
-            description: None,
-            environment: None,
-            owner: None,
-            parent_allocation_id: None,
-            tags: None,
-            ttl_seconds: None,
-        })
+        ops.allocate_specific(
+            TEST_TENANT,
+            &CreateAllocation {
+                supernet_id: sn.id.clone(),
+                cidr: "10.0.0.0/25".to_string(),
+                status: None,
+                resource_id: None,
+                resource_type: None,
+                name: None,
+                description: None,
+                environment: None,
+                owner: None,
+                parent_allocation_id: None,
+                tags: None,
+                ttl_seconds: None,
+            },
+        )
         .await
         .unwrap();
 
@@ -1488,28 +1506,34 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "10.0.0.0/24".to_string(),
-                name: None,
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "10.0.0.0/24".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
-        ops.allocate_specific(TEST_TENANT, &CreateAllocation {
-            supernet_id: sn.id.clone(),
-            cidr: "10.0.0.0/25".to_string(),
-            status: None,
-            resource_id: None,
-            resource_type: None,
-            name: None,
-            description: None,
-            environment: None,
-            owner: None,
-            parent_allocation_id: None,
-            tags: None,
-            ttl_seconds: None,
-        })
+        ops.allocate_specific(
+            TEST_TENANT,
+            &CreateAllocation {
+                supernet_id: sn.id.clone(),
+                cidr: "10.0.0.0/25".to_string(),
+                status: None,
+                resource_id: None,
+                resource_type: None,
+                name: None,
+                description: None,
+                environment: None,
+                owner: None,
+                parent_allocation_id: None,
+                tags: None,
+                ttl_seconds: None,
+            },
+        )
         .await
         .unwrap();
 
@@ -1524,56 +1548,22 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "10.0.0.0/8".to_string(),
-                name: None,
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "10.0.0.0/8".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
-        ops.allocate_specific(TEST_TENANT, &CreateAllocation {
-            supernet_id: sn.id.clone(),
-            cidr: "10.0.1.0/24".to_string(),
-            status: None,
-            resource_id: None,
-            resource_type: None,
-            name: None,
-            description: None,
-            environment: None,
-            owner: None,
-            parent_allocation_id: None,
-            tags: None,
-            ttl_seconds: None,
-        })
-        .await
-        .unwrap();
-
-        let found = ops.find_by_ip(TEST_TENANT,"10.0.1.50").await.unwrap();
-        assert_eq!(found.len(), 1);
-        assert_eq!(found[0].cidr, "10.0.1.0/24");
-
-        let not_found = ops.find_by_ip(TEST_TENANT,"10.0.2.50").await.unwrap();
-        assert!(not_found.is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_release_frees_space() {
-        let ops = test_ops().await;
-
-        let sn = ops
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "10.0.0.0/24".to_string(),
-                name: None,
-                description: None,
-            })
-            .await
-            .unwrap();
-
-        let a1 = ops
-            .allocate_specific(TEST_TENANT, &CreateAllocation {
+        ops.allocate_specific(
+            TEST_TENANT,
+            &CreateAllocation {
                 supernet_id: sn.id.clone(),
-                cidr: "10.0.0.0/25".to_string(),
+                cidr: "10.0.1.0/24".to_string(),
                 status: None,
                 resource_id: None,
                 resource_type: None,
@@ -1584,24 +1574,73 @@ mod tests {
                 parent_allocation_id: None,
                 tags: None,
                 ttl_seconds: None,
-            })
+            },
+        )
+        .await
+        .unwrap();
+
+        let found = ops.find_by_ip(TEST_TENANT, "10.0.1.50").await.unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].cidr, "10.0.1.0/24");
+
+        let not_found = ops.find_by_ip(TEST_TENANT, "10.0.2.50").await.unwrap();
+        assert!(not_found.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_release_frees_space() {
+        let ops = test_ops().await;
+
+        let sn = ops
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "10.0.0.0/24".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
-        ops.allocate_specific(TEST_TENANT, &CreateAllocation {
-            supernet_id: sn.id.clone(),
-            cidr: "10.0.0.128/25".to_string(),
-            status: None,
-            resource_id: None,
-            resource_type: None,
-            name: None,
-            description: None,
-            environment: None,
-            owner: None,
-            parent_allocation_id: None,
-            tags: None,
-            ttl_seconds: None,
-        })
+        let a1 = ops
+            .allocate_specific(
+                TEST_TENANT,
+                &CreateAllocation {
+                    supernet_id: sn.id.clone(),
+                    cidr: "10.0.0.0/25".to_string(),
+                    status: None,
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        ops.allocate_specific(
+            TEST_TENANT,
+            &CreateAllocation {
+                supernet_id: sn.id.clone(),
+                cidr: "10.0.0.128/25".to_string(),
+                status: None,
+                resource_id: None,
+                resource_type: None,
+                name: None,
+                description: None,
+                environment: None,
+                owner: None,
+                parent_allocation_id: None,
+                tags: None,
+                ttl_seconds: None,
+            },
+        )
         .await
         .unwrap();
 
@@ -1614,21 +1653,24 @@ mod tests {
 
         // Now auto-allocate should find the freed space
         let allocs = ops
-            .allocate_auto(TEST_TENANT, &AutoAllocateRequest {
-                supernet_id: sn.id.clone(),
-                prefix_length: 25,
-                count: Some(1),
-                status: None,
-                resource_id: None,
-                resource_type: None,
-                name: None,
-                description: None,
-                environment: None,
-                owner: None,
-                parent_allocation_id: None,
-                tags: None,
-                ttl_seconds: None,
-            })
+            .allocate_auto(
+                TEST_TENANT,
+                &AutoAllocateRequest {
+                    supernet_id: sn.id.clone(),
+                    prefix_length: 25,
+                    count: Some(1),
+                    status: None,
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: None,
+                },
+            )
             .await
             .unwrap();
 
@@ -1641,20 +1683,46 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "10.0.0.0/24".to_string(),
-                name: None,
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "10.0.0.0/24".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
         // Active allocation
         let a1 = ops
-            .allocate_specific(TEST_TENANT, &CreateAllocation {
+            .allocate_specific(
+                TEST_TENANT,
+                &CreateAllocation {
+                    supernet_id: sn.id.clone(),
+                    cidr: "10.0.0.0/26".to_string(),
+                    status: None,
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Reserved allocation
+        ops.allocate_specific(
+            TEST_TENANT,
+            &CreateAllocation {
                 supernet_id: sn.id.clone(),
-                cidr: "10.0.0.0/26".to_string(),
-                status: None,
+                cidr: "10.0.0.64/26".to_string(),
+                status: Some(AllocationStatus::Reserved),
                 resource_id: None,
                 resource_type: None,
                 name: None,
@@ -1664,25 +1732,8 @@ mod tests {
                 parent_allocation_id: None,
                 tags: None,
                 ttl_seconds: None,
-            })
-            .await
-            .unwrap();
-
-        // Reserved allocation
-        ops.allocate_specific(TEST_TENANT, &CreateAllocation {
-            supernet_id: sn.id.clone(),
-            cidr: "10.0.0.64/26".to_string(),
-            status: Some(AllocationStatus::Reserved),
-            resource_id: None,
-            resource_type: None,
-            name: None,
-            description: None,
-            environment: None,
-            owner: None,
-            parent_allocation_id: None,
-            tags: None,
-            ttl_seconds: None,
-        })
+            },
+        )
         .await
         .unwrap();
 
@@ -1706,30 +1757,36 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "10.0.0.0/24".to_string(),
-                name: None,
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "10.0.0.0/24".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
         // Allocate with TTL of 0 seconds (already expired)
         let alloc = ops
-            .allocate_specific(TEST_TENANT, &CreateAllocation {
-                supernet_id: sn.id.clone(),
-                cidr: "10.0.0.0/25".to_string(),
-                status: None,
-                resource_id: None,
-                resource_type: None,
-                name: None,
-                description: None,
-                environment: None,
-                owner: None,
-                parent_allocation_id: None,
-                tags: None,
-                ttl_seconds: Some(0),
-            })
+            .allocate_specific(
+                TEST_TENANT,
+                &CreateAllocation {
+                    supernet_id: sn.id.clone(),
+                    cidr: "10.0.0.0/25".to_string(),
+                    status: None,
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: Some(0),
+                },
+            )
             .await
             .unwrap();
 
@@ -1753,28 +1810,34 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "10.0.0.0/8".to_string(),
-                name: Some("Corp".to_string()),
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "10.0.0.0/8".to_string(),
+                    name: Some("Corp".to_string()),
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
-        ops.allocate_specific(TEST_TENANT, &CreateAllocation {
-            supernet_id: sn.id.clone(),
-            cidr: "10.0.0.0/24".to_string(),
-            status: None,
-            resource_id: Some("vpc-1".to_string()),
-            resource_type: None,
-            name: Some("web".to_string()),
-            description: None,
-            environment: None,
-            owner: None,
-            parent_allocation_id: None,
-            tags: None,
-            ttl_seconds: None,
-        })
+        ops.allocate_specific(
+            TEST_TENANT,
+            &CreateAllocation {
+                supernet_id: sn.id.clone(),
+                cidr: "10.0.0.0/24".to_string(),
+                status: None,
+                resource_id: Some("vpc-1".to_string()),
+                resource_type: None,
+                name: Some("web".to_string()),
+                description: None,
+                environment: None,
+                owner: None,
+                parent_allocation_id: None,
+                tags: None,
+                ttl_seconds: None,
+            },
+        )
         .await
         .unwrap();
 
@@ -1812,11 +1875,14 @@ mod tests {
     async fn test_load_rejects_non_empty_store() {
         let ops = test_ops().await;
 
-        ops.create_supernet(TEST_TENANT, &CreateSupernet {
-            cidr: "10.0.0.0/8".to_string(),
-            name: None,
-            description: None,
-        })
+        ops.create_supernet(
+            TEST_TENANT,
+            &CreateSupernet {
+                cidr: "10.0.0.0/8".to_string(),
+                name: None,
+                description: None,
+            },
+        )
         .await
         .unwrap();
 
@@ -1895,30 +1961,36 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "2001:db8::/32".to_string(),
-                name: None,
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "2001:db8::/32".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
         // Try to allocate an IPv4 CIDR in an IPv6 supernet
         let err = ops
-            .allocate_specific(TEST_TENANT, &CreateAllocation {
-                supernet_id: sn.id.clone(),
-                cidr: "10.0.0.0/24".to_string(),
-                status: None,
-                resource_id: None,
-                resource_type: None,
-                name: None,
-                description: None,
-                environment: None,
-                owner: None,
-                parent_allocation_id: None,
-                tags: None,
-                ttl_seconds: None,
-            })
+            .allocate_specific(
+                TEST_TENANT,
+                &CreateAllocation {
+                    supernet_id: sn.id.clone(),
+                    cidr: "10.0.0.0/24".to_string(),
+                    status: None,
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: None,
+                },
+            )
             .await
             .unwrap_err();
 
@@ -1932,29 +2004,35 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "10.0.0.0/8".to_string(),
-                name: None,
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "10.0.0.0/8".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
         let err = ops
-            .allocate_specific(TEST_TENANT, &CreateAllocation {
-                supernet_id: sn.id.clone(),
-                cidr: "2001:db8::/48".to_string(),
-                status: None,
-                resource_id: None,
-                resource_type: None,
-                name: None,
-                description: None,
-                environment: None,
-                owner: None,
-                parent_allocation_id: None,
-                tags: None,
-                ttl_seconds: None,
-            })
+            .allocate_specific(
+                TEST_TENANT,
+                &CreateAllocation {
+                    supernet_id: sn.id.clone(),
+                    cidr: "2001:db8::/48".to_string(),
+                    status: None,
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: None,
+                },
+            )
             .await
             .unwrap_err();
 
@@ -1966,30 +2044,36 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "10.0.0.0/8".to_string(),
-                name: None,
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "10.0.0.0/8".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
         let err = ops
-            .allocate_auto(TEST_TENANT, &AutoAllocateRequest {
-                supernet_id: sn.id.clone(),
-                prefix_length: 33,
-                count: Some(1),
-                status: None,
-                resource_id: None,
-                resource_type: None,
-                name: None,
-                description: None,
-                environment: None,
-                owner: None,
-                parent_allocation_id: None,
-                tags: None,
-                ttl_seconds: None,
-            })
+            .allocate_auto(
+                TEST_TENANT,
+                &AutoAllocateRequest {
+                    supernet_id: sn.id.clone(),
+                    prefix_length: 33,
+                    count: Some(1),
+                    status: None,
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: None,
+                },
+            )
             .await
             .unwrap_err();
 
@@ -2006,11 +2090,14 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "2001:db8::/32".to_string(),
-                name: Some("IPv6 Corp".to_string()),
-                description: Some("Test IPv6 supernet".to_string()),
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "2001:db8::/32".to_string(),
+                    name: Some("IPv6 Corp".to_string()),
+                    description: Some("Test IPv6 supernet".to_string()),
+                },
+            )
             .await
             .unwrap();
 
@@ -2024,20 +2111,26 @@ mod tests {
     async fn test_ipv6_supernet_overlap_rejected() {
         let ops = test_ops().await;
 
-        ops.create_supernet(TEST_TENANT, &CreateSupernet {
-            cidr: "2001:db8::/32".to_string(),
-            name: None,
-            description: None,
-        })
+        ops.create_supernet(
+            TEST_TENANT,
+            &CreateSupernet {
+                cidr: "2001:db8::/32".to_string(),
+                name: None,
+                description: None,
+            },
+        )
         .await
         .unwrap();
 
         let err = ops
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "2001:db8:1000::/36".to_string(),
-                name: None,
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "2001:db8:1000::/36".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
             .await
             .unwrap_err();
 
@@ -2049,29 +2142,35 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "2001:db8::/32".to_string(),
-                name: None,
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "2001:db8::/32".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
         let alloc = ops
-            .allocate_specific(TEST_TENANT, &CreateAllocation {
-                supernet_id: sn.id.clone(),
-                cidr: "2001:db8::/48".to_string(),
-                status: None,
-                resource_id: Some("vpc-v6".to_string()),
-                resource_type: None,
-                name: Some("web-v6".to_string()),
-                description: None,
-                environment: Some("prod".to_string()),
-                owner: None,
-                parent_allocation_id: None,
-                tags: None,
-                ttl_seconds: None,
-            })
+            .allocate_specific(
+                TEST_TENANT,
+                &CreateAllocation {
+                    supernet_id: sn.id.clone(),
+                    cidr: "2001:db8::/48".to_string(),
+                    status: None,
+                    resource_id: Some("vpc-v6".to_string()),
+                    resource_type: None,
+                    name: Some("web-v6".to_string()),
+                    description: None,
+                    environment: Some("prod".to_string()),
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: None,
+                },
+            )
             .await
             .unwrap();
 
@@ -2085,36 +2184,22 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "2001:db8::/32".to_string(),
-                name: None,
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "2001:db8::/32".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
-        ops.allocate_specific(TEST_TENANT, &CreateAllocation {
-            supernet_id: sn.id.clone(),
-            cidr: "2001:db8::/48".to_string(),
-            status: None,
-            resource_id: None,
-            resource_type: None,
-            name: None,
-            description: None,
-            environment: None,
-            owner: None,
-            parent_allocation_id: None,
-            tags: None,
-            ttl_seconds: None,
-        })
-        .await
-        .unwrap();
-
-        // Overlapping: /64 within the /48
-        let err = ops
-            .allocate_specific(TEST_TENANT, &CreateAllocation {
+        ops.allocate_specific(
+            TEST_TENANT,
+            &CreateAllocation {
                 supernet_id: sn.id.clone(),
-                cidr: "2001:db8::/64".to_string(),
+                cidr: "2001:db8::/48".to_string(),
                 status: None,
                 resource_id: None,
                 resource_type: None,
@@ -2125,7 +2210,30 @@ mod tests {
                 parent_allocation_id: None,
                 tags: None,
                 ttl_seconds: None,
-            })
+            },
+        )
+        .await
+        .unwrap();
+
+        // Overlapping: /64 within the /48
+        let err = ops
+            .allocate_specific(
+                TEST_TENANT,
+                &CreateAllocation {
+                    supernet_id: sn.id.clone(),
+                    cidr: "2001:db8::/64".to_string(),
+                    status: None,
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: None,
+                },
+            )
             .await
             .unwrap_err();
 
@@ -2137,38 +2245,23 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "2001:db8::/32".to_string(),
-                name: None,
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "2001:db8::/32".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
         // Manually allocate first /48
-        ops.allocate_specific(TEST_TENANT, &CreateAllocation {
-            supernet_id: sn.id.clone(),
-            cidr: "2001:db8::/48".to_string(),
-            status: None,
-            resource_id: None,
-            resource_type: None,
-            name: None,
-            description: None,
-            environment: None,
-            owner: None,
-            parent_allocation_id: None,
-            tags: None,
-            ttl_seconds: None,
-        })
-        .await
-        .unwrap();
-
-        // Auto-allocate next 3 /48s
-        let allocs = ops
-            .allocate_auto(TEST_TENANT, &AutoAllocateRequest {
+        ops.allocate_specific(
+            TEST_TENANT,
+            &CreateAllocation {
                 supernet_id: sn.id.clone(),
-                prefix_length: 48,
-                count: Some(3),
+                cidr: "2001:db8::/48".to_string(),
                 status: None,
                 resource_id: None,
                 resource_type: None,
@@ -2179,7 +2272,31 @@ mod tests {
                 parent_allocation_id: None,
                 tags: None,
                 ttl_seconds: None,
-            })
+            },
+        )
+        .await
+        .unwrap();
+
+        // Auto-allocate next 3 /48s
+        let allocs = ops
+            .allocate_auto(
+                TEST_TENANT,
+                &AutoAllocateRequest {
+                    supernet_id: sn.id.clone(),
+                    prefix_length: 48,
+                    count: Some(3),
+                    status: None,
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: None,
+                },
+            )
             .await
             .unwrap();
 
@@ -2195,28 +2312,34 @@ mod tests {
 
         // Use a small /126 supernet (4 addresses) for easy math
         let sn = ops
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "2001:db8::/126".to_string(),
-                name: None,
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "2001:db8::/126".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
-        ops.allocate_specific(TEST_TENANT, &CreateAllocation {
-            supernet_id: sn.id.clone(),
-            cidr: "2001:db8::/127".to_string(),
-            status: None,
-            resource_id: None,
-            resource_type: None,
-            name: None,
-            description: None,
-            environment: None,
-            owner: None,
-            parent_allocation_id: None,
-            tags: None,
-            ttl_seconds: None,
-        })
+        ops.allocate_specific(
+            TEST_TENANT,
+            &CreateAllocation {
+                supernet_id: sn.id.clone(),
+                cidr: "2001:db8::/127".to_string(),
+                status: None,
+                resource_id: None,
+                resource_type: None,
+                name: None,
+                description: None,
+                environment: None,
+                owner: None,
+                parent_allocation_id: None,
+                tags: None,
+                ttl_seconds: None,
+            },
+        )
         .await
         .unwrap();
 
@@ -2232,33 +2355,42 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "2001:db8::/46".to_string(),
-                name: None,
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "2001:db8::/46".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
         // Allocate the first /48
-        ops.allocate_specific(TEST_TENANT, &CreateAllocation {
-            supernet_id: sn.id.clone(),
-            cidr: "2001:db8::/48".to_string(),
-            status: None,
-            resource_id: None,
-            resource_type: None,
-            name: None,
-            description: None,
-            environment: None,
-            owner: None,
-            parent_allocation_id: None,
-            tags: None,
-            ttl_seconds: None,
-        })
+        ops.allocate_specific(
+            TEST_TENANT,
+            &CreateAllocation {
+                supernet_id: sn.id.clone(),
+                cidr: "2001:db8::/48".to_string(),
+                status: None,
+                resource_id: None,
+                resource_type: None,
+                name: None,
+                description: None,
+                environment: None,
+                owner: None,
+                parent_allocation_id: None,
+                tags: None,
+                ttl_seconds: None,
+            },
+        )
         .await
         .unwrap();
 
-        let report = ops.free_blocks(TEST_TENANT, &sn.id, Some(48)).await.unwrap();
+        let report = ops
+            .free_blocks(TEST_TENANT, &sn.id, Some(48))
+            .await
+            .unwrap();
         // /46 has 4 /48s; we allocated 1, so 3 free
         assert_eq!(report.blocks.len(), 3);
         assert_eq!(report.blocks[0].cidr, "2001:db8:1::/48");
@@ -2271,56 +2403,22 @@ mod tests {
         let ops = test_ops().await;
 
         let sn = ops
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "2001:db8::/32".to_string(),
-                name: None,
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "2001:db8::/32".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
-        ops.allocate_specific(TEST_TENANT, &CreateAllocation {
-            supernet_id: sn.id.clone(),
-            cidr: "2001:db8:1::/48".to_string(),
-            status: None,
-            resource_id: None,
-            resource_type: None,
-            name: None,
-            description: None,
-            environment: None,
-            owner: None,
-            parent_allocation_id: None,
-            tags: None,
-            ttl_seconds: None,
-        })
-        .await
-        .unwrap();
-
-        let found = ops.find_by_ip(TEST_TENANT,"2001:db8:1::50").await.unwrap();
-        assert_eq!(found.len(), 1);
-        assert_eq!(found[0].cidr, "2001:db8:1::/48");
-
-        let not_found = ops.find_by_ip(TEST_TENANT,"2001:db8:2::1").await.unwrap();
-        assert!(not_found.is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_ipv6_release_frees_space() {
-        let ops = test_ops().await;
-
-        let sn = ops
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "2001:db8::/126".to_string(),
-                name: None,
-                description: None,
-            })
-            .await
-            .unwrap();
-
-        let a1 = ops
-            .allocate_specific(TEST_TENANT, &CreateAllocation {
+        ops.allocate_specific(
+            TEST_TENANT,
+            &CreateAllocation {
                 supernet_id: sn.id.clone(),
-                cidr: "2001:db8::/127".to_string(),
+                cidr: "2001:db8:1::/48".to_string(),
                 status: None,
                 resource_id: None,
                 resource_type: None,
@@ -2331,24 +2429,73 @@ mod tests {
                 parent_allocation_id: None,
                 tags: None,
                 ttl_seconds: None,
-            })
+            },
+        )
+        .await
+        .unwrap();
+
+        let found = ops.find_by_ip(TEST_TENANT, "2001:db8:1::50").await.unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].cidr, "2001:db8:1::/48");
+
+        let not_found = ops.find_by_ip(TEST_TENANT, "2001:db8:2::1").await.unwrap();
+        assert!(not_found.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_ipv6_release_frees_space() {
+        let ops = test_ops().await;
+
+        let sn = ops
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "2001:db8::/126".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
-        ops.allocate_specific(TEST_TENANT, &CreateAllocation {
-            supernet_id: sn.id.clone(),
-            cidr: "2001:db8::2/127".to_string(),
-            status: None,
-            resource_id: None,
-            resource_type: None,
-            name: None,
-            description: None,
-            environment: None,
-            owner: None,
-            parent_allocation_id: None,
-            tags: None,
-            ttl_seconds: None,
-        })
+        let a1 = ops
+            .allocate_specific(
+                TEST_TENANT,
+                &CreateAllocation {
+                    supernet_id: sn.id.clone(),
+                    cidr: "2001:db8::/127".to_string(),
+                    status: None,
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        ops.allocate_specific(
+            TEST_TENANT,
+            &CreateAllocation {
+                supernet_id: sn.id.clone(),
+                cidr: "2001:db8::2/127".to_string(),
+                status: None,
+                resource_id: None,
+                resource_type: None,
+                name: None,
+                description: None,
+                environment: None,
+                owner: None,
+                parent_allocation_id: None,
+                tags: None,
+                ttl_seconds: None,
+            },
+        )
         .await
         .unwrap();
 
@@ -2361,21 +2508,24 @@ mod tests {
 
         // Auto-allocate should reclaim it
         let allocs = ops
-            .allocate_auto(TEST_TENANT, &AutoAllocateRequest {
-                supernet_id: sn.id.clone(),
-                prefix_length: 127,
-                count: Some(1),
-                status: None,
-                resource_id: None,
-                resource_type: None,
-                name: None,
-                description: None,
-                environment: None,
-                owner: None,
-                parent_allocation_id: None,
-                tags: None,
-                ttl_seconds: None,
-            })
+            .allocate_auto(
+                TEST_TENANT,
+                &AutoAllocateRequest {
+                    supernet_id: sn.id.clone(),
+                    prefix_length: 127,
+                    count: Some(1),
+                    status: None,
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: None,
+                },
+            )
             .await
             .unwrap();
 
@@ -2812,11 +2962,14 @@ mod tests {
         let ops = test_ops_concurrent(db.to_str().unwrap()).await;
 
         let sn = ops
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "10.0.0.0/16".to_string(),
-                name: Some("concurrent-test".to_string()),
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "10.0.0.0/16".to_string(),
+                    name: Some("concurrent-test".to_string()),
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
@@ -2831,21 +2984,24 @@ mod tests {
 
             handles.push(tokio::spawn(async move {
                 barrier.wait().await;
-                ops.allocate_auto(TEST_TENANT, &AutoAllocateRequest {
-                    supernet_id: sn_id,
-                    prefix_length: 24,
-                    count: Some(1),
-                    status: None,
-                    resource_id: None,
-                    resource_type: None,
-                    name: None,
-                    description: None,
-                    environment: None,
-                    owner: None,
-                    parent_allocation_id: None,
-                    tags: None,
-                    ttl_seconds: None,
-                })
+                ops.allocate_auto(
+                    TEST_TENANT,
+                    &AutoAllocateRequest {
+                        supernet_id: sn_id,
+                        prefix_length: 24,
+                        count: Some(1),
+                        status: None,
+                        resource_id: None,
+                        resource_type: None,
+                        name: None,
+                        description: None,
+                        environment: None,
+                        owner: None,
+                        parent_allocation_id: None,
+                        tags: None,
+                        ttl_seconds: None,
+                    },
+                )
                 .await
             }));
         }
@@ -2901,11 +3057,14 @@ mod tests {
         let ops = test_ops_concurrent(db.to_str().unwrap()).await;
 
         let sn = ops
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "10.0.0.0/16".to_string(),
-                name: None,
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "10.0.0.0/16".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
@@ -2920,20 +3079,23 @@ mod tests {
 
             handles.push(tokio::spawn(async move {
                 barrier.wait().await;
-                ops.allocate_specific(TEST_TENANT, &CreateAllocation {
-                    supernet_id: sn_id,
-                    cidr: "10.0.1.0/24".to_string(),
-                    status: None,
-                    resource_id: None,
-                    resource_type: None,
-                    name: None,
-                    description: None,
-                    environment: None,
-                    owner: None,
-                    parent_allocation_id: None,
-                    tags: None,
-                    ttl_seconds: None,
-                })
+                ops.allocate_specific(
+                    TEST_TENANT,
+                    &CreateAllocation {
+                        supernet_id: sn_id,
+                        cidr: "10.0.1.0/24".to_string(),
+                        status: None,
+                        resource_id: None,
+                        resource_type: None,
+                        name: None,
+                        description: None,
+                        environment: None,
+                        owner: None,
+                        parent_allocation_id: None,
+                        tags: None,
+                        ttl_seconds: None,
+                    },
+                )
                 .await
             }));
         }
@@ -2952,10 +3114,13 @@ mod tests {
         // before either writes, so we might get 2 successes (TOCTOU).
         // But the end state must be consistent: verify via the store.
         let allocs = ops
-            .list_allocations(TEST_TENANT, &AllocationFilter {
-                supernet_id: Some(sn.id.clone()),
-                ..Default::default()
-            })
+            .list_allocations(
+                TEST_TENANT,
+                &AllocationFilter {
+                    supernet_id: Some(sn.id.clone()),
+                    ..Default::default()
+                },
+            )
             .await
             .unwrap();
 
@@ -2994,30 +3159,36 @@ mod tests {
         let ops = test_ops_concurrent(db.to_str().unwrap()).await;
 
         let sn = ops
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "10.0.0.0/24".to_string(),
-                name: None,
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "10.0.0.0/24".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
         // Pre-allocate the first /25 block
         let existing = ops
-            .allocate_specific(TEST_TENANT, &CreateAllocation {
-                supernet_id: sn.id.clone(),
-                cidr: "10.0.0.0/25".to_string(),
-                status: None,
-                resource_id: None,
-                resource_type: None,
-                name: None,
-                description: None,
-                environment: None,
-                owner: None,
-                parent_allocation_id: None,
-                tags: None,
-                ttl_seconds: None,
-            })
+            .allocate_specific(
+                TEST_TENANT,
+                &CreateAllocation {
+                    supernet_id: sn.id.clone(),
+                    cidr: "10.0.0.0/25".to_string(),
+                    status: None,
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: None,
+                },
+            )
             .await
             .unwrap();
 
@@ -3038,20 +3209,23 @@ mod tests {
         let b2 = Arc::clone(&barrier);
         let alloc_handle = tokio::spawn(async move {
             b2.wait().await;
-            ops2.allocate_specific(TEST_TENANT, &CreateAllocation {
-                supernet_id: sn_id,
-                cidr: "10.0.0.128/25".to_string(),
-                status: None,
-                resource_id: None,
-                resource_type: None,
-                name: None,
-                description: None,
-                environment: None,
-                owner: None,
-                parent_allocation_id: None,
-                tags: None,
-                ttl_seconds: None,
-            })
+            ops2.allocate_specific(
+                TEST_TENANT,
+                &CreateAllocation {
+                    supernet_id: sn_id,
+                    cidr: "10.0.0.128/25".to_string(),
+                    status: None,
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: None,
+                },
+            )
             .await
         });
 
@@ -3069,10 +3243,13 @@ mod tests {
 
         // Verify final state: one released, one active
         let all = ops
-            .list_allocations(TEST_TENANT, &AllocationFilter {
-                supernet_id: Some(sn.id.clone()),
-                ..Default::default()
-            })
+            .list_allocations(
+                TEST_TENANT,
+                &AllocationFilter {
+                    supernet_id: Some(sn.id.clone()),
+                    ..Default::default()
+                },
+            )
             .await
             .unwrap();
 
@@ -3112,11 +3289,14 @@ mod tests {
 
             handles.push(tokio::spawn(async move {
                 barrier.wait().await;
-                ops.create_supernet(TEST_TENANT, &CreateSupernet {
-                    cidr,
-                    name: None,
-                    description: None,
-                })
+                ops.create_supernet(
+                    TEST_TENANT,
+                    &CreateSupernet {
+                        cidr,
+                        name: None,
+                        description: None,
+                    },
+                )
                 .await
             }));
         }
@@ -3181,10 +3361,13 @@ mod tests {
     async fn test_query_audit_rejects_entity_id_with_path_traversal() {
         let ops = test_ops().await;
         let err = ops
-            .query_audit(TEST_TENANT, &AuditFilter {
-                entity_id: Some("../etc/passwd".to_string()),
-                ..Default::default()
-            })
+            .query_audit(
+                TEST_TENANT,
+                &AuditFilter {
+                    entity_id: Some("../etc/passwd".to_string()),
+                    ..Default::default()
+                },
+            )
             .await
             .unwrap_err();
         assert!(matches!(err, NetcidrError::InvalidInput(_)));
@@ -3194,10 +3377,13 @@ mod tests {
     async fn test_query_audit_rejects_entity_id_with_null_byte() {
         let ops = test_ops().await;
         let err = ops
-            .query_audit(TEST_TENANT, &AuditFilter {
-                entity_id: Some("id\x00injected".to_string()),
-                ..Default::default()
-            })
+            .query_audit(
+                TEST_TENANT,
+                &AuditFilter {
+                    entity_id: Some("id\x00injected".to_string()),
+                    ..Default::default()
+                },
+            )
             .await
             .unwrap_err();
         assert!(matches!(err, NetcidrError::InvalidInput(_)));
@@ -3207,10 +3393,13 @@ mod tests {
     async fn test_query_audit_rejects_entity_type_with_control_char() {
         let ops = test_ops().await;
         let err = ops
-            .query_audit(TEST_TENANT, &AuditFilter {
-                entity_type: Some("supernet\x01injected".to_string()),
-                ..Default::default()
-            })
+            .query_audit(
+                TEST_TENANT,
+                &AuditFilter {
+                    entity_type: Some("supernet\x01injected".to_string()),
+                    ..Default::default()
+                },
+            )
             .await
             .unwrap_err();
         assert!(matches!(err, NetcidrError::InvalidInput(_)));
@@ -3220,10 +3409,13 @@ mod tests {
     async fn test_query_audit_rejects_action_with_control_char() {
         let ops = test_ops().await;
         let err = ops
-            .query_audit(TEST_TENANT, &AuditFilter {
-                action: Some("create\x07bell".to_string()),
-                ..Default::default()
-            })
+            .query_audit(
+                TEST_TENANT,
+                &AuditFilter {
+                    action: Some("create\x07bell".to_string()),
+                    ..Default::default()
+                },
+            )
             .await
             .unwrap_err();
         assert!(matches!(err, NetcidrError::InvalidInput(_)));
@@ -3233,10 +3425,13 @@ mod tests {
     async fn test_query_audit_rejects_oversized_entity_type() {
         let ops = test_ops().await;
         let err = ops
-            .query_audit(TEST_TENANT, &AuditFilter {
-                entity_type: Some("x".repeat(1025)),
-                ..Default::default()
-            })
+            .query_audit(
+                TEST_TENANT,
+                &AuditFilter {
+                    entity_type: Some("x".repeat(1025)),
+                    ..Default::default()
+                },
+            )
             .await
             .unwrap_err();
         assert!(matches!(err, NetcidrError::InputTooLong { .. }));
@@ -3247,12 +3442,15 @@ mod tests {
         let ops = test_ops().await;
         // No entries, but valid filter should not error.
         let entries = ops
-            .query_audit(TEST_TENANT, &AuditFilter {
-                entity_type: Some("supernet".to_string()),
-                entity_id: Some("sn-abc123".to_string()),
-                action: Some("create_supernet".to_string()),
-                limit: Some(10),
-            })
+            .query_audit(
+                TEST_TENANT,
+                &AuditFilter {
+                    entity_type: Some("supernet".to_string()),
+                    entity_id: Some("sn-abc123".to_string()),
+                    action: Some("create_supernet".to_string()),
+                    limit: Some(10),
+                },
+            )
             .await
             .unwrap();
         assert!(entries.is_empty());

--- a/src/ipam/postgres/migrations.rs
+++ b/src/ipam/postgres/migrations.rs
@@ -6,6 +6,7 @@ pub const MIGRATIONS: &[(u32, &str)] = &[
     (3, MIGRATION_003),
     (4, MIGRATION_004),
     (5, MIGRATION_005),
+    (6, MIGRATION_006),
 ];
 
 const MIGRATION_001: &str = r#"
@@ -105,3 +106,173 @@ CREATE TABLE IF NOT EXISTS idempotency_keys (
 
 CREATE INDEX IF NOT EXISTS idx_idempotency_expires ON idempotency_keys(expires_at);
 "#;
+
+/// Migration 006: multi-tenant isolation. Mirrors the SQLite migration in
+/// Postgres dialect — destructively drops and recreates the IPAM tables
+/// with `tenant_id` columns, replaces `UNIQUE(cidr)` with
+/// `UNIQUE(tenant_id, cidr)` on supernets, adds composite tenant indexes,
+/// and installs a plpgsql trigger function enforcing the cross-table
+/// invariant `allocations.tenant_id == supernets.tenant_id`.
+const MIGRATION_006: &str = r#"
+DROP TABLE IF EXISTS allocation_tags CASCADE;
+DROP TABLE IF EXISTS allocations CASCADE;
+DROP TABLE IF EXISTS supernets CASCADE;
+DROP TABLE IF EXISTS audit_log CASCADE;
+DROP TABLE IF EXISTS idempotency_keys CASCADE;
+
+CREATE TABLE supernets (
+    id                TEXT PRIMARY KEY,
+    tenant_id         TEXT NOT NULL,
+    cidr              TEXT NOT NULL,
+    network_address   TEXT NOT NULL,
+    broadcast_address TEXT NOT NULL,
+    prefix_length     SMALLINT NOT NULL,
+    total_hosts       TEXT NOT NULL,
+    name              TEXT,
+    description       TEXT,
+    ip_version        SMALLINT NOT NULL,
+    created_at        TEXT NOT NULL,
+    updated_at        TEXT NOT NULL,
+    UNIQUE (tenant_id, cidr)
+);
+CREATE INDEX idx_supernets_tenant ON supernets(tenant_id);
+
+CREATE TABLE allocations (
+    id                    TEXT PRIMARY KEY,
+    tenant_id             TEXT NOT NULL,
+    supernet_id           TEXT NOT NULL REFERENCES supernets(id),
+    cidr                  TEXT NOT NULL,
+    network_address       TEXT NOT NULL,
+    broadcast_address     TEXT NOT NULL,
+    prefix_length         SMALLINT NOT NULL,
+    total_hosts           TEXT NOT NULL,
+    status                TEXT NOT NULL,
+    resource_id           TEXT,
+    resource_type         TEXT,
+    name                  TEXT,
+    description           TEXT,
+    environment           TEXT,
+    owner                 TEXT,
+    parent_allocation_id  TEXT REFERENCES allocations(id),
+    created_at            TEXT NOT NULL,
+    updated_at            TEXT NOT NULL,
+    released_at           TEXT,
+    expires_at            TEXT
+);
+CREATE INDEX idx_allocations_tenant    ON allocations(tenant_id);
+CREATE INDEX idx_allocations_tenant_sn ON allocations(tenant_id, supernet_id);
+CREATE INDEX idx_allocations_supernet  ON allocations(supernet_id);
+CREATE INDEX idx_allocations_status    ON allocations(status);
+CREATE INDEX idx_allocations_cidr      ON allocations(cidr);
+
+CREATE OR REPLACE FUNCTION assert_alloc_tenant_match() RETURNS trigger AS $$
+DECLARE
+    sn_tenant TEXT;
+BEGIN
+    SELECT tenant_id INTO sn_tenant FROM supernets WHERE id = NEW.supernet_id;
+    IF sn_tenant IS NULL OR sn_tenant != NEW.tenant_id THEN
+        RAISE EXCEPTION 'allocation tenant_id must match parent supernet tenant_id';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_allocations_tenant_match_insert
+    BEFORE INSERT ON allocations
+    FOR EACH ROW EXECUTE FUNCTION assert_alloc_tenant_match();
+CREATE TRIGGER trg_allocations_tenant_match_update
+    BEFORE UPDATE OF tenant_id, supernet_id ON allocations
+    FOR EACH ROW EXECUTE FUNCTION assert_alloc_tenant_match();
+
+CREATE TABLE allocation_tags (
+    allocation_id TEXT NOT NULL REFERENCES allocations(id) ON DELETE CASCADE,
+    key           TEXT NOT NULL,
+    value         TEXT NOT NULL,
+    PRIMARY KEY (allocation_id, key)
+);
+
+CREATE TABLE audit_log (
+    id            BIGSERIAL PRIMARY KEY,
+    tenant_id     TEXT NOT NULL,
+    entity_type   TEXT NOT NULL,
+    entity_id     TEXT NOT NULL,
+    action        TEXT NOT NULL,
+    details       TEXT,
+    timestamp     TEXT NOT NULL,
+    caller_sub    TEXT,
+    caller_email  TEXT,
+    source_ip     TEXT,
+    request_id    TEXT
+);
+CREATE INDEX idx_audit_tenant         ON audit_log(tenant_id);
+CREATE INDEX idx_audit_tenant_entity  ON audit_log(tenant_id, entity_type, entity_id);
+CREATE INDEX idx_audit_request_id     ON audit_log(request_id);
+CREATE INDEX idx_audit_caller_sub     ON audit_log(caller_sub);
+
+CREATE TABLE idempotency_keys (
+    tenant_id     TEXT NOT NULL,
+    key           TEXT NOT NULL,
+    scope         TEXT NOT NULL,
+    request_hash  TEXT NOT NULL,
+    status_code   INTEGER NOT NULL,
+    response_body TEXT NOT NULL,
+    created_at    TEXT NOT NULL,
+    expires_at    TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, key, scope)
+);
+CREATE INDEX idx_idempotency_expires ON idempotency_keys(expires_at);
+"#;
+
+#[cfg(all(test, feature = "ipam-postgres"))]
+mod tests {
+    use crate::ipam::postgres::PostgresStore;
+    use crate::ipam::config::PostgresConfig;
+    use crate::ipam::store::IpamStore;
+
+    #[tokio::test]
+    async fn pg_allocation_with_mismatched_tenant_id_is_rejected_by_trigger() {
+        // Skip if no NETCIDR_TEST_DATABASE_URL set.
+        let url = match std::env::var("NETCIDR_TEST_DATABASE_URL") {
+            Ok(v) => v,
+            Err(_) => {
+                eprintln!(
+                    "skipping: NETCIDR_TEST_DATABASE_URL not set"
+                );
+                return;
+            }
+        };
+        let config = PostgresConfig::default();
+        let store = PostgresStore::new(&url, &config).await.unwrap();
+        store.initialize().await.unwrap();
+        store.migrate().await.unwrap();
+
+        sqlx::query(
+            r#"INSERT INTO supernets
+               (id, tenant_id, cidr, network_address, broadcast_address,
+                prefix_length, total_hosts, ip_version, created_at, updated_at)
+               VALUES ('s1','a@x','10.0.0.0/8','10.0.0.0','10.255.255.255',
+                       8,'16777216',4,'2026-05-02T00:00:00Z','2026-05-02T00:00:00Z')"#,
+        )
+        .execute(store.pool())
+        .await
+        .unwrap();
+
+        let result = sqlx::query(
+            r#"INSERT INTO allocations
+               (id, tenant_id, supernet_id, cidr, network_address, broadcast_address,
+                prefix_length, total_hosts, status, created_at, updated_at)
+               VALUES ('a1','b@x','s1','10.1.0.0/16','10.1.0.0','10.1.255.255',
+                       16,'65536','active','2026-05-02T00:00:00Z','2026-05-02T00:00:00Z')"#,
+        )
+        .execute(store.pool())
+        .await;
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("must match parent")
+        );
+    }
+}

--- a/src/ipam/postgres/migrations.rs
+++ b/src/ipam/postgres/migrations.rs
@@ -225,8 +225,8 @@ CREATE INDEX idx_idempotency_expires ON idempotency_keys(expires_at);
 
 #[cfg(all(test, feature = "ipam-postgres"))]
 mod tests {
-    use crate::ipam::postgres::PostgresStore;
     use crate::ipam::config::PostgresConfig;
+    use crate::ipam::postgres::PostgresStore;
     use crate::ipam::store::IpamStore;
 
     #[tokio::test]
@@ -235,9 +235,7 @@ mod tests {
         let url = match std::env::var("NETCIDR_TEST_DATABASE_URL") {
             Ok(v) => v,
             Err(_) => {
-                eprintln!(
-                    "skipping: NETCIDR_TEST_DATABASE_URL not set"
-                );
+                eprintln!("skipping: NETCIDR_TEST_DATABASE_URL not set");
                 return;
             }
         };

--- a/src/ipam/postgres/mod.rs
+++ b/src/ipam/postgres/mod.rs
@@ -28,6 +28,13 @@ impl PostgresStore {
         Ok(Self { pool })
     }
 
+    /// Test-only access to the underlying connection pool, used by migration
+    /// tests that need to issue raw SQL outside the normal `IpamStore` API.
+    #[cfg(test)]
+    pub(crate) fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+
     fn now() -> String {
         Utc::now().to_rfc3339()
     }

--- a/src/ipam/postgres/mod.rs
+++ b/src/ipam/postgres/mod.rs
@@ -59,14 +59,13 @@ impl PostgresStore {
         tenant_id: &str,
         allocation_id: &str,
     ) -> Result<()> {
-        let row = sqlx::query(
-            "SELECT COUNT(*) as cnt FROM allocations WHERE id = $1 AND tenant_id = $2",
-        )
-        .bind(allocation_id)
-        .bind(tenant_id)
-        .fetch_one(&self.pool)
-        .await
-        .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
+        let row =
+            sqlx::query("SELECT COUNT(*) as cnt FROM allocations WHERE id = $1 AND tenant_id = $2")
+                .bind(allocation_id)
+                .bind(tenant_id)
+                .fetch_one(&self.pool)
+                .await
+                .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
         let cnt: i64 = row.get("cnt");
         if cnt == 0 {
             return Err(NetcidrError::AllocationNotFound(allocation_id.to_string()));
@@ -155,11 +154,7 @@ impl IpamStore for PostgresStore {
 
     // --- supernets ---
 
-    async fn create_supernet(
-        &self,
-        tenant_id: &str,
-        input: &CreateSupernet,
-    ) -> Result<Supernet> {
+    async fn create_supernet(&self, tenant_id: &str, input: &CreateSupernet) -> Result<Supernet> {
         let id = uuid::Uuid::new_v4().to_string();
         let now = Self::now();
         let (network, broadcast, prefix, total, ip_version) = parse_cidr_metadata(&input.cidr)?;
@@ -265,14 +260,13 @@ impl IpamStore for PostgresStore {
 
     async fn delete_supernet(&self, tenant_id: &str, id: &str) -> Result<()> {
         // Verify supernet exists in this tenant; cross-tenant ⇒ NotFound.
-        let exists_row = sqlx::query(
-            "SELECT COUNT(*) as cnt FROM supernets WHERE id = $1 AND tenant_id = $2",
-        )
-        .bind(id)
-        .bind(tenant_id)
-        .fetch_one(&self.pool)
-        .await
-        .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
+        let exists_row =
+            sqlx::query("SELECT COUNT(*) as cnt FROM supernets WHERE id = $1 AND tenant_id = $2")
+                .bind(id)
+                .bind(tenant_id)
+                .fetch_one(&self.pool)
+                .await
+                .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
         let exists_cnt: i64 = exists_row.get("cnt");
         if exists_cnt == 0 {
             return Err(NetcidrError::SupernetNotFound(id.to_string()));
@@ -345,14 +339,13 @@ impl IpamStore for PostgresStore {
         // Application-level cross-tenant invariant: confirm the parent
         // supernet belongs to this tenant. NotFound (not Forbidden) hides
         // existence. The DB trigger is belt-and-suspenders.
-        let supernet_row = sqlx::query(
-            "SELECT COUNT(*) as cnt FROM supernets WHERE id = $1 AND tenant_id = $2",
-        )
-        .bind(&input.supernet_id)
-        .bind(tenant_id)
-        .fetch_one(&self.pool)
-        .await
-        .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
+        let supernet_row =
+            sqlx::query("SELECT COUNT(*) as cnt FROM supernets WHERE id = $1 AND tenant_id = $2")
+                .bind(&input.supernet_id)
+                .bind(tenant_id)
+                .fetch_one(&self.pool)
+                .await
+                .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
         let supernet_cnt: i64 = supernet_row.get("cnt");
         if supernet_cnt == 0 {
             return Err(NetcidrError::SupernetNotFound(input.supernet_id.clone()));
@@ -641,12 +634,7 @@ impl IpamStore for PostgresStore {
 
     // --- tags ---
 
-    async fn set_tags(
-        &self,
-        tenant_id: &str,
-        allocation_id: &str,
-        tags: &[Tag],
-    ) -> Result<()> {
+    async fn set_tags(&self, tenant_id: &str, allocation_id: &str, tags: &[Tag]) -> Result<()> {
         self.assert_allocation_in_tenant(tenant_id, allocation_id)
             .await?;
 
@@ -698,11 +686,7 @@ impl IpamStore for PostgresStore {
         Ok(())
     }
 
-    async fn query_audit(
-        &self,
-        tenant_id: &str,
-        filter: &AuditFilter,
-    ) -> Result<Vec<AuditEntry>> {
+    async fn query_audit(&self, tenant_id: &str, filter: &AuditFilter) -> Result<Vec<AuditEntry>> {
         let mut sql = String::from(
             "SELECT id, tenant_id, timestamp, action, entity_type, entity_id, details, caller_sub, caller_email, source_ip, request_id FROM audit_log WHERE tenant_id = $1",
         );

--- a/src/ipam/postgres/mod.rs
+++ b/src/ipam/postgres/mod.rs
@@ -9,7 +9,7 @@ use crate::error::{NetcidrError, Result};
 use crate::ipam::config::PostgresConfig;
 use crate::ipam::models::*;
 use crate::ipam::store::IpamStore;
-use crate::ipam::{parse_cidr_metadata, read_total_hosts, total_hosts_as_i64};
+use crate::ipam::{parse_cidr_metadata, read_total_hosts};
 
 pub struct PostgresStore {
     pool: PgPool,
@@ -54,15 +54,35 @@ impl PostgresStore {
             .collect())
     }
 
+    async fn assert_allocation_in_tenant(
+        &self,
+        tenant_id: &str,
+        allocation_id: &str,
+    ) -> Result<()> {
+        let row = sqlx::query(
+            "SELECT COUNT(*) as cnt FROM allocations WHERE id = $1 AND tenant_id = $2",
+        )
+        .bind(allocation_id)
+        .bind(tenant_id)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
+        let cnt: i64 = row.get("cnt");
+        if cnt == 0 {
+            return Err(NetcidrError::AllocationNotFound(allocation_id.to_string()));
+        }
+        Ok(())
+    }
+
     fn row_to_allocation(row: &sqlx::postgres::PgRow) -> Allocation {
         let status_str: String = row.get("status");
         let status = status_str
             .parse::<AllocationStatus>()
             .unwrap_or(AllocationStatus::Active);
-        let total_hosts_i64: i64 = row.get("total_hosts");
-        let total_hosts_text: Option<String> = row.get("total_hosts_text");
+        let total_hosts_text: String = row.get("total_hosts");
         Allocation {
             id: row.get("id"),
+            tenant_id: row.get("tenant_id"),
             supernet_id: row.get("supernet_id"),
             cidr: row.get("cidr"),
             network_address: row.get("network_address"),
@@ -71,7 +91,7 @@ impl PostgresStore {
                 let v: i16 = row.get("prefix_length");
                 v as u8
             },
-            total_hosts: read_total_hosts(total_hosts_text, total_hosts_i64),
+            total_hosts: read_total_hosts(Some(total_hosts_text), 0),
             status,
             resource_id: row.get("resource_id"),
             resource_type: row.get("resource_type"),
@@ -117,18 +137,11 @@ impl IpamStore for PostgresStore {
 
         for &(version, sql) in migrations::MIGRATIONS {
             if version > current {
-                // PostgreSQL prepared statements don't support multiple commands,
-                // so split on semicolons and execute each statement individually.
-                for stmt in sql.split(';') {
-                    let stmt = stmt.trim();
-                    if stmt.is_empty() {
-                        continue;
-                    }
-                    sqlx::query(stmt)
-                        .execute(&self.pool)
-                        .await
-                        .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
-                }
+                // Migration 006 contains a plpgsql CREATE FUNCTION whose body
+                // includes semicolons. Naively splitting on ';' would break
+                // it. Detect the function block and execute it as a single
+                // statement; everything else stays one-statement-per-split.
+                Self::execute_migration_sql(&self.pool, sql).await?;
                 sqlx::query("INSERT INTO schema_version (version, applied_at) VALUES ($1, $2)")
                     .bind(version as i32)
                     .bind(Self::now())
@@ -142,21 +155,25 @@ impl IpamStore for PostgresStore {
 
     // --- supernets ---
 
-    async fn create_supernet(&self, input: &CreateSupernet) -> Result<Supernet> {
+    async fn create_supernet(
+        &self,
+        tenant_id: &str,
+        input: &CreateSupernet,
+    ) -> Result<Supernet> {
         let id = uuid::Uuid::new_v4().to_string();
         let now = Self::now();
         let (network, broadcast, prefix, total, ip_version) = parse_cidr_metadata(&input.cidr)?;
 
         sqlx::query(
-            "INSERT INTO supernets (id, cidr, network_address, broadcast_address, prefix_length, total_hosts, total_hosts_text, name, description, ip_version, created_at, updated_at)
+            "INSERT INTO supernets (id, tenant_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, name, description, ip_version, created_at, updated_at)
              VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
         )
         .bind(&id)
+        .bind(tenant_id)
         .bind(&input.cidr)
         .bind(&network)
         .bind(&broadcast)
         .bind(prefix as i16)
-        .bind(total_hosts_as_i64(total))
         .bind(total.to_string())
         .bind(&input.name)
         .bind(&input.description)
@@ -169,6 +186,7 @@ impl IpamStore for PostgresStore {
 
         Ok(Supernet {
             id,
+            tenant_id: tenant_id.to_string(),
             cidr: input.cidr.clone(),
             network_address: network,
             broadcast_address: broadcast,
@@ -182,27 +200,28 @@ impl IpamStore for PostgresStore {
         })
     }
 
-    async fn get_supernet(&self, id: &str) -> Result<Supernet> {
+    async fn get_supernet(&self, tenant_id: &str, id: &str) -> Result<Supernet> {
         let row = sqlx::query(
-            "SELECT id, cidr, network_address, broadcast_address, prefix_length, total_hosts, total_hosts_text, name, description, ip_version, created_at, updated_at FROM supernets WHERE id = $1",
+            "SELECT id, tenant_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, name, description, ip_version, created_at, updated_at FROM supernets WHERE id = $1 AND tenant_id = $2",
         )
         .bind(id)
+        .bind(tenant_id)
         .fetch_optional(&self.pool)
         .await
         .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?
         .ok_or_else(|| NetcidrError::SupernetNotFound(id.to_string()))?;
 
-        let total_hosts_i64: i64 = row.get("total_hosts");
-        let total_hosts_text: Option<String> = row.get("total_hosts_text");
+        let total_hosts_text: String = row.get("total_hosts");
         let prefix_length: i16 = row.get("prefix_length");
         let ip_version: i16 = row.get("ip_version");
         Ok(Supernet {
             id: row.get("id"),
+            tenant_id: row.get("tenant_id"),
             cidr: row.get("cidr"),
             network_address: row.get("network_address"),
             broadcast_address: row.get("broadcast_address"),
             prefix_length: prefix_length as u8,
-            total_hosts: read_total_hosts(total_hosts_text, total_hosts_i64),
+            total_hosts: read_total_hosts(Some(total_hosts_text), 0),
             name: row.get("name"),
             description: row.get("description"),
             ip_version: ip_version as u8,
@@ -211,10 +230,11 @@ impl IpamStore for PostgresStore {
         })
     }
 
-    async fn list_supernets(&self) -> Result<Vec<Supernet>> {
+    async fn list_supernets(&self, tenant_id: &str) -> Result<Vec<Supernet>> {
         let rows = sqlx::query(
-            "SELECT id, cidr, network_address, broadcast_address, prefix_length, total_hosts, total_hosts_text, name, description, ip_version, created_at, updated_at FROM supernets ORDER BY created_at",
+            "SELECT id, tenant_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, name, description, ip_version, created_at, updated_at FROM supernets WHERE tenant_id = $1 ORDER BY created_at",
         )
+        .bind(tenant_id)
         .fetch_all(&self.pool)
         .await
         .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
@@ -222,17 +242,17 @@ impl IpamStore for PostgresStore {
         Ok(rows
             .iter()
             .map(|row| {
-                let total_hosts_i64: i64 = row.get("total_hosts");
-                let total_hosts_text: Option<String> = row.get("total_hosts_text");
+                let total_hosts_text: String = row.get("total_hosts");
                 let prefix_length: i16 = row.get("prefix_length");
                 let ip_version: i16 = row.get("ip_version");
                 Supernet {
                     id: row.get("id"),
+                    tenant_id: row.get("tenant_id"),
                     cidr: row.get("cidr"),
                     network_address: row.get("network_address"),
                     broadcast_address: row.get("broadcast_address"),
                     prefix_length: prefix_length as u8,
-                    total_hosts: read_total_hosts(total_hosts_text, total_hosts_i64),
+                    total_hosts: read_total_hosts(Some(total_hosts_text), 0),
                     name: row.get("name"),
                     description: row.get("description"),
                     ip_version: ip_version as u8,
@@ -243,11 +263,26 @@ impl IpamStore for PostgresStore {
             .collect())
     }
 
-    async fn delete_supernet(&self, id: &str) -> Result<()> {
-        let row = sqlx::query(
-            "SELECT COUNT(*) as cnt FROM allocations WHERE supernet_id = $1 AND status != 'released'",
+    async fn delete_supernet(&self, tenant_id: &str, id: &str) -> Result<()> {
+        // Verify supernet exists in this tenant; cross-tenant ⇒ NotFound.
+        let exists_row = sqlx::query(
+            "SELECT COUNT(*) as cnt FROM supernets WHERE id = $1 AND tenant_id = $2",
         )
         .bind(id)
+        .bind(tenant_id)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
+        let exists_cnt: i64 = exists_row.get("cnt");
+        if exists_cnt == 0 {
+            return Err(NetcidrError::SupernetNotFound(id.to_string()));
+        }
+
+        let row = sqlx::query(
+            "SELECT COUNT(*) as cnt FROM allocations WHERE supernet_id = $1 AND tenant_id = $2 AND status != 'released'",
+        )
+        .bind(id)
+        .bind(tenant_id)
         .fetch_one(&self.pool)
         .await
         .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
@@ -259,21 +294,24 @@ impl IpamStore for PostgresStore {
 
         // Delete released allocations' tags, then allocations, then supernet
         sqlx::query(
-            "DELETE FROM allocation_tags WHERE allocation_id IN (SELECT id FROM allocations WHERE supernet_id = $1)",
+            "DELETE FROM allocation_tags WHERE allocation_id IN (SELECT id FROM allocations WHERE supernet_id = $1 AND tenant_id = $2)",
         )
         .bind(id)
+        .bind(tenant_id)
         .execute(&self.pool)
         .await
         .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
 
-        sqlx::query("DELETE FROM allocations WHERE supernet_id = $1")
+        sqlx::query("DELETE FROM allocations WHERE supernet_id = $1 AND tenant_id = $2")
             .bind(id)
+            .bind(tenant_id)
             .execute(&self.pool)
             .await
             .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
 
-        let result = sqlx::query("DELETE FROM supernets WHERE id = $1")
+        let result = sqlx::query("DELETE FROM supernets WHERE id = $1 AND tenant_id = $2")
             .bind(id)
+            .bind(tenant_id)
             .execute(&self.pool)
             .await
             .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
@@ -286,7 +324,11 @@ impl IpamStore for PostgresStore {
 
     // --- allocations ---
 
-    async fn create_allocation(&self, input: &CreateAllocation) -> Result<Allocation> {
+    async fn create_allocation(
+        &self,
+        tenant_id: &str,
+        input: &CreateAllocation,
+    ) -> Result<Allocation> {
         let id = uuid::Uuid::new_v4().to_string();
         let now = Self::now();
         let status = input
@@ -300,17 +342,33 @@ impl IpamStore for PostgresStore {
             .ttl_seconds
             .map(|ttl| (Utc::now() + chrono::Duration::seconds(ttl as i64)).to_rfc3339());
 
+        // Application-level cross-tenant invariant: confirm the parent
+        // supernet belongs to this tenant. NotFound (not Forbidden) hides
+        // existence. The DB trigger is belt-and-suspenders.
+        let supernet_row = sqlx::query(
+            "SELECT COUNT(*) as cnt FROM supernets WHERE id = $1 AND tenant_id = $2",
+        )
+        .bind(&input.supernet_id)
+        .bind(tenant_id)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
+        let supernet_cnt: i64 = supernet_row.get("cnt");
+        if supernet_cnt == 0 {
+            return Err(NetcidrError::SupernetNotFound(input.supernet_id.clone()));
+        }
+
         sqlx::query(
-            "INSERT INTO allocations (id, supernet_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, total_hosts_text, resource_id, resource_type, name, description, environment, owner, status, parent_allocation_id, created_at, updated_at, expires_at)
+            "INSERT INTO allocations (id, tenant_id, supernet_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, resource_id, resource_type, name, description, environment, owner, status, parent_allocation_id, created_at, updated_at, expires_at)
              VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)",
         )
         .bind(&id)
+        .bind(tenant_id)
         .bind(&input.supernet_id)
         .bind(&input.cidr)
         .bind(&network)
         .bind(&broadcast)
         .bind(prefix as i16)
-        .bind(total_hosts_as_i64(total))
         .bind(total.to_string())
         .bind(&input.resource_id)
         .bind(&input.resource_type)
@@ -345,6 +403,7 @@ impl IpamStore for PostgresStore {
         let tags = input.tags.clone().unwrap_or_default();
         Ok(Allocation {
             id,
+            tenant_id: tenant_id.to_string(),
             supernet_id: input.supernet_id.clone(),
             cidr: input.cidr.clone(),
             network_address: network,
@@ -367,11 +426,12 @@ impl IpamStore for PostgresStore {
         })
     }
 
-    async fn get_allocation(&self, id: &str) -> Result<Allocation> {
+    async fn get_allocation(&self, tenant_id: &str, id: &str) -> Result<Allocation> {
         let row = sqlx::query(
-            "SELECT id, supernet_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, total_hosts_text, resource_id, resource_type, name, description, environment, owner, status, parent_allocation_id, created_at, updated_at, released_at, expires_at FROM allocations WHERE id = $1",
+            "SELECT id, tenant_id, supernet_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, resource_id, resource_type, name, description, environment, owner, status, parent_allocation_id, created_at, updated_at, released_at, expires_at FROM allocations WHERE id = $1 AND tenant_id = $2",
         )
         .bind(id)
+        .bind(tenant_id)
         .fetch_optional(&self.pool)
         .await
         .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?
@@ -382,12 +442,17 @@ impl IpamStore for PostgresStore {
         Ok(alloc)
     }
 
-    async fn list_allocations(&self, filter: &AllocationFilter) -> Result<Vec<Allocation>> {
+    async fn list_allocations(
+        &self,
+        tenant_id: &str,
+        filter: &AllocationFilter,
+    ) -> Result<Vec<Allocation>> {
         let mut sql = String::from(
-            "SELECT id, supernet_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, total_hosts_text, resource_id, resource_type, name, description, environment, owner, status, parent_allocation_id, created_at, updated_at, released_at, expires_at FROM allocations WHERE true",
+            "SELECT id, tenant_id, supernet_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, resource_id, resource_type, name, description, environment, owner, status, parent_allocation_id, created_at, updated_at, released_at, expires_at FROM allocations WHERE tenant_id = $1",
         );
         let mut param_values: Vec<String> = Vec::new();
-        let mut idx = 1;
+        param_values.push(tenant_id.to_string());
+        let mut idx = 2;
 
         if let Some(ref sid) = filter.supernet_id {
             sql.push_str(&format!(" AND supernet_id = ${idx}"));
@@ -442,19 +507,16 @@ impl IpamStore for PostgresStore {
         Ok(allocations)
     }
 
-    async fn update_allocation(&self, id: &str, input: &UpdateAllocation) -> Result<Allocation> {
+    async fn update_allocation(
+        &self,
+        tenant_id: &str,
+        id: &str,
+        input: &UpdateAllocation,
+    ) -> Result<Allocation> {
         let now = Self::now();
 
-        // Verify allocation exists
-        let exists = sqlx::query("SELECT id FROM allocations WHERE id = $1")
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
-
-        if exists.is_none() {
-            return Err(NetcidrError::AllocationNotFound(id.to_string()));
-        }
+        // Verify allocation exists in this tenant
+        self.assert_allocation_in_tenant(tenant_id, id).await?;
 
         let mut sets = vec!["updated_at = $1".to_string()];
         let mut param_values: Vec<String> = vec![now];
@@ -485,16 +547,16 @@ impl IpamStore for PostgresStore {
             }
         }
 
+        let id_idx = idx;
+        let tenant_idx = idx + 1;
         let sql = format!(
-            "UPDATE allocations SET {} WHERE id = ${}",
+            "UPDATE allocations SET {} WHERE id = ${} AND tenant_id = ${}",
             sets.join(", "),
-            idx
+            id_idx,
+            tenant_idx,
         );
         param_values.push(id.to_string());
-        #[allow(unused_assignments)]
-        {
-            idx += 1;
-        }
+        param_values.push(tenant_id.to_string());
 
         let mut query = sqlx::query(&sql);
         for val in &param_values {
@@ -505,38 +567,43 @@ impl IpamStore for PostgresStore {
             .await
             .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
 
-        self.get_allocation(id).await
+        self.get_allocation(tenant_id, id).await
     }
 
-    async fn release_allocation(&self, id: &str) -> Result<Allocation> {
+    async fn release_allocation(&self, tenant_id: &str, id: &str) -> Result<Allocation> {
         let now = Self::now();
 
         let result = sqlx::query(
-            "UPDATE allocations SET status = 'released', released_at = $1, updated_at = $1 WHERE id = $2 AND status != 'released'",
+            "UPDATE allocations SET status = 'released', released_at = $1, updated_at = $1 WHERE id = $2 AND tenant_id = $3 AND status != 'released'",
         )
         .bind(&now)
         .bind(id)
+        .bind(tenant_id)
         .execute(&self.pool)
         .await
         .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
 
         if result.rows_affected() == 0 {
-            let exists = sqlx::query("SELECT COUNT(*) as cnt FROM allocations WHERE id = $1")
-                .bind(id)
-                .fetch_one(&self.pool)
-                .await
-                .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
+            let exists = sqlx::query(
+                "SELECT COUNT(*) as cnt FROM allocations WHERE id = $1 AND tenant_id = $2",
+            )
+            .bind(id)
+            .bind(tenant_id)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
             let cnt: i64 = exists.get("cnt");
             if cnt == 0 {
                 return Err(NetcidrError::AllocationNotFound(id.to_string()));
             }
         }
 
-        self.get_allocation(id).await
+        self.get_allocation(tenant_id, id).await
     }
 
     async fn find_allocations_in_supernet(
         &self,
+        tenant_id: &str,
         supernet_id: &str,
         statuses: &[AllocationStatus],
     ) -> Result<Vec<Allocation>> {
@@ -545,17 +612,17 @@ impl IpamStore for PostgresStore {
         }
 
         let mut placeholders = Vec::new();
-        // $1 is supernet_id, statuses start at $2
+        // $1 = supernet_id, $2 = tenant_id, statuses start at $3.
         for i in 0..statuses.len() {
-            placeholders.push(format!("${}", i + 2));
+            placeholders.push(format!("${}", i + 3));
         }
 
         let sql = format!(
-            "SELECT id, supernet_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, total_hosts_text, resource_id, resource_type, name, description, environment, owner, status, parent_allocation_id, created_at, updated_at, released_at, expires_at FROM allocations WHERE supernet_id = $1 AND status IN ({}) ORDER BY network_address",
+            "SELECT id, tenant_id, supernet_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, resource_id, resource_type, name, description, environment, owner, status, parent_allocation_id, created_at, updated_at, released_at, expires_at FROM allocations WHERE supernet_id = $1 AND tenant_id = $2 AND status IN ({}) ORDER BY network_address",
             placeholders.join(", ")
         );
 
-        let mut query = sqlx::query(&sql).bind(supernet_id);
+        let mut query = sqlx::query(&sql).bind(supernet_id).bind(tenant_id);
         for s in statuses {
             query = query.bind(s.to_string());
         }
@@ -574,7 +641,15 @@ impl IpamStore for PostgresStore {
 
     // --- tags ---
 
-    async fn set_tags(&self, allocation_id: &str, tags: &[Tag]) -> Result<()> {
+    async fn set_tags(
+        &self,
+        tenant_id: &str,
+        allocation_id: &str,
+        tags: &[Tag],
+    ) -> Result<()> {
+        self.assert_allocation_in_tenant(tenant_id, allocation_id)
+            .await?;
+
         sqlx::query("DELETE FROM allocation_tags WHERE allocation_id = $1")
             .bind(allocation_id)
             .execute(&self.pool)
@@ -595,7 +670,9 @@ impl IpamStore for PostgresStore {
         Ok(())
     }
 
-    async fn get_tags(&self, allocation_id: &str) -> Result<Vec<Tag>> {
+    async fn get_tags(&self, tenant_id: &str, allocation_id: &str) -> Result<Vec<Tag>> {
+        self.assert_allocation_in_tenant(tenant_id, allocation_id)
+            .await?;
         self.load_tags_for_allocation(allocation_id).await
     }
 
@@ -603,8 +680,9 @@ impl IpamStore for PostgresStore {
 
     async fn append_audit(&self, entry: &AuditEntry) -> Result<()> {
         sqlx::query(
-            "INSERT INTO audit_log (timestamp, action, entity_type, entity_id, details, caller_sub, caller_email, source_ip, request_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+            "INSERT INTO audit_log (tenant_id, timestamp, action, entity_type, entity_id, details, caller_sub, caller_email, source_ip, request_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
         )
+        .bind(&entry.tenant_id)
         .bind(&entry.timestamp)
         .bind(&entry.action)
         .bind(&entry.entity_type)
@@ -620,12 +698,17 @@ impl IpamStore for PostgresStore {
         Ok(())
     }
 
-    async fn query_audit(&self, filter: &AuditFilter) -> Result<Vec<AuditEntry>> {
+    async fn query_audit(
+        &self,
+        tenant_id: &str,
+        filter: &AuditFilter,
+    ) -> Result<Vec<AuditEntry>> {
         let mut sql = String::from(
-            "SELECT id, timestamp, action, entity_type, entity_id, details, caller_sub, caller_email, source_ip, request_id FROM audit_log WHERE true",
+            "SELECT id, tenant_id, timestamp, action, entity_type, entity_id, details, caller_sub, caller_email, source_ip, request_id FROM audit_log WHERE tenant_id = $1",
         );
         let mut param_values: Vec<String> = Vec::new();
-        let mut idx = 1;
+        param_values.push(tenant_id.to_string());
+        let mut idx = 2;
 
         if let Some(ref et) = filter.entity_type {
             sql.push_str(&format!(" AND entity_type = ${idx}"));
@@ -640,10 +723,7 @@ impl IpamStore for PostgresStore {
         if let Some(ref action) = filter.action {
             sql.push_str(&format!(" AND action = ${idx}"));
             param_values.push(action.clone());
-            #[allow(unused_assignments)]
-            {
-                idx += 1;
-            }
+            idx += 1;
         }
 
         sql.push_str(" ORDER BY id DESC");
@@ -674,6 +754,7 @@ impl IpamStore for PostgresStore {
                 let id_i64: i64 = row.get("id");
                 AuditEntry {
                     id: id_i64.to_string(),
+                    tenant_id: row.get("tenant_id"),
                     timestamp: row.get("timestamp"),
                     action: row.get("action"),
                     entity_type: row.get("entity_type"),
@@ -688,11 +769,17 @@ impl IpamStore for PostgresStore {
             .collect())
     }
 
-    async fn idempotency_get(&self, key: &str, scope: &str) -> Result<Option<IdempotencyRecord>> {
+    async fn idempotency_get(
+        &self,
+        tenant_id: &str,
+        key: &str,
+        scope: &str,
+    ) -> Result<Option<IdempotencyRecord>> {
         let row = sqlx::query(
-            "SELECT key, scope, request_hash, status_code, response_body, created_at, expires_at \
-             FROM idempotency_keys WHERE key = $1 AND scope = $2",
+            "SELECT tenant_id, key, scope, request_hash, status_code, response_body, created_at, expires_at \
+             FROM idempotency_keys WHERE tenant_id = $1 AND key = $2 AND scope = $3",
         )
+        .bind(tenant_id)
         .bind(key)
         .bind(scope)
         .fetch_optional(&self.pool)
@@ -701,6 +788,7 @@ impl IpamStore for PostgresStore {
         Ok(row.map(|row| {
             let status_code: i32 = row.get("status_code");
             IdempotencyRecord {
+                tenant_id: row.get("tenant_id"),
                 key: row.get("key"),
                 scope: row.get("scope"),
                 request_hash: row.get("request_hash"),
@@ -715,10 +803,11 @@ impl IpamStore for PostgresStore {
     async fn idempotency_put(&self, record: &IdempotencyRecord) -> Result<()> {
         sqlx::query(
             "INSERT INTO idempotency_keys \
-                (key, scope, request_hash, status_code, response_body, created_at, expires_at) \
-             VALUES ($1, $2, $3, $4, $5, $6, $7) \
-             ON CONFLICT (key, scope) DO NOTHING",
+                (tenant_id, key, scope, request_hash, status_code, response_body, created_at, expires_at) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8) \
+             ON CONFLICT (tenant_id, key, scope) DO NOTHING",
         )
+        .bind(&record.tenant_id)
         .bind(&record.key)
         .bind(&record.scope)
         .bind(&record.request_hash)
@@ -739,5 +828,50 @@ impl IpamStore for PostgresStore {
             .await
             .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
         Ok(result.rows_affected())
+    }
+}
+
+impl PostgresStore {
+    /// Execute a migration SQL blob. Postgres prepared statements only support
+    /// one statement, so we split on `;` — but plpgsql function bodies
+    /// (`$$ ... $$`) themselves contain `;`. Track whether we're inside a
+    /// dollar-quoted block and don't split there.
+    async fn execute_migration_sql(pool: &PgPool, sql: &str) -> Result<()> {
+        let mut buf = String::new();
+        let mut in_dollar = false;
+        let bytes = sql.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            // Detect $$ delimiter.
+            if i + 1 < bytes.len() && bytes[i] == b'$' && bytes[i + 1] == b'$' {
+                buf.push('$');
+                buf.push('$');
+                in_dollar = !in_dollar;
+                i += 2;
+                continue;
+            }
+            let c = bytes[i] as char;
+            if c == ';' && !in_dollar {
+                let stmt = buf.trim();
+                if !stmt.is_empty() {
+                    sqlx::query(stmt)
+                        .execute(pool)
+                        .await
+                        .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
+                }
+                buf.clear();
+            } else {
+                buf.push(c);
+            }
+            i += 1;
+        }
+        let tail = buf.trim();
+        if !tail.is_empty() {
+            sqlx::query(tail)
+                .execute(pool)
+                .await
+                .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
+        }
+        Ok(())
     }
 }

--- a/src/ipam/sqlite/migrations.rs
+++ b/src/ipam/sqlite/migrations.rs
@@ -6,6 +6,7 @@ pub const MIGRATIONS: &[(u32, &str)] = &[
     (3, MIGRATION_003),
     (4, MIGRATION_004),
     (5, MIGRATION_005),
+    (6, MIGRATION_006),
 ];
 
 const MIGRATION_001: &str = r#"
@@ -110,3 +111,175 @@ CREATE TABLE IF NOT EXISTS idempotency_keys (
 
 CREATE INDEX IF NOT EXISTS idx_idempotency_expires ON idempotency_keys(expires_at);
 "#;
+
+/// Migration 006: multi-tenant isolation. Destructively drops and recreates
+/// `supernets`, `allocations`, `audit_log`, `idempotency_keys`, and
+/// `allocation_tags` (last one because it FKs allocations) so we can add
+/// `tenant_id` columns, replace `UNIQUE(cidr)` with `UNIQUE(tenant_id, cidr)`
+/// on supernets, add composite tenant indexes, and install triggers
+/// enforcing the cross-table invariant
+/// `allocations.tenant_id == supernets.tenant_id`.
+const MIGRATION_006: &str = r#"
+DROP TABLE IF EXISTS allocation_tags;
+DROP TABLE IF EXISTS allocations;
+DROP TABLE IF EXISTS supernets;
+DROP TABLE IF EXISTS audit_log;
+DROP TABLE IF EXISTS idempotency_keys;
+
+CREATE TABLE supernets (
+    id                TEXT PRIMARY KEY,
+    tenant_id         TEXT NOT NULL,
+    cidr              TEXT NOT NULL,
+    network_address   TEXT NOT NULL,
+    broadcast_address TEXT NOT NULL,
+    prefix_length     INTEGER NOT NULL,
+    total_hosts       TEXT NOT NULL,
+    name              TEXT,
+    description       TEXT,
+    ip_version        INTEGER NOT NULL,
+    created_at        TEXT NOT NULL,
+    updated_at        TEXT NOT NULL,
+    UNIQUE (tenant_id, cidr)
+);
+CREATE INDEX idx_supernets_tenant ON supernets(tenant_id);
+
+CREATE TABLE allocations (
+    id                    TEXT PRIMARY KEY,
+    tenant_id             TEXT NOT NULL,
+    supernet_id           TEXT NOT NULL REFERENCES supernets(id),
+    cidr                  TEXT NOT NULL,
+    network_address       TEXT NOT NULL,
+    broadcast_address     TEXT NOT NULL,
+    prefix_length         INTEGER NOT NULL,
+    total_hosts           TEXT NOT NULL,
+    status                TEXT NOT NULL,
+    resource_id           TEXT,
+    resource_type         TEXT,
+    name                  TEXT,
+    description           TEXT,
+    environment           TEXT,
+    owner                 TEXT,
+    parent_allocation_id  TEXT REFERENCES allocations(id),
+    created_at            TEXT NOT NULL,
+    updated_at            TEXT NOT NULL,
+    released_at           TEXT,
+    expires_at            TEXT
+);
+CREATE INDEX idx_allocations_tenant     ON allocations(tenant_id);
+CREATE INDEX idx_allocations_tenant_sn  ON allocations(tenant_id, supernet_id);
+CREATE INDEX idx_allocations_supernet   ON allocations(supernet_id);
+CREATE INDEX idx_allocations_status     ON allocations(status);
+CREATE INDEX idx_allocations_cidr       ON allocations(cidr);
+
+-- Cross-table invariant: allocations.tenant_id must match the parent supernet's.
+CREATE TRIGGER trg_allocations_tenant_match_insert
+    BEFORE INSERT ON allocations
+    FOR EACH ROW
+    WHEN NEW.tenant_id != (SELECT tenant_id FROM supernets WHERE id = NEW.supernet_id)
+    BEGIN
+        SELECT RAISE(ABORT, 'allocation tenant_id must match parent supernet tenant_id');
+    END;
+CREATE TRIGGER trg_allocations_tenant_match_update
+    BEFORE UPDATE OF tenant_id, supernet_id ON allocations
+    FOR EACH ROW
+    WHEN NEW.tenant_id != (SELECT tenant_id FROM supernets WHERE id = NEW.supernet_id)
+    BEGIN
+        SELECT RAISE(ABORT, 'allocation tenant_id must match parent supernet tenant_id');
+    END;
+
+CREATE TABLE allocation_tags (
+    allocation_id TEXT NOT NULL REFERENCES allocations(id) ON DELETE CASCADE,
+    key           TEXT NOT NULL,
+    value         TEXT NOT NULL,
+    PRIMARY KEY (allocation_id, key)
+);
+
+CREATE TABLE audit_log (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    tenant_id     TEXT NOT NULL,
+    entity_type   TEXT NOT NULL,
+    entity_id     TEXT NOT NULL,
+    action        TEXT NOT NULL,
+    details       TEXT,
+    timestamp     TEXT NOT NULL,
+    caller_sub    TEXT,
+    caller_email  TEXT,
+    source_ip     TEXT,
+    request_id    TEXT
+);
+CREATE INDEX idx_audit_tenant         ON audit_log(tenant_id);
+CREATE INDEX idx_audit_tenant_entity  ON audit_log(tenant_id, entity_type, entity_id);
+CREATE INDEX idx_audit_request_id     ON audit_log(request_id);
+CREATE INDEX idx_audit_caller_sub     ON audit_log(caller_sub);
+
+CREATE TABLE idempotency_keys (
+    tenant_id     TEXT NOT NULL,
+    key           TEXT NOT NULL,
+    scope         TEXT NOT NULL,
+    request_hash  TEXT NOT NULL,
+    status_code   INTEGER NOT NULL,
+    response_body TEXT NOT NULL,
+    created_at    TEXT NOT NULL,
+    expires_at    TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, key, scope)
+);
+CREATE INDEX idx_idempotency_expires ON idempotency_keys(expires_at);
+"#;
+
+#[cfg(test)]
+mod tests {
+    use crate::ipam::sqlite::SqliteStore;
+    use crate::ipam::store::IpamStore;
+
+    #[tokio::test]
+    async fn allocation_with_mismatched_tenant_id_is_rejected_by_trigger() {
+        let store = SqliteStore::in_memory().unwrap();
+        store.initialize().await.unwrap();
+        store.migrate().await.unwrap();
+
+        let conn = store.pool().get().expect("pool checkout");
+
+        // Insert a supernet for tenant "a@x".
+        conn.execute(
+            r#"INSERT INTO supernets
+               (id, tenant_id, cidr, network_address, broadcast_address,
+                prefix_length, total_hosts, ip_version, created_at, updated_at)
+               VALUES ('s1','a@x','10.0.0.0/8','10.0.0.0','10.255.255.255',
+                       8,'16777216',4,'2026-05-02T00:00:00Z','2026-05-02T00:00:00Z')"#,
+            [],
+        )
+        .expect("insert supernet");
+
+        // Attempt to insert allocation with mismatched tenant_id.
+        let result = conn.execute(
+            r#"INSERT INTO allocations
+               (id, tenant_id, supernet_id, cidr, network_address, broadcast_address,
+                prefix_length, total_hosts, status, created_at, updated_at)
+               VALUES ('a1','b@x','s1','10.1.0.0/16','10.1.0.0','10.1.255.255',
+                       16,'65536','active','2026-05-02T00:00:00Z','2026-05-02T00:00:00Z')"#,
+            [],
+        );
+
+        assert!(
+            result.is_err(),
+            "trigger should reject allocation whose tenant_id != supernet's tenant_id"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("allocation tenant_id must match"),
+            "unexpected error: {}",
+            err
+        );
+
+        // Matching tenant_id should succeed.
+        conn.execute(
+            r#"INSERT INTO allocations
+               (id, tenant_id, supernet_id, cidr, network_address, broadcast_address,
+                prefix_length, total_hosts, status, created_at, updated_at)
+               VALUES ('a2','a@x','s1','10.1.0.0/16','10.1.0.0','10.1.255.255',
+                       16,'65536','active','2026-05-02T00:00:00Z','2026-05-02T00:00:00Z')"#,
+            [],
+        )
+        .expect("matching tenant insert should succeed");
+    }
+}

--- a/src/ipam/sqlite/mod.rs
+++ b/src/ipam/sqlite/mod.rs
@@ -59,6 +59,13 @@ impl SqliteStore {
             .map_err(|e| NetcidrError::DatabaseError(e.to_string()))
     }
 
+    /// Test-only access to the underlying connection pool, used by migration
+    /// tests that need to issue raw SQL outside the normal `IpamStore` API.
+    #[cfg(test)]
+    pub(crate) fn pool(&self) -> &ConnPool {
+        &self.pool
+    }
+
     fn now() -> String {
         Utc::now().to_rfc3339()
     }

--- a/src/ipam/sqlite/mod.rs
+++ b/src/ipam/sqlite/mod.rs
@@ -188,11 +188,7 @@ impl IpamStore for SqliteStore {
 
     // --- supernets ---
 
-    async fn create_supernet(
-        &self,
-        tenant_id: &str,
-        input: &CreateSupernet,
-    ) -> Result<Supernet> {
+    async fn create_supernet(&self, tenant_id: &str, input: &CreateSupernet) -> Result<Supernet> {
         let conn = self.conn()?;
         let id = uuid::Uuid::new_v4().to_string();
         let now = Self::now();
@@ -655,12 +651,7 @@ impl IpamStore for SqliteStore {
 
     // --- tags ---
 
-    async fn set_tags(
-        &self,
-        tenant_id: &str,
-        allocation_id: &str,
-        tags: &[Tag],
-    ) -> Result<()> {
+    async fn set_tags(&self, tenant_id: &str, allocation_id: &str, tags: &[Tag]) -> Result<()> {
         let conn = self.conn()?;
         Self::assert_allocation_in_tenant(&conn, tenant_id, allocation_id)?;
 
@@ -708,11 +699,7 @@ impl IpamStore for SqliteStore {
         Ok(())
     }
 
-    async fn query_audit(
-        &self,
-        tenant_id: &str,
-        filter: &AuditFilter,
-    ) -> Result<Vec<AuditEntry>> {
+    async fn query_audit(&self, tenant_id: &str, filter: &AuditFilter) -> Result<Vec<AuditEntry>> {
         let conn = self.conn()?;
         let mut sql = String::from(
             "SELECT id, tenant_id, timestamp, action, entity_type, entity_id, details, caller_sub, caller_email, source_ip, request_id FROM audit_log WHERE tenant_id = ?1",
@@ -1022,7 +1009,10 @@ mod tests {
             .await
             .unwrap();
 
-        let err = store.delete_supernet(TEST_TENANT, &sn.id).await.unwrap_err();
+        let err = store
+            .delete_supernet(TEST_TENANT, &sn.id)
+            .await
+            .unwrap_err();
         assert!(matches!(err, NetcidrError::SupernetHasActiveAllocations(_)));
     }
 

--- a/src/ipam/sqlite/mod.rs
+++ b/src/ipam/sqlite/mod.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use crate::error::{NetcidrError, Result};
 use crate::ipam::models::*;
 use crate::ipam::store::IpamStore;
-use crate::ipam::{parse_cidr_metadata, read_total_hosts, total_hosts_as_i64};
+use crate::ipam::{parse_cidr_metadata, read_total_hosts};
 
 type ConnPool = Pool<SqliteConnectionManager>;
 
@@ -95,16 +95,16 @@ impl SqliteStore {
         let status = status_str
             .parse::<AllocationStatus>()
             .unwrap_or(AllocationStatus::Active);
-        let total_hosts_i64: i64 = row.get("total_hosts")?;
-        let total_hosts_text: Option<String> = row.get("total_hosts_text")?;
+        let total_hosts_text: String = row.get("total_hosts")?;
         Ok(Allocation {
             id: row.get("id")?,
+            tenant_id: row.get("tenant_id")?,
             supernet_id: row.get("supernet_id")?,
             cidr: row.get("cidr")?,
             network_address: row.get("network_address")?,
             broadcast_address: row.get("broadcast_address")?,
             prefix_length: row.get::<_, u8>("prefix_length")?,
-            total_hosts: read_total_hosts(total_hosts_text, total_hosts_i64),
+            total_hosts: read_total_hosts(Some(total_hosts_text), 0),
             status,
             resource_id: row.get("resource_id")?,
             resource_type: row.get("resource_type")?,
@@ -119,6 +119,27 @@ impl SqliteStore {
             released_at: row.get("released_at")?,
             expires_at: row.get("expires_at")?,
         })
+    }
+
+    /// Verify that an allocation exists and belongs to the given tenant. Used
+    /// before reading or mutating tag tables (which don't carry tenant_id
+    /// directly).
+    fn assert_allocation_in_tenant(
+        conn: &rusqlite::Connection,
+        tenant_id: &str,
+        allocation_id: &str,
+    ) -> Result<()> {
+        let exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM allocations WHERE id = ?1 AND tenant_id = ?2",
+                params![allocation_id, tenant_id],
+                |row| row.get(0),
+            )
+            .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
+        if !exists {
+            return Err(NetcidrError::AllocationNotFound(allocation_id.to_string()));
+        }
+        Ok(())
     }
 }
 
@@ -167,7 +188,11 @@ impl IpamStore for SqliteStore {
 
     // --- supernets ---
 
-    async fn create_supernet(&self, input: &CreateSupernet) -> Result<Supernet> {
+    async fn create_supernet(
+        &self,
+        tenant_id: &str,
+        input: &CreateSupernet,
+    ) -> Result<Supernet> {
         let conn = self.conn()?;
         let id = uuid::Uuid::new_v4().to_string();
         let now = Self::now();
@@ -176,13 +201,14 @@ impl IpamStore for SqliteStore {
         let (network, broadcast, prefix, total, ip_version) = parse_cidr_metadata(&input.cidr)?;
 
         conn.execute(
-            "INSERT INTO supernets (id, cidr, network_address, broadcast_address, prefix_length, total_hosts, total_hosts_text, name, description, ip_version, created_at, updated_at)
+            "INSERT INTO supernets (id, tenant_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, name, description, ip_version, created_at, updated_at)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
-            params![id, input.cidr, network, broadcast, prefix, total_hosts_as_i64(total), total.to_string(), input.name, input.description, ip_version, now, now],
+            params![id, tenant_id, input.cidr, network, broadcast, prefix, total.to_string(), input.name, input.description, ip_version, now, now],
         ).map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
 
         Ok(Supernet {
             id,
+            tenant_id: tenant_id.to_string(),
             cidr: input.cidr.clone(),
             network_address: network,
             broadcast_address: broadcast,
@@ -196,21 +222,21 @@ impl IpamStore for SqliteStore {
         })
     }
 
-    async fn get_supernet(&self, id: &str) -> Result<Supernet> {
+    async fn get_supernet(&self, tenant_id: &str, id: &str) -> Result<Supernet> {
         let conn = self.conn()?;
         conn.query_row(
-            "SELECT id, cidr, network_address, broadcast_address, prefix_length, total_hosts, total_hosts_text, name, description, ip_version, created_at, updated_at FROM supernets WHERE id = ?1",
-            params![id],
+            "SELECT id, tenant_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, name, description, ip_version, created_at, updated_at FROM supernets WHERE id = ?1 AND tenant_id = ?2",
+            params![id, tenant_id],
             |row| {
-                let total_hosts_i64: i64 = row.get(5)?;
-                let total_hosts_text: Option<String> = row.get(6)?;
+                let total_hosts_text: String = row.get(6)?;
                 Ok(Supernet {
                     id: row.get(0)?,
-                    cidr: row.get(1)?,
-                    network_address: row.get(2)?,
-                    broadcast_address: row.get(3)?,
-                    prefix_length: row.get(4)?,
-                    total_hosts: read_total_hosts(total_hosts_text, total_hosts_i64),
+                    tenant_id: row.get(1)?,
+                    cidr: row.get(2)?,
+                    network_address: row.get(3)?,
+                    broadcast_address: row.get(4)?,
+                    prefix_length: row.get(5)?,
+                    total_hosts: read_total_hosts(Some(total_hosts_text), 0),
                     name: row.get(7)?,
                     description: row.get(8)?,
                     ip_version: row.get(9)?,
@@ -224,22 +250,22 @@ impl IpamStore for SqliteStore {
         })
     }
 
-    async fn list_supernets(&self) -> Result<Vec<Supernet>> {
+    async fn list_supernets(&self, tenant_id: &str) -> Result<Vec<Supernet>> {
         let conn = self.conn()?;
         let mut stmt = conn
-            .prepare("SELECT id, cidr, network_address, broadcast_address, prefix_length, total_hosts, total_hosts_text, name, description, ip_version, created_at, updated_at FROM supernets ORDER BY created_at")
+            .prepare("SELECT id, tenant_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, name, description, ip_version, created_at, updated_at FROM supernets WHERE tenant_id = ?1 ORDER BY created_at")
             .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
         let rows = stmt
-            .query_map([], |row| {
-                let total_hosts_i64: i64 = row.get(5)?;
-                let total_hosts_text: Option<String> = row.get(6)?;
+            .query_map(params![tenant_id], |row| {
+                let total_hosts_text: String = row.get(6)?;
                 Ok(Supernet {
                     id: row.get(0)?,
-                    cidr: row.get(1)?,
-                    network_address: row.get(2)?,
-                    broadcast_address: row.get(3)?,
-                    prefix_length: row.get(4)?,
-                    total_hosts: read_total_hosts(total_hosts_text, total_hosts_i64),
+                    tenant_id: row.get(1)?,
+                    cidr: row.get(2)?,
+                    network_address: row.get(3)?,
+                    broadcast_address: row.get(4)?,
+                    prefix_length: row.get(5)?,
+                    total_hosts: read_total_hosts(Some(total_hosts_text), 0),
                     name: row.get(7)?,
                     description: row.get(8)?,
                     ip_version: row.get(9)?,
@@ -253,14 +279,26 @@ impl IpamStore for SqliteStore {
         Ok(rows)
     }
 
-    async fn delete_supernet(&self, id: &str) -> Result<()> {
+    async fn delete_supernet(&self, tenant_id: &str, id: &str) -> Result<()> {
         let conn = self.conn()?;
+
+        // Verify supernet exists in this tenant first; cross-tenant ⇒ NotFound.
+        let exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM supernets WHERE id = ?1 AND tenant_id = ?2",
+                params![id, tenant_id],
+                |row| row.get(0),
+            )
+            .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
+        if !exists {
+            return Err(NetcidrError::SupernetNotFound(id.to_string()));
+        }
 
         // Check for active allocations
         let active_count: u32 = conn
             .query_row(
-                "SELECT COUNT(*) FROM allocations WHERE supernet_id = ?1 AND status != 'released'",
-                params![id],
+                "SELECT COUNT(*) FROM allocations WHERE supernet_id = ?1 AND tenant_id = ?2 AND status != 'released'",
+                params![id, tenant_id],
                 |row| row.get(0),
             )
             .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
@@ -271,18 +309,21 @@ impl IpamStore for SqliteStore {
 
         // Delete released allocations' tags, then allocations, then supernet
         conn.execute(
-            "DELETE FROM allocation_tags WHERE allocation_id IN (SELECT id FROM allocations WHERE supernet_id = ?1)",
-            params![id],
+            "DELETE FROM allocation_tags WHERE allocation_id IN (SELECT id FROM allocations WHERE supernet_id = ?1 AND tenant_id = ?2)",
+            params![id, tenant_id],
         ).map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
 
         conn.execute(
-            "DELETE FROM allocations WHERE supernet_id = ?1",
-            params![id],
+            "DELETE FROM allocations WHERE supernet_id = ?1 AND tenant_id = ?2",
+            params![id, tenant_id],
         )
         .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
 
         let deleted = conn
-            .execute("DELETE FROM supernets WHERE id = ?1", params![id])
+            .execute(
+                "DELETE FROM supernets WHERE id = ?1 AND tenant_id = ?2",
+                params![id, tenant_id],
+            )
             .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
 
         if deleted == 0 {
@@ -293,7 +334,11 @@ impl IpamStore for SqliteStore {
 
     // --- allocations ---
 
-    async fn create_allocation(&self, input: &CreateAllocation) -> Result<Allocation> {
+    async fn create_allocation(
+        &self,
+        tenant_id: &str,
+        input: &CreateAllocation,
+    ) -> Result<Allocation> {
         let conn = self.conn()?;
         let id = uuid::Uuid::new_v4().to_string();
         let now = Self::now();
@@ -309,12 +354,27 @@ impl IpamStore for SqliteStore {
             .ttl_seconds
             .map(|ttl| (Utc::now() + chrono::Duration::seconds(ttl as i64)).to_rfc3339());
 
+        // Application-level cross-tenant invariant: confirm the parent
+        // supernet belongs to this tenant. Returning NotFound (not Forbidden)
+        // disguises cross-tenant references as missing rows. The DB trigger
+        // is belt-and-suspenders.
+        let supernet_in_tenant: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM supernets WHERE id = ?1 AND tenant_id = ?2",
+                params![input.supernet_id, tenant_id],
+                |row| row.get(0),
+            )
+            .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
+        if !supernet_in_tenant {
+            return Err(NetcidrError::SupernetNotFound(input.supernet_id.clone()));
+        }
+
         conn.execute(
-            "INSERT INTO allocations (id, supernet_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, total_hosts_text, resource_id, resource_type, name, description, environment, owner, status, parent_allocation_id, created_at, updated_at, expires_at)
+            "INSERT INTO allocations (id, tenant_id, supernet_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, resource_id, resource_type, name, description, environment, owner, status, parent_allocation_id, created_at, updated_at, expires_at)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)",
             params![
-                id, input.supernet_id, input.cidr, network, broadcast, prefix,
-                total_hosts_as_i64(total), total.to_string(),
+                id, tenant_id, input.supernet_id, input.cidr, network, broadcast, prefix,
+                total.to_string(),
                 input.resource_id, input.resource_type, input.name, input.description,
                 input.environment, input.owner, status, input.parent_allocation_id, now, now,
                 expires_at
@@ -335,6 +395,7 @@ impl IpamStore for SqliteStore {
         let tags = input.tags.clone().unwrap_or_default();
         Ok(Allocation {
             id,
+            tenant_id: tenant_id.to_string(),
             supernet_id: input.supernet_id.clone(),
             cidr: input.cidr.clone(),
             network_address: network,
@@ -357,12 +418,12 @@ impl IpamStore for SqliteStore {
         })
     }
 
-    async fn get_allocation(&self, id: &str) -> Result<Allocation> {
+    async fn get_allocation(&self, tenant_id: &str, id: &str) -> Result<Allocation> {
         let conn = self.conn()?;
         let mut alloc = conn
             .query_row(
-                "SELECT id, supernet_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, total_hosts_text, resource_id, resource_type, name, description, environment, owner, status, parent_allocation_id, created_at, updated_at, released_at, expires_at FROM allocations WHERE id = ?1",
-                params![id],
+                "SELECT id, tenant_id, supernet_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, resource_id, resource_type, name, description, environment, owner, status, parent_allocation_id, created_at, updated_at, released_at, expires_at FROM allocations WHERE id = ?1 AND tenant_id = ?2",
+                params![id, tenant_id],
                 Self::row_to_allocation,
             )
             .map_err(|e| match e {
@@ -373,13 +434,18 @@ impl IpamStore for SqliteStore {
         Ok(alloc)
     }
 
-    async fn list_allocations(&self, filter: &AllocationFilter) -> Result<Vec<Allocation>> {
+    async fn list_allocations(
+        &self,
+        tenant_id: &str,
+        filter: &AllocationFilter,
+    ) -> Result<Vec<Allocation>> {
         let conn = self.conn()?;
         let mut sql = String::from(
-            "SELECT id, supernet_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, total_hosts_text, resource_id, resource_type, name, description, environment, owner, status, parent_allocation_id, created_at, updated_at, released_at, expires_at FROM allocations WHERE 1=1",
+            "SELECT id, tenant_id, supernet_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, resource_id, resource_type, name, description, environment, owner, status, parent_allocation_id, created_at, updated_at, released_at, expires_at FROM allocations WHERE tenant_id = ?1",
         );
         let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
-        let mut idx = 1;
+        param_values.push(Box::new(tenant_id.to_string()));
+        let mut idx = 2;
 
         if let Some(ref sid) = filter.supernet_id {
             sql.push_str(&format!(" AND supernet_id = ?{}", idx));
@@ -437,22 +503,17 @@ impl IpamStore for SqliteStore {
         Ok(allocations)
     }
 
-    async fn update_allocation(&self, id: &str, input: &UpdateAllocation) -> Result<Allocation> {
+    async fn update_allocation(
+        &self,
+        tenant_id: &str,
+        id: &str,
+        input: &UpdateAllocation,
+    ) -> Result<Allocation> {
         let conn = self.conn()?;
         let now = Self::now();
 
-        // Verify allocation exists
-        conn.query_row(
-            "SELECT id FROM allocations WHERE id = ?1",
-            params![id],
-            |_| Ok(()),
-        )
-        .map_err(|e| match e {
-            rusqlite::Error::QueryReturnedNoRows => {
-                NetcidrError::AllocationNotFound(id.to_string())
-            }
-            _ => NetcidrError::DatabaseError(e.to_string()),
-        })?;
+        // Verify allocation exists in this tenant
+        Self::assert_allocation_in_tenant(&conn, tenant_id, id)?;
 
         let mut sets = vec!["updated_at = ?1".to_string()];
         let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(now)];
@@ -483,16 +544,16 @@ impl IpamStore for SqliteStore {
             }
         }
 
+        let id_idx = idx;
+        let tenant_idx = idx + 1;
         let sql = format!(
-            "UPDATE allocations SET {} WHERE id = ?{}",
+            "UPDATE allocations SET {} WHERE id = ?{} AND tenant_id = ?{}",
             sets.join(", "),
-            idx
+            id_idx,
+            tenant_idx,
         );
         param_values.push(Box::new(id.to_string()));
-        #[allow(unused_assignments)]
-        {
-            idx += 1;
-        }
+        param_values.push(Box::new(tenant_id.to_string()));
 
         let params_refs: Vec<&dyn rusqlite::types::ToSql> =
             param_values.iter().map(|p| p.as_ref()).collect();
@@ -503,8 +564,8 @@ impl IpamStore for SqliteStore {
         // Fetch updated allocation using same connection
         let mut alloc = conn
             .query_row(
-                "SELECT id, supernet_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, total_hosts_text, resource_id, resource_type, name, description, environment, owner, status, parent_allocation_id, created_at, updated_at, released_at, expires_at FROM allocations WHERE id = ?1",
-                params![id],
+                "SELECT id, tenant_id, supernet_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, resource_id, resource_type, name, description, environment, owner, status, parent_allocation_id, created_at, updated_at, released_at, expires_at FROM allocations WHERE id = ?1 AND tenant_id = ?2",
+                params![id, tenant_id],
                 Self::row_to_allocation,
             )
             .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
@@ -512,22 +573,23 @@ impl IpamStore for SqliteStore {
         Ok(alloc)
     }
 
-    async fn release_allocation(&self, id: &str) -> Result<Allocation> {
+    async fn release_allocation(&self, tenant_id: &str, id: &str) -> Result<Allocation> {
         let conn = self.conn()?;
         let now = Self::now();
 
         let updated = conn
             .execute(
-                "UPDATE allocations SET status = 'released', released_at = ?1, updated_at = ?1 WHERE id = ?2 AND status != 'released'",
-                params![now, id],
+                "UPDATE allocations SET status = 'released', released_at = ?1, updated_at = ?1 WHERE id = ?2 AND tenant_id = ?3 AND status != 'released'",
+                params![now, id, tenant_id],
             )
             .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
 
         if updated == 0 {
+            // Either it doesn't exist (in this tenant) or it's already released.
             let exists: bool = conn
                 .query_row(
-                    "SELECT COUNT(*) > 0 FROM allocations WHERE id = ?1",
-                    params![id],
+                    "SELECT COUNT(*) > 0 FROM allocations WHERE id = ?1 AND tenant_id = ?2",
+                    params![id, tenant_id],
                     |row| row.get(0),
                 )
                 .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
@@ -539,8 +601,8 @@ impl IpamStore for SqliteStore {
         // Fetch using same connection to avoid pool exhaustion
         let mut alloc = conn
             .query_row(
-                "SELECT id, supernet_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, total_hosts_text, resource_id, resource_type, name, description, environment, owner, status, parent_allocation_id, created_at, updated_at, released_at, expires_at FROM allocations WHERE id = ?1",
-                params![id],
+                "SELECT id, tenant_id, supernet_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, resource_id, resource_type, name, description, environment, owner, status, parent_allocation_id, created_at, updated_at, released_at, expires_at FROM allocations WHERE id = ?1 AND tenant_id = ?2",
+                params![id, tenant_id],
                 Self::row_to_allocation,
             )
             .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
@@ -550,6 +612,7 @@ impl IpamStore for SqliteStore {
 
     async fn find_allocations_in_supernet(
         &self,
+        tenant_id: &str,
         supernet_id: &str,
         statuses: &[AllocationStatus],
     ) -> Result<Vec<Allocation>> {
@@ -557,15 +620,17 @@ impl IpamStore for SqliteStore {
             return Ok(Vec::new());
         }
         let conn = self.conn()?;
+        // ?1 = supernet_id, ?2 = tenant_id, statuses start at ?3.
         let placeholders: Vec<String> =
-            (0..statuses.len()).map(|i| format!("?{}", i + 2)).collect();
+            (0..statuses.len()).map(|i| format!("?{}", i + 3)).collect();
         let sql = format!(
-            "SELECT id, supernet_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, total_hosts_text, resource_id, resource_type, name, description, environment, owner, status, parent_allocation_id, created_at, updated_at, released_at, expires_at FROM allocations WHERE supernet_id = ?1 AND status IN ({}) ORDER BY network_address",
+            "SELECT id, tenant_id, supernet_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, resource_id, resource_type, name, description, environment, owner, status, parent_allocation_id, created_at, updated_at, released_at, expires_at FROM allocations WHERE supernet_id = ?1 AND tenant_id = ?2 AND status IN ({}) ORDER BY network_address",
             placeholders.join(", ")
         );
 
         let mut params_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
         params_values.push(Box::new(supernet_id.to_string()));
+        params_values.push(Box::new(tenant_id.to_string()));
         for s in statuses {
             params_values.push(Box::new(s.to_string()));
         }
@@ -590,8 +655,15 @@ impl IpamStore for SqliteStore {
 
     // --- tags ---
 
-    async fn set_tags(&self, allocation_id: &str, tags: &[Tag]) -> Result<()> {
+    async fn set_tags(
+        &self,
+        tenant_id: &str,
+        allocation_id: &str,
+        tags: &[Tag],
+    ) -> Result<()> {
         let conn = self.conn()?;
+        Self::assert_allocation_in_tenant(&conn, tenant_id, allocation_id)?;
+
         conn.execute(
             "DELETE FROM allocation_tags WHERE allocation_id = ?1",
             params![allocation_id],
@@ -608,8 +680,9 @@ impl IpamStore for SqliteStore {
         Ok(())
     }
 
-    async fn get_tags(&self, allocation_id: &str) -> Result<Vec<Tag>> {
+    async fn get_tags(&self, tenant_id: &str, allocation_id: &str) -> Result<Vec<Tag>> {
         let conn = self.conn()?;
+        Self::assert_allocation_in_tenant(&conn, tenant_id, allocation_id)?;
         Self::load_tags_for_allocation(&conn, allocation_id)
     }
 
@@ -618,8 +691,9 @@ impl IpamStore for SqliteStore {
     async fn append_audit(&self, entry: &AuditEntry) -> Result<()> {
         let conn = self.conn()?;
         conn.execute(
-            "INSERT INTO audit_log (timestamp, action, entity_type, entity_id, details, caller_sub, caller_email, source_ip, request_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            "INSERT INTO audit_log (tenant_id, timestamp, action, entity_type, entity_id, details, caller_sub, caller_email, source_ip, request_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
             params![
+                entry.tenant_id,
                 entry.timestamp,
                 entry.action,
                 entry.entity_type,
@@ -634,13 +708,18 @@ impl IpamStore for SqliteStore {
         Ok(())
     }
 
-    async fn query_audit(&self, filter: &AuditFilter) -> Result<Vec<AuditEntry>> {
+    async fn query_audit(
+        &self,
+        tenant_id: &str,
+        filter: &AuditFilter,
+    ) -> Result<Vec<AuditEntry>> {
         let conn = self.conn()?;
         let mut sql = String::from(
-            "SELECT id, timestamp, action, entity_type, entity_id, details, caller_sub, caller_email, source_ip, request_id FROM audit_log WHERE 1=1",
+            "SELECT id, tenant_id, timestamp, action, entity_type, entity_id, details, caller_sub, caller_email, source_ip, request_id FROM audit_log WHERE tenant_id = ?1",
         );
         let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
-        let mut idx = 1;
+        param_values.push(Box::new(tenant_id.to_string()));
+        let mut idx = 2;
 
         if let Some(ref et) = filter.entity_type {
             sql.push_str(&format!(" AND entity_type = ?{}", idx));
@@ -655,10 +734,7 @@ impl IpamStore for SqliteStore {
         if let Some(ref action) = filter.action {
             sql.push_str(&format!(" AND action = ?{}", idx));
             param_values.push(Box::new(action.clone()));
-            #[allow(unused_assignments)]
-            {
-                idx += 1;
-            }
+            idx += 1;
         }
 
         sql.push_str(" ORDER BY id DESC");
@@ -681,15 +757,16 @@ impl IpamStore for SqliteStore {
                 let id_int: i64 = row.get(0)?;
                 Ok(AuditEntry {
                     id: id_int.to_string(),
-                    timestamp: row.get(1)?,
-                    action: row.get(2)?,
-                    entity_type: row.get(3)?,
-                    entity_id: row.get(4)?,
-                    details: row.get(5)?,
-                    caller_sub: row.get(6)?,
-                    caller_email: row.get(7)?,
-                    source_ip: row.get(8)?,
-                    request_id: row.get(9)?,
+                    tenant_id: row.get(1)?,
+                    timestamp: row.get(2)?,
+                    action: row.get(3)?,
+                    entity_type: row.get(4)?,
+                    entity_id: row.get(5)?,
+                    details: row.get(6)?,
+                    caller_sub: row.get(7)?,
+                    caller_email: row.get(8)?,
+                    source_ip: row.get(9)?,
+                    request_id: row.get(10)?,
                 })
             })
             .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?
@@ -698,43 +775,51 @@ impl IpamStore for SqliteStore {
         Ok(rows)
     }
 
-    async fn idempotency_get(&self, key: &str, scope: &str) -> Result<Option<IdempotencyRecord>> {
+    async fn idempotency_get(
+        &self,
+        tenant_id: &str,
+        key: &str,
+        scope: &str,
+    ) -> Result<Option<IdempotencyRecord>> {
         let conn = self.conn()?;
         let mut stmt = conn
             .prepare(
-                "SELECT key, scope, request_hash, status_code, response_body, created_at, expires_at \
-                 FROM idempotency_keys WHERE key = ?1 AND scope = ?2",
+                "SELECT tenant_id, key, scope, request_hash, status_code, response_body, created_at, expires_at \
+                 FROM idempotency_keys WHERE tenant_id = ?1 AND key = ?2 AND scope = ?3",
             )
             .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
         let mut rows = stmt
-            .query(params![key, scope])
+            .query(params![tenant_id, key, scope])
             .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
         if let Some(row) = rows
             .next()
             .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?
         {
             let status_code: i64 = row
-                .get(3)
+                .get(4)
                 .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
             Ok(Some(IdempotencyRecord {
-                key: row
+                tenant_id: row
                     .get(0)
                     .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?,
-                scope: row
+                key: row
                     .get(1)
                     .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?,
-                request_hash: row
+                scope: row
                     .get(2)
+                    .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?,
+                request_hash: row
+                    .get(3)
                     .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?,
                 status_code: status_code as u16,
                 response_body: row
-                    .get(4)
-                    .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?,
-                created_at: row
                     .get(5)
                     .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?,
-                expires_at: row
+                created_at: row
                     .get(6)
+                    .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?,
+                expires_at: row
+                    .get(7)
                     .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?,
             }))
         } else {
@@ -746,10 +831,11 @@ impl IpamStore for SqliteStore {
         let conn = self.conn()?;
         conn.execute(
             "INSERT INTO idempotency_keys \
-                (key, scope, request_hash, status_code, response_body, created_at, expires_at) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7) \
-             ON CONFLICT(key, scope) DO NOTHING",
+                (tenant_id, key, scope, request_hash, status_code, response_body, created_at, expires_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8) \
+             ON CONFLICT(tenant_id, key, scope) DO NOTHING",
             params![
+                record.tenant_id,
                 record.key,
                 record.scope,
                 record.request_hash,
@@ -780,6 +866,8 @@ mod tests {
     use super::*;
     use crate::ipam::parse_cidr_metadata;
 
+    const TEST_TENANT: &str = "test@example.com";
+
     async fn test_store() -> SqliteStore {
         let store = SqliteStore::in_memory().unwrap();
         store.initialize().await.unwrap();
@@ -792,11 +880,14 @@ mod tests {
         let store = test_store().await;
 
         let sn = store
-            .create_supernet(&CreateSupernet {
-                cidr: "10.0.0.0/8".to_string(),
-                name: Some("RFC1918 Class A".to_string()),
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "10.0.0.0/8".to_string(),
+                    name: Some("RFC1918 Class A".to_string()),
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
@@ -805,15 +896,16 @@ mod tests {
         assert_eq!(sn.broadcast_address, "10.255.255.255");
         assert_eq!(sn.prefix_length, 8);
         assert_eq!(sn.ip_version, 4);
+        assert_eq!(sn.tenant_id, TEST_TENANT);
 
-        let fetched = store.get_supernet(&sn.id).await.unwrap();
+        let fetched = store.get_supernet(TEST_TENANT, &sn.id).await.unwrap();
         assert_eq!(fetched.cidr, "10.0.0.0/8");
 
-        let all = store.list_supernets().await.unwrap();
+        let all = store.list_supernets(TEST_TENANT).await.unwrap();
         assert_eq!(all.len(), 1);
 
-        store.delete_supernet(&sn.id).await.unwrap();
-        let all = store.list_supernets().await.unwrap();
+        store.delete_supernet(TEST_TENANT, &sn.id).await.unwrap();
+        let all = store.list_supernets(TEST_TENANT).await.unwrap();
         assert!(all.is_empty());
     }
 
@@ -822,45 +914,53 @@ mod tests {
         let store = test_store().await;
 
         let sn = store
-            .create_supernet(&CreateSupernet {
-                cidr: "10.0.0.0/8".to_string(),
-                name: None,
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "10.0.0.0/8".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
         let alloc = store
-            .create_allocation(&CreateAllocation {
-                supernet_id: sn.id.clone(),
-                cidr: "10.0.0.0/24".to_string(),
-                status: None,
-                resource_id: Some("vpc-123".to_string()),
-                resource_type: Some("vpc".to_string()),
-                name: Some("test".to_string()),
-                description: None,
-                environment: Some("production".to_string()),
-                owner: Some("team-a".to_string()),
-                parent_allocation_id: None,
-                tags: Some(vec![Tag {
-                    key: "env".to_string(),
-                    value: "prod".to_string(),
-                }]),
-                ttl_seconds: None,
-            })
+            .create_allocation(
+                TEST_TENANT,
+                &CreateAllocation {
+                    supernet_id: sn.id.clone(),
+                    cidr: "10.0.0.0/24".to_string(),
+                    status: None,
+                    resource_id: Some("vpc-123".to_string()),
+                    resource_type: Some("vpc".to_string()),
+                    name: Some("test".to_string()),
+                    description: None,
+                    environment: Some("production".to_string()),
+                    owner: Some("team-a".to_string()),
+                    parent_allocation_id: None,
+                    tags: Some(vec![Tag {
+                        key: "env".to_string(),
+                        value: "prod".to_string(),
+                    }]),
+                    ttl_seconds: None,
+                },
+            )
             .await
             .unwrap();
 
         assert_eq!(alloc.status, AllocationStatus::Active);
         assert_eq!(alloc.tags.len(), 1);
+        assert_eq!(alloc.tenant_id, TEST_TENANT);
 
-        let fetched = store.get_allocation(&alloc.id).await.unwrap();
+        let fetched = store.get_allocation(TEST_TENANT, &alloc.id).await.unwrap();
         assert_eq!(fetched.resource_id, Some("vpc-123".to_string()));
         assert_eq!(fetched.tags.len(), 1);
 
         // Update
         let updated = store
             .update_allocation(
+                TEST_TENANT,
                 &alloc.id,
                 &UpdateAllocation {
                     name: None,
@@ -877,7 +977,10 @@ mod tests {
         assert_eq!(updated.description, Some("updated desc".to_string()));
 
         // Release
-        let released = store.release_allocation(&alloc.id).await.unwrap();
+        let released = store
+            .release_allocation(TEST_TENANT, &alloc.id)
+            .await
+            .unwrap();
         assert_eq!(released.status, AllocationStatus::Released);
         assert!(released.released_at.is_some());
     }
@@ -887,33 +990,39 @@ mod tests {
         let store = test_store().await;
 
         let sn = store
-            .create_supernet(&CreateSupernet {
-                cidr: "10.0.0.0/8".to_string(),
-                name: None,
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "10.0.0.0/8".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
         store
-            .create_allocation(&CreateAllocation {
-                supernet_id: sn.id.clone(),
-                cidr: "10.0.0.0/24".to_string(),
-                status: None,
-                resource_id: None,
-                resource_type: None,
-                name: None,
-                description: None,
-                environment: None,
-                owner: None,
-                parent_allocation_id: None,
-                tags: None,
-                ttl_seconds: None,
-            })
+            .create_allocation(
+                TEST_TENANT,
+                &CreateAllocation {
+                    supernet_id: sn.id.clone(),
+                    cidr: "10.0.0.0/24".to_string(),
+                    status: None,
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: None,
+                },
+            )
             .await
             .unwrap();
 
-        let err = store.delete_supernet(&sn.id).await.unwrap_err();
+        let err = store.delete_supernet(TEST_TENANT, &sn.id).await.unwrap_err();
         assert!(matches!(err, NetcidrError::SupernetHasActiveAllocations(_)));
     }
 
@@ -922,54 +1031,64 @@ mod tests {
         let store = test_store().await;
 
         let sn = store
-            .create_supernet(&CreateSupernet {
-                cidr: "10.0.0.0/8".to_string(),
-                name: None,
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "10.0.0.0/8".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
         let a1 = store
-            .create_allocation(&CreateAllocation {
-                supernet_id: sn.id.clone(),
-                cidr: "10.0.0.0/24".to_string(),
-                status: None,
-                resource_id: None,
-                resource_type: None,
-                name: None,
-                description: None,
-                environment: None,
-                owner: None,
-                parent_allocation_id: None,
-                tags: None,
-                ttl_seconds: None,
-            })
+            .create_allocation(
+                TEST_TENANT,
+                &CreateAllocation {
+                    supernet_id: sn.id.clone(),
+                    cidr: "10.0.0.0/24".to_string(),
+                    status: None,
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: None,
+                },
+            )
             .await
             .unwrap();
 
         store
-            .create_allocation(&CreateAllocation {
-                supernet_id: sn.id.clone(),
-                cidr: "10.0.1.0/24".to_string(),
-                status: Some(AllocationStatus::Reserved),
-                resource_id: None,
-                resource_type: None,
-                name: None,
-                description: None,
-                environment: None,
-                owner: None,
-                parent_allocation_id: None,
-                tags: None,
-                ttl_seconds: None,
-            })
+            .create_allocation(
+                TEST_TENANT,
+                &CreateAllocation {
+                    supernet_id: sn.id.clone(),
+                    cidr: "10.0.1.0/24".to_string(),
+                    status: Some(AllocationStatus::Reserved),
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: None,
+                },
+            )
             .await
             .unwrap();
 
-        store.release_allocation(&a1.id).await.unwrap();
+        store.release_allocation(TEST_TENANT, &a1.id).await.unwrap();
 
         let active = store
             .find_allocations_in_supernet(
+                TEST_TENANT,
                 &sn.id,
                 &[AllocationStatus::Active, AllocationStatus::Reserved],
             )
@@ -986,6 +1105,7 @@ mod tests {
         store
             .append_audit(&AuditEntry {
                 id: String::new(),
+                tenant_id: TEST_TENANT.to_string(),
                 entity_type: "supernet".to_string(),
                 entity_id: "sn-1".to_string(),
                 action: "create_supernet".to_string(),
@@ -997,10 +1117,13 @@ mod tests {
             .unwrap();
 
         let entries = store
-            .query_audit(&AuditFilter {
-                entity_id: Some("sn-1".to_string()),
-                ..Default::default()
-            })
+            .query_audit(
+                TEST_TENANT,
+                &AuditFilter {
+                    entity_id: Some("sn-1".to_string()),
+                    ..Default::default()
+                },
+            )
             .await
             .unwrap();
         assert_eq!(entries.len(), 1);
@@ -1012,34 +1135,41 @@ mod tests {
         let store = test_store().await;
 
         let sn = store
-            .create_supernet(&CreateSupernet {
-                cidr: "10.0.0.0/8".to_string(),
-                name: None,
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "10.0.0.0/8".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
         let alloc = store
-            .create_allocation(&CreateAllocation {
-                supernet_id: sn.id.clone(),
-                cidr: "10.0.0.0/24".to_string(),
-                status: None,
-                resource_id: None,
-                resource_type: None,
-                name: None,
-                description: None,
-                environment: None,
-                owner: None,
-                parent_allocation_id: None,
-                tags: None,
-                ttl_seconds: None,
-            })
+            .create_allocation(
+                TEST_TENANT,
+                &CreateAllocation {
+                    supernet_id: sn.id.clone(),
+                    cidr: "10.0.0.0/24".to_string(),
+                    status: None,
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: None,
+                },
+            )
             .await
             .unwrap();
 
         store
             .set_tags(
+                TEST_TENANT,
                 &alloc.id,
                 &[
                     Tag {
@@ -1055,12 +1185,13 @@ mod tests {
             .await
             .unwrap();
 
-        let tags = store.get_tags(&alloc.id).await.unwrap();
+        let tags = store.get_tags(TEST_TENANT, &alloc.id).await.unwrap();
         assert_eq!(tags.len(), 2);
 
         // Replace tags
         store
             .set_tags(
+                TEST_TENANT,
                 &alloc.id,
                 &[Tag {
                     key: "env".to_string(),
@@ -1069,7 +1200,7 @@ mod tests {
             )
             .await
             .unwrap();
-        let tags = store.get_tags(&alloc.id).await.unwrap();
+        let tags = store.get_tags(TEST_TENANT, &alloc.id).await.unwrap();
         assert_eq!(tags.len(), 1);
         assert_eq!(tags[0].value, "staging");
     }
@@ -1142,11 +1273,14 @@ mod tests {
 
         // Create an IPv6 /32 supernet (2^96 addresses > i64::MAX)
         let sn = store
-            .create_supernet(&CreateSupernet {
-                cidr: "2001:db8::/32".to_string(),
-                name: Some("IPv6 test".to_string()),
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "2001:db8::/32".to_string(),
+                    name: Some("IPv6 test".to_string()),
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
@@ -1155,11 +1289,11 @@ mod tests {
         assert_eq!(sn.ip_version, 6);
 
         // Verify roundtrip through get
-        let fetched = store.get_supernet(&sn.id).await.unwrap();
+        let fetched = store.get_supernet(TEST_TENANT, &sn.id).await.unwrap();
         assert_eq!(fetched.total_hosts, expected);
 
         // Verify roundtrip through list
-        let all = store.list_supernets().await.unwrap();
+        let all = store.list_supernets(TEST_TENANT).await.unwrap();
         assert_eq!(all[0].total_hosts, expected);
     }
 
@@ -1168,29 +1302,35 @@ mod tests {
         let store = test_store().await;
 
         let sn = store
-            .create_supernet(&CreateSupernet {
-                cidr: "2001:db8::/32".to_string(),
-                name: None,
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "2001:db8::/32".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
         let alloc = store
-            .create_allocation(&CreateAllocation {
-                supernet_id: sn.id.clone(),
-                cidr: "2001:db8::/48".to_string(),
-                status: None,
-                resource_id: None,
-                resource_type: None,
-                name: None,
-                description: None,
-                environment: None,
-                owner: None,
-                parent_allocation_id: None,
-                tags: None,
-                ttl_seconds: None,
-            })
+            .create_allocation(
+                TEST_TENANT,
+                &CreateAllocation {
+                    supernet_id: sn.id.clone(),
+                    cidr: "2001:db8::/48".to_string(),
+                    status: None,
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: None,
+                },
+            )
             .await
             .unwrap();
 
@@ -1198,7 +1338,7 @@ mod tests {
         assert_eq!(alloc.total_hosts, expected);
 
         // Verify roundtrip through get
-        let fetched = store.get_allocation(&alloc.id).await.unwrap();
+        let fetched = store.get_allocation(TEST_TENANT, &alloc.id).await.unwrap();
         assert_eq!(fetched.total_hosts, expected);
     }
 
@@ -1215,6 +1355,7 @@ mod tests {
             store
                 .append_audit(&AuditEntry {
                     id: String::new(),
+                    tenant_id: TEST_TENANT.to_string(),
                     entity_type: "supernet".to_string(),
                     entity_id: format!("sn-{i}"),
                     action: "create_supernet".to_string(),
@@ -1228,10 +1369,13 @@ mod tests {
 
         // A limit larger than 10_000 must be silently capped — query must succeed.
         let entries = store
-            .query_audit(&AuditFilter {
-                limit: Some(u32::MAX),
-                ..Default::default()
-            })
+            .query_audit(
+                TEST_TENANT,
+                &AuditFilter {
+                    limit: Some(u32::MAX),
+                    ..Default::default()
+                },
+            )
             .await
             .unwrap();
         // All 5 entries are returned (well within the cap).
@@ -1246,6 +1390,7 @@ mod tests {
             store
                 .append_audit(&AuditEntry {
                     id: String::new(),
+                    tenant_id: TEST_TENANT.to_string(),
                     entity_type: "supernet".to_string(),
                     entity_id: format!("sn-{i}"),
                     action: "create_supernet".to_string(),
@@ -1258,10 +1403,13 @@ mod tests {
         }
 
         let entries = store
-            .query_audit(&AuditFilter {
-                limit: Some(3),
-                ..Default::default()
-            })
+            .query_audit(
+                TEST_TENANT,
+                &AuditFilter {
+                    limit: Some(3),
+                    ..Default::default()
+                },
+            )
             .await
             .unwrap();
         assert_eq!(entries.len(), 3);

--- a/src/ipam/sqlite/mod.rs
+++ b/src/ipam/sqlite/mod.rs
@@ -1250,13 +1250,6 @@ mod tests {
         assert_eq!(val, 256);
     }
 
-    #[test]
-    fn test_total_hosts_as_i64_clamps() {
-        use crate::ipam::total_hosts_as_i64;
-        assert_eq!(total_hosts_as_i64(256), 256);
-        assert_eq!(total_hosts_as_i64(1u128 << 96), i64::MAX);
-    }
-
     #[tokio::test]
     async fn test_ipv6_supernet_total_hosts_roundtrip() {
         let store = test_store().await;

--- a/src/ipam/store.rs
+++ b/src/ipam/store.rs
@@ -5,9 +5,11 @@ use crate::ipam::models::*;
 
 /// Core storage abstraction for the IPAM persistence layer.
 ///
-/// All methods take `&self` and return `Result<T>`. Backends manage their own
-/// connection pooling internally. Conflict detection and business logic live in
-/// `ipam::operations`, not here — the store is a thin persistence boundary.
+/// All tenant-scoped methods take an explicit `tenant_id: &str` parameter so
+/// the type system makes per-tenant filtering unforgettable. Backends must
+/// add `WHERE tenant_id = ?` to every query and refuse cross-tenant
+/// references with `IpamError::NotFound` (never `Forbidden`, to avoid
+/// leaking existence).
 #[async_trait]
 pub trait IpamStore: Send + Sync {
     // --- lifecycle ---
@@ -15,33 +17,68 @@ pub trait IpamStore: Send + Sync {
     async fn migrate(&self) -> Result<()>;
 
     // --- supernets ---
-    async fn create_supernet(&self, input: &CreateSupernet) -> Result<Supernet>;
-    async fn get_supernet(&self, id: &str) -> Result<Supernet>;
-    async fn list_supernets(&self) -> Result<Vec<Supernet>>;
-    async fn delete_supernet(&self, id: &str) -> Result<()>;
+    async fn create_supernet(
+        &self,
+        tenant_id: &str,
+        input: &CreateSupernet,
+    ) -> Result<Supernet>;
+    async fn get_supernet(&self, tenant_id: &str, id: &str) -> Result<Supernet>;
+    async fn list_supernets(&self, tenant_id: &str) -> Result<Vec<Supernet>>;
+    async fn delete_supernet(&self, tenant_id: &str, id: &str) -> Result<()>;
 
     // --- allocations ---
-    async fn create_allocation(&self, input: &CreateAllocation) -> Result<Allocation>;
-    async fn get_allocation(&self, id: &str) -> Result<Allocation>;
-    async fn list_allocations(&self, filter: &AllocationFilter) -> Result<Vec<Allocation>>;
-    async fn update_allocation(&self, id: &str, input: &UpdateAllocation) -> Result<Allocation>;
-    async fn release_allocation(&self, id: &str) -> Result<Allocation>;
+    async fn create_allocation(
+        &self,
+        tenant_id: &str,
+        input: &CreateAllocation,
+    ) -> Result<Allocation>;
+    async fn get_allocation(&self, tenant_id: &str, id: &str) -> Result<Allocation>;
+    async fn list_allocations(
+        &self,
+        tenant_id: &str,
+        filter: &AllocationFilter,
+    ) -> Result<Vec<Allocation>>;
+    async fn update_allocation(
+        &self,
+        tenant_id: &str,
+        id: &str,
+        input: &UpdateAllocation,
+    ) -> Result<Allocation>;
+    async fn release_allocation(&self, tenant_id: &str, id: &str) -> Result<Allocation>;
     async fn find_allocations_in_supernet(
         &self,
+        tenant_id: &str,
         supernet_id: &str,
         statuses: &[AllocationStatus],
     ) -> Result<Vec<Allocation>>;
 
     // --- tags ---
-    async fn set_tags(&self, allocation_id: &str, tags: &[Tag]) -> Result<()>;
-    async fn get_tags(&self, allocation_id: &str) -> Result<Vec<Tag>>;
+    async fn set_tags(
+        &self,
+        tenant_id: &str,
+        allocation_id: &str,
+        tags: &[Tag],
+    ) -> Result<()>;
+    async fn get_tags(&self, tenant_id: &str, allocation_id: &str) -> Result<Vec<Tag>>;
 
     // --- audit ---
+    /// `entry.tenant_id` is the source of truth (already populated by caller).
     async fn append_audit(&self, entry: &AuditEntry) -> Result<()>;
-    async fn query_audit(&self, filter: &AuditFilter) -> Result<Vec<AuditEntry>>;
+    async fn query_audit(
+        &self,
+        tenant_id: &str,
+        filter: &AuditFilter,
+    ) -> Result<Vec<AuditEntry>>;
 
     // --- idempotency ---
-    async fn idempotency_get(&self, key: &str, scope: &str) -> Result<Option<IdempotencyRecord>>;
+    async fn idempotency_get(
+        &self,
+        tenant_id: &str,
+        key: &str,
+        scope: &str,
+    ) -> Result<Option<IdempotencyRecord>>;
+    /// `record.tenant_id` is the source of truth.
     async fn idempotency_put(&self, record: &IdempotencyRecord) -> Result<()>;
+    /// Tenant-agnostic: prunes expired rows across all tenants.
     async fn idempotency_reap_expired(&self, now_rfc3339: &str) -> Result<u64>;
 }

--- a/src/ipam/store.rs
+++ b/src/ipam/store.rs
@@ -17,11 +17,7 @@ pub trait IpamStore: Send + Sync {
     async fn migrate(&self) -> Result<()>;
 
     // --- supernets ---
-    async fn create_supernet(
-        &self,
-        tenant_id: &str,
-        input: &CreateSupernet,
-    ) -> Result<Supernet>;
+    async fn create_supernet(&self, tenant_id: &str, input: &CreateSupernet) -> Result<Supernet>;
     async fn get_supernet(&self, tenant_id: &str, id: &str) -> Result<Supernet>;
     async fn list_supernets(&self, tenant_id: &str) -> Result<Vec<Supernet>>;
     async fn delete_supernet(&self, tenant_id: &str, id: &str) -> Result<()>;
@@ -53,22 +49,13 @@ pub trait IpamStore: Send + Sync {
     ) -> Result<Vec<Allocation>>;
 
     // --- tags ---
-    async fn set_tags(
-        &self,
-        tenant_id: &str,
-        allocation_id: &str,
-        tags: &[Tag],
-    ) -> Result<()>;
+    async fn set_tags(&self, tenant_id: &str, allocation_id: &str, tags: &[Tag]) -> Result<()>;
     async fn get_tags(&self, tenant_id: &str, allocation_id: &str) -> Result<Vec<Tag>>;
 
     // --- audit ---
     /// `entry.tenant_id` is the source of truth (already populated by caller).
     async fn append_audit(&self, entry: &AuditEntry) -> Result<()>;
-    async fn query_audit(
-        &self,
-        tenant_id: &str,
-        filter: &AuditFilter,
-    ) -> Result<Vec<AuditEntry>>;
+    async fn query_audit(&self, tenant_id: &str, filter: &AuditFilter) -> Result<Vec<AuditEntry>>;
 
     // --- idempotency ---
     async fn idempotency_get(

--- a/src/ipam_api.rs
+++ b/src/ipam_api.rs
@@ -97,6 +97,7 @@ fn error_to_parts(err: &NetcidrError) -> (StatusCode, String) {
 /// retry with the same key can still succeed once the underlying issue clears.
 async fn idempotent_post<T, F, Fut>(
     ops: Arc<IpamOps>,
+    tenant_id: String,
     headers: HeaderMap,
     body: Bytes,
     scope: String,
@@ -104,13 +105,13 @@ async fn idempotent_post<T, F, Fut>(
 ) -> Response
 where
     T: serde::de::DeserializeOwned,
-    F: FnOnce(Arc<IpamOps>, T) -> Fut,
+    F: FnOnce(Arc<IpamOps>, String, T) -> Fut,
     Fut: std::future::Future<
             Output = std::result::Result<(StatusCode, serde_json::Value), NetcidrError>,
         >,
 {
     let outcome = if body.len() <= idempotency::MAX_BODY_BYTES {
-        match idempotency::check(ops.store(), &headers, &scope, &body).await {
+        match idempotency::check(ops.store(), &tenant_id, &headers, &scope, &body).await {
             Ok(o) => o,
             Err(e) => return ipam_error_response(e),
         }
@@ -146,7 +147,7 @@ where
         Err(e) => return ipam_error_response(NetcidrError::InvalidInput(e.to_string())),
     };
 
-    let (status, value) = match handler(ops.clone(), parsed).await {
+    let (status, value) = match handler(ops.clone(), tenant_id.clone(), parsed).await {
         Ok(pair) => pair,
         Err(e) => error_to_status_value(e),
     };
@@ -157,6 +158,7 @@ where
         let cached_body = value.to_string();
         if let Err(e) = idempotency::record(
             ops.store(),
+            &tenant_id,
             &key,
             &scope,
             &request_hash,
@@ -348,9 +350,10 @@ pub fn create_ipam_router() -> Router {
 ))]
 async fn ipam_create_supernet(
     Extension(ops): Extension<Arc<IpamOps>>,
+    tenant: crate::tenant::Tenant,
     Json(body): Json<CreateSupernet>,
 ) -> impl IntoResponse {
-    match ops.create_supernet(&body).await {
+    match ops.create_supernet(tenant.as_str(), &body).await {
         Ok(supernet) => (StatusCode::CREATED, Json(supernet)).into_response(),
         Err(e) => ipam_error_response(e),
     }
@@ -364,8 +367,11 @@ async fn ipam_create_supernet(
     ),
     tag = "ipam"
 ))]
-async fn ipam_list_supernets(Extension(ops): Extension<Arc<IpamOps>>) -> impl IntoResponse {
-    match ops.list_supernets().await {
+async fn ipam_list_supernets(
+    Extension(ops): Extension<Arc<IpamOps>>,
+    tenant: crate::tenant::Tenant,
+) -> impl IntoResponse {
+    match ops.list_supernets(tenant.as_str()).await {
         Ok(supernets) => {
             let list = SupernetList {
                 count: supernets.len(),
@@ -391,9 +397,10 @@ async fn ipam_list_supernets(Extension(ops): Extension<Arc<IpamOps>>) -> impl In
 ))]
 async fn ipam_get_supernet(
     Extension(ops): Extension<Arc<IpamOps>>,
+    tenant: crate::tenant::Tenant,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
-    match ops.get_supernet(&id).await {
+    match ops.get_supernet(tenant.as_str(), &id).await {
         Ok(supernet) => Json(supernet).into_response(),
         Err(e) => ipam_error_response(e),
     }
@@ -414,9 +421,10 @@ async fn ipam_get_supernet(
 ))]
 async fn ipam_delete_supernet(
     Extension(ops): Extension<Arc<IpamOps>>,
+    tenant: crate::tenant::Tenant,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
-    match ops.delete_supernet(&id).await {
+    match ops.delete_supernet(tenant.as_str(), &id).await {
         Ok(()) => StatusCode::NO_CONTENT.into_response(),
         Err(e) => ipam_error_response(e),
     }
@@ -439,6 +447,7 @@ async fn ipam_delete_supernet(
 ))]
 async fn ipam_allocate_specific(
     Extension(ops): Extension<Arc<IpamOps>>,
+    tenant: crate::tenant::Tenant,
     Path(supernet_id): Path<String>,
     headers: HeaderMap,
     body: Bytes,
@@ -446,10 +455,11 @@ async fn ipam_allocate_specific(
     let scope = format!("allocate-specific:{supernet_id}");
     idempotent_post::<AllocateSpecificRequest, _, _>(
         ops,
+        tenant.0,
         headers,
         body,
         scope,
-        move |ops, parsed: AllocateSpecificRequest| {
+        move |ops, tenant_id, parsed: AllocateSpecificRequest| {
             let supernet_id = supernet_id.clone();
             async move {
                 let input = CreateAllocation {
@@ -466,7 +476,7 @@ async fn ipam_allocate_specific(
                     tags: parsed.tags,
                     ttl_seconds: parsed.ttl_seconds,
                 };
-                let allocation = ops.allocate_specific(&input).await?;
+                let allocation = ops.allocate_specific(&tenant_id, &input).await?;
                 Ok((
                     StatusCode::CREATED,
                     serde_json::to_value(&allocation).unwrap_or(serde_json::Value::Null),
@@ -493,6 +503,7 @@ async fn ipam_allocate_specific(
 ))]
 async fn ipam_auto_allocate(
     Extension(ops): Extension<Arc<IpamOps>>,
+    tenant: crate::tenant::Tenant,
     Path(supernet_id): Path<String>,
     headers: HeaderMap,
     body: Bytes,
@@ -500,10 +511,11 @@ async fn ipam_auto_allocate(
     let scope = format!("auto-allocate:{supernet_id}");
     idempotent_post::<AutoAllocateBody, _, _>(
         ops,
+        tenant.0,
         headers,
         body,
         scope,
-        move |ops, parsed: AutoAllocateBody| {
+        move |ops, tenant_id, parsed: AutoAllocateBody| {
             let supernet_id = supernet_id.clone();
             async move {
                 let request = AutoAllocateRequest {
@@ -521,7 +533,7 @@ async fn ipam_auto_allocate(
                     tags: parsed.tags,
                     ttl_seconds: parsed.ttl_seconds,
                 };
-                let allocations = ops.allocate_auto(&request).await?;
+                let allocations = ops.allocate_auto(&tenant_id, &request).await?;
                 let list = AllocationList {
                     count: allocations.len(),
                     allocations,
@@ -551,6 +563,7 @@ async fn ipam_auto_allocate(
 ))]
 async fn ipam_list_supernet_allocations(
     Extension(ops): Extension<Arc<IpamOps>>,
+    tenant: crate::tenant::Tenant,
     Path(supernet_id): Path<String>,
     Query(query): Query<AllocationFilterQuery>,
 ) -> impl IntoResponse {
@@ -563,7 +576,7 @@ async fn ipam_list_supernet_allocations(
         environment: query.environment,
         owner: query.owner,
     };
-    match ops.list_allocations(&filter).await {
+    match ops.list_allocations(tenant.as_str(), &filter).await {
         Ok(allocations) => {
             let list = AllocationList {
                 count: allocations.len(),
@@ -590,10 +603,14 @@ async fn ipam_list_supernet_allocations(
 ))]
 async fn ipam_free_blocks(
     Extension(ops): Extension<Arc<IpamOps>>,
+    tenant: crate::tenant::Tenant,
     Path(supernet_id): Path<String>,
     Query(query): Query<FreeBlocksQuery>,
 ) -> impl IntoResponse {
-    match ops.free_blocks(&supernet_id, query.prefix).await {
+    match ops
+        .free_blocks(tenant.as_str(), &supernet_id, query.prefix)
+        .await
+    {
         Ok(report) => Json(report).into_response(),
         Err(e) => ipam_error_response(e),
     }
@@ -613,9 +630,10 @@ async fn ipam_free_blocks(
 ))]
 async fn ipam_utilization(
     Extension(ops): Extension<Arc<IpamOps>>,
+    tenant: crate::tenant::Tenant,
     Path(supernet_id): Path<String>,
 ) -> impl IntoResponse {
-    match ops.utilization(&supernet_id).await {
+    match ops.utilization(tenant.as_str(), &supernet_id).await {
         Ok(report) => Json(report).into_response(),
         Err(e) => ipam_error_response(e),
     }
@@ -635,9 +653,10 @@ async fn ipam_utilization(
 ))]
 async fn ipam_get_allocation(
     Extension(ops): Extension<Arc<IpamOps>>,
+    tenant: crate::tenant::Tenant,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
-    match ops.get_allocation(&id).await {
+    match ops.get_allocation(tenant.as_str(), &id).await {
         Ok(allocation) => Json(allocation).into_response(),
         Err(e) => ipam_error_response(e),
     }
@@ -658,10 +677,11 @@ async fn ipam_get_allocation(
 ))]
 async fn ipam_update_allocation(
     Extension(ops): Extension<Arc<IpamOps>>,
+    tenant: crate::tenant::Tenant,
     Path(id): Path<String>,
     Json(body): Json<UpdateAllocation>,
 ) -> impl IntoResponse {
-    match ops.update_allocation(&id, &body).await {
+    match ops.update_allocation(tenant.as_str(), &id, &body).await {
         Ok(allocation) => Json(allocation).into_response(),
         Err(e) => ipam_error_response(e),
     }
@@ -681,9 +701,10 @@ async fn ipam_update_allocation(
 ))]
 async fn ipam_release_allocation(
     Extension(ops): Extension<Arc<IpamOps>>,
+    tenant: crate::tenant::Tenant,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
-    match ops.release_allocation(&id).await {
+    match ops.release_allocation(tenant.as_str(), &id).await {
         Ok(allocation) => Json(allocation).into_response(),
         Err(e) => ipam_error_response(e),
     }
@@ -702,9 +723,10 @@ async fn ipam_release_allocation(
 ))]
 async fn ipam_find_ip(
     Extension(ops): Extension<Arc<IpamOps>>,
+    tenant: crate::tenant::Tenant,
     Path(address): Path<String>,
 ) -> impl IntoResponse {
-    match ops.find_by_ip(&address).await {
+    match ops.find_by_ip(tenant.as_str(), &address).await {
         Ok(allocations) => {
             let list = AllocationList {
                 count: allocations.len(),
@@ -729,9 +751,10 @@ async fn ipam_find_ip(
 ))]
 async fn ipam_find_resource(
     Extension(ops): Extension<Arc<IpamOps>>,
+    tenant: crate::tenant::Tenant,
     Path(resource_id): Path<String>,
 ) -> impl IntoResponse {
-    match ops.find_by_resource(&resource_id).await {
+    match ops.find_by_resource(tenant.as_str(), &resource_id).await {
         Ok(allocations) => {
             let list = AllocationList {
                 count: allocations.len(),
@@ -754,6 +777,7 @@ async fn ipam_find_resource(
 ))]
 async fn ipam_query_audit(
     Extension(ops): Extension<Arc<IpamOps>>,
+    tenant: crate::tenant::Tenant,
     Query(query): Query<AuditQuery>,
 ) -> impl IntoResponse {
     let filter = AuditFilter {
@@ -762,7 +786,7 @@ async fn ipam_query_audit(
         action: query.action,
         limit: query.limit,
     };
-    match ops.query_audit(&filter).await {
+    match ops.query_audit(tenant.as_str(), &filter).await {
         Ok(entries) => {
             let list = AuditList {
                 count: entries.len(),
@@ -789,13 +813,14 @@ async fn ipam_query_audit(
 ))]
 async fn ipam_set_tags(
     Extension(ops): Extension<Arc<IpamOps>>,
+    tenant: crate::tenant::Tenant,
     Path(id): Path<String>,
     Json(body): Json<TagsBody>,
 ) -> impl IntoResponse {
-    if let Err(e) = ops.set_tags(&id, &body.tags).await {
+    if let Err(e) = ops.set_tags(tenant.as_str(), &id, &body.tags).await {
         return ipam_error_response(e);
     }
-    match ops.get_allocation(&id).await {
+    match ops.get_allocation(tenant.as_str(), &id).await {
         Ok(allocation) => Json(allocation).into_response(),
         Err(e) => ipam_error_response(e),
     }
@@ -807,17 +832,19 @@ async fn ipam_set_tags(
 
 async fn ipam_batch_allocate(
     Extension(ops): Extension<Arc<IpamOps>>,
+    tenant: crate::tenant::Tenant,
     headers: HeaderMap,
     body: Bytes,
 ) -> Response {
     let scope = "batch-allocate".to_string();
     idempotent_post::<Vec<BatchAllocateItem>, _, _>(
         ops,
+        tenant.0,
         headers,
         body,
         scope,
-        |ops, items: Vec<BatchAllocateItem>| async move {
-            let result = ops.batch_allocate(&items).await?;
+        |ops, tenant_id, items: Vec<BatchAllocateItem>| async move {
+            let result = ops.batch_allocate(&tenant_id, &items).await?;
             Ok((
                 StatusCode::OK,
                 serde_json::to_value(&result).unwrap_or(serde_json::Value::Null),
@@ -829,9 +856,10 @@ async fn ipam_batch_allocate(
 
 async fn ipam_batch_release(
     Extension(ops): Extension<Arc<IpamOps>>,
+    tenant: crate::tenant::Tenant,
     Json(body): Json<BatchReleaseRequest>,
 ) -> impl IntoResponse {
-    match ops.batch_release(&body).await {
+    match ops.batch_release(tenant.as_str(), &body).await {
         Ok(result) => Json(result).into_response(),
         Err(e) => ipam_error_response(e),
     }
@@ -839,9 +867,13 @@ async fn ipam_batch_release(
 
 async fn ipam_batch_summary(
     Extension(ops): Extension<Arc<IpamOps>>,
+    tenant: crate::tenant::Tenant,
     Query(query): Query<SummaryQuery>,
 ) -> impl IntoResponse {
-    match ops.allocation_summary(query.supernet_id.as_deref()).await {
+    match ops
+        .allocation_summary(tenant.as_str(), query.supernet_id.as_deref())
+        .await
+    {
         Ok(summary) => Json(summary).into_response(),
         Err(e) => ipam_error_response(e),
     }

--- a/src/ipam_cli.rs
+++ b/src/ipam_cli.rs
@@ -69,11 +69,14 @@ pub async fn handle_ipam_command(
                 description,
             } => {
                 let sn = ops
-                    .create_supernet(CLI_TENANT_ID, &CreateSupernet {
-                        cidr,
-                        name,
-                        description,
-                    })
+                    .create_supernet(
+                        CLI_TENANT_ID,
+                        &CreateSupernet {
+                            cidr,
+                            name,
+                            description,
+                        },
+                    )
                     .await?;
                 output_result(writer, output_file, &sn);
             }
@@ -110,20 +113,23 @@ pub async fn handle_ipam_command(
         } => {
             let status = parse_status(&status)?;
             let alloc = ops
-                .allocate_specific(CLI_TENANT_ID, &CreateAllocation {
-                    supernet_id,
-                    cidr,
-                    status,
-                    resource_id,
-                    resource_type,
-                    name,
-                    description,
-                    environment,
-                    owner,
-                    parent_allocation_id: parent_id,
-                    tags: None,
-                    ttl_seconds: ttl,
-                })
+                .allocate_specific(
+                    CLI_TENANT_ID,
+                    &CreateAllocation {
+                        supernet_id,
+                        cidr,
+                        status,
+                        resource_id,
+                        resource_type,
+                        name,
+                        description,
+                        environment,
+                        owner,
+                        parent_allocation_id: parent_id,
+                        tags: None,
+                        ttl_seconds: ttl,
+                    },
+                )
                 .await?;
             output_result(writer, output_file, &alloc);
         }
@@ -144,21 +150,24 @@ pub async fn handle_ipam_command(
         } => {
             let status = parse_status(&status)?;
             let allocs = ops
-                .allocate_auto(CLI_TENANT_ID, &AutoAllocateRequest {
-                    supernet_id,
-                    prefix_length: prefix,
-                    count: Some(count),
-                    status,
-                    resource_id,
-                    resource_type,
-                    name,
-                    description,
-                    environment,
-                    owner,
-                    parent_allocation_id: parent_id,
-                    tags: None,
-                    ttl_seconds: ttl,
-                })
+                .allocate_auto(
+                    CLI_TENANT_ID,
+                    &AutoAllocateRequest {
+                        supernet_id,
+                        prefix_length: prefix,
+                        count: Some(count),
+                        status,
+                        resource_id,
+                        resource_type,
+                        name,
+                        description,
+                        environment,
+                        owner,
+                        parent_allocation_id: parent_id,
+                        tags: None,
+                        ttl_seconds: ttl,
+                    },
+                )
                 .await?;
             let result = AllocationList {
                 count: allocs.len(),
@@ -182,14 +191,17 @@ pub async fn handle_ipam_command(
             } => {
                 let status = parse_status(&status)?;
                 let allocs = ops
-                    .list_allocations(CLI_TENANT_ID, &AllocationFilter {
-                        supernet_id,
-                        status,
-                        resource_id,
-                        resource_type,
-                        environment,
-                        owner,
-                    })
+                    .list_allocations(
+                        CLI_TENANT_ID,
+                        &AllocationFilter {
+                            supernet_id,
+                            status,
+                            resource_id,
+                            resource_type,
+                            environment,
+                            owner,
+                        },
+                    )
                     .await?;
                 let result = AllocationList {
                     count: allocs.len(),
@@ -270,12 +282,15 @@ pub async fn handle_ipam_command(
             limit,
         } => {
             let entries = ops
-                .query_audit(CLI_TENANT_ID, &AuditFilter {
-                    entity_type,
-                    entity_id,
-                    action,
-                    limit: Some(limit),
-                })
+                .query_audit(
+                    CLI_TENANT_ID,
+                    &AuditFilter {
+                        entity_type,
+                        entity_id,
+                        action,
+                        limit: Some(limit),
+                    },
+                )
                 .await?;
             let result = AuditList {
                 count: entries.len(),
@@ -335,7 +350,8 @@ pub async fn handle_ipam_command(
                 tags,
             } => {
                 let parsed_tags = parse_tags(&tags)?;
-                ops.set_tags(CLI_TENANT_ID, &allocation_id, &parsed_tags).await?;
+                ops.set_tags(CLI_TENANT_ID, &allocation_id, &parsed_tags)
+                    .await?;
                 let alloc = ops.get_allocation(CLI_TENANT_ID, &allocation_id).await?;
                 output_result(writer, output_file, &alloc);
             }

--- a/src/ipam_cli.rs
+++ b/src/ipam_cli.rs
@@ -9,6 +9,9 @@ use serde::Serialize;
 
 use crate::print_stdout;
 
+/// CLI uses local SQLite, single-tenant by definition.
+const CLI_TENANT_ID: &str = "local";
+
 fn output_result<T: Serialize + TextOutput + CsvOutput>(
     writer: &OutputWriter,
     output_file: &Option<String>,
@@ -66,7 +69,7 @@ pub async fn handle_ipam_command(
                 description,
             } => {
                 let sn = ops
-                    .create_supernet(&CreateSupernet {
+                    .create_supernet(CLI_TENANT_ID, &CreateSupernet {
                         cidr,
                         name,
                         description,
@@ -75,7 +78,7 @@ pub async fn handle_ipam_command(
                 output_result(writer, output_file, &sn);
             }
             SupernetCommands::List => {
-                let list = ops.list_supernets().await?;
+                let list = ops.list_supernets(CLI_TENANT_ID).await?;
                 let result = SupernetList {
                     count: list.len(),
                     supernets: list,
@@ -83,11 +86,11 @@ pub async fn handle_ipam_command(
                 output_result(writer, output_file, &result);
             }
             SupernetCommands::Get { id } => {
-                let sn = ops.get_supernet(&id).await?;
+                let sn = ops.get_supernet(CLI_TENANT_ID, &id).await?;
                 output_result(writer, output_file, &sn);
             }
             SupernetCommands::Delete { id } => {
-                ops.delete_supernet(&id).await?;
+                ops.delete_supernet(CLI_TENANT_ID, &id).await?;
                 eprintln!("Supernet {} deleted", id);
             }
         },
@@ -107,7 +110,7 @@ pub async fn handle_ipam_command(
         } => {
             let status = parse_status(&status)?;
             let alloc = ops
-                .allocate_specific(&CreateAllocation {
+                .allocate_specific(CLI_TENANT_ID, &CreateAllocation {
                     supernet_id,
                     cidr,
                     status,
@@ -141,7 +144,7 @@ pub async fn handle_ipam_command(
         } => {
             let status = parse_status(&status)?;
             let allocs = ops
-                .allocate_auto(&AutoAllocateRequest {
+                .allocate_auto(CLI_TENANT_ID, &AutoAllocateRequest {
                     supernet_id,
                     prefix_length: prefix,
                     count: Some(count),
@@ -166,7 +169,7 @@ pub async fn handle_ipam_command(
 
         IpamCommands::Allocation { command } => match command {
             AllocationCommands::Get { id } => {
-                let alloc = ops.get_allocation(&id).await?;
+                let alloc = ops.get_allocation(CLI_TENANT_ID, &id).await?;
                 output_result(writer, output_file, &alloc);
             }
             AllocationCommands::List {
@@ -179,7 +182,7 @@ pub async fn handle_ipam_command(
             } => {
                 let status = parse_status(&status)?;
                 let allocs = ops
-                    .list_allocations(&AllocationFilter {
+                    .list_allocations(CLI_TENANT_ID, &AllocationFilter {
                         supernet_id,
                         status,
                         resource_id,
@@ -207,6 +210,7 @@ pub async fn handle_ipam_command(
                 let status = parse_status(&status)?;
                 let alloc = ops
                     .update_allocation(
+                        CLI_TENANT_ID,
                         &id,
                         &UpdateAllocation {
                             name,
@@ -224,12 +228,12 @@ pub async fn handle_ipam_command(
         },
 
         IpamCommands::Release { id } => {
-            let alloc = ops.release_allocation(&id).await?;
+            let alloc = ops.release_allocation(CLI_TENANT_ID, &id).await?;
             output_result(writer, output_file, &alloc);
         }
 
         IpamCommands::Utilization { supernet_id } => {
-            let report = ops.utilization(&supernet_id).await?;
+            let report = ops.utilization(CLI_TENANT_ID, &supernet_id).await?;
             output_result(writer, output_file, &report);
         }
 
@@ -237,12 +241,12 @@ pub async fn handle_ipam_command(
             supernet_id,
             prefix,
         } => {
-            let report = ops.free_blocks(&supernet_id, prefix).await?;
+            let report = ops.free_blocks(CLI_TENANT_ID, &supernet_id, prefix).await?;
             output_result(writer, output_file, &report);
         }
 
         IpamCommands::FindIp { address } => {
-            let allocs = ops.find_by_ip(&address).await?;
+            let allocs = ops.find_by_ip(CLI_TENANT_ID, &address).await?;
             let result = AllocationList {
                 count: allocs.len(),
                 allocations: allocs,
@@ -251,7 +255,7 @@ pub async fn handle_ipam_command(
         }
 
         IpamCommands::FindResource { resource_id } => {
-            let allocs = ops.find_by_resource(&resource_id).await?;
+            let allocs = ops.find_by_resource(CLI_TENANT_ID, &resource_id).await?;
             let result = AllocationList {
                 count: allocs.len(),
                 allocations: allocs,
@@ -266,7 +270,7 @@ pub async fn handle_ipam_command(
             limit,
         } => {
             let entries = ops
-                .query_audit(&AuditFilter {
+                .query_audit(CLI_TENANT_ID, &AuditFilter {
                     entity_type,
                     entity_id,
                     action,
@@ -281,7 +285,7 @@ pub async fn handle_ipam_command(
         }
 
         IpamCommands::Dump => {
-            let dump = ops.dump().await?;
+            let dump = ops.dump(CLI_TENANT_ID).await?;
             let json = serde_json::to_string_pretty(&dump).expect("Failed to serialize dump");
             if output_file.is_none() {
                 print_stdout(&json);
@@ -314,7 +318,7 @@ pub async fn handle_ipam_command(
                     netcidr::error::NetcidrError::InvalidInput(format!("invalid JSON: {}", e))
                 })?;
 
-            let (sn_count, alloc_count) = ops.load(&dump).await?;
+            let (sn_count, alloc_count) = ops.load(CLI_TENANT_ID, &dump).await?;
             eprintln!(
                 "Imported {} supernets and {} allocations",
                 sn_count, alloc_count
@@ -323,7 +327,7 @@ pub async fn handle_ipam_command(
 
         IpamCommands::Tags { command } => match command {
             TagCommands::Get { allocation_id } => {
-                let alloc = ops.get_allocation(&allocation_id).await?;
+                let alloc = ops.get_allocation(CLI_TENANT_ID, &allocation_id).await?;
                 output_result(writer, output_file, &alloc);
             }
             TagCommands::Set {
@@ -331,8 +335,8 @@ pub async fn handle_ipam_command(
                 tags,
             } => {
                 let parsed_tags = parse_tags(&tags)?;
-                ops.set_tags(&allocation_id, &parsed_tags).await?;
-                let alloc = ops.get_allocation(&allocation_id).await?;
+                ops.set_tags(CLI_TENANT_ID, &allocation_id, &parsed_tags).await?;
+                let alloc = ops.get_allocation(CLI_TENANT_ID, &allocation_id).await?;
                 output_result(writer, output_file, &alloc);
             }
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod auth;
 pub mod cli;
 pub mod ipam_api;
 pub mod output;
+pub mod tenant;
 
 // IPAM persistence layer
 pub mod ipam;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -89,7 +89,10 @@ impl McpIpamBackend {
         prefix: Option<u8>,
     ) -> crate::error::Result<FreeBlocksReport> {
         match self {
-            Self::Local(ops) => ops.free_blocks(MCP_LOCAL_TENANT_ID, supernet_id, prefix).await,
+            Self::Local(ops) => {
+                ops.free_blocks(MCP_LOCAL_TENANT_ID, supernet_id, prefix)
+                    .await
+            }
             Self::Remote(client) => client.free_blocks(supernet_id, prefix).await,
         }
     }
@@ -143,7 +146,10 @@ impl McpIpamBackend {
         supernet_id: Option<&str>,
     ) -> crate::error::Result<AllocationSummary> {
         match self {
-            Self::Local(ops) => ops.allocation_summary(MCP_LOCAL_TENANT_ID, supernet_id).await,
+            Self::Local(ops) => {
+                ops.allocation_summary(MCP_LOCAL_TENANT_ID, supernet_id)
+                    .await
+            }
             Self::Remote(client) => client.allocation_summary(supernet_id).await,
         }
     }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -20,6 +20,11 @@ use crate::summarize::{summarize_ipv4, summarize_ipv6};
 // IPAM backend abstraction — local IpamOps or remote HTTP client
 // ---------------------------------------------------------------------------
 
+/// Local MCP backend uses local SQLite, single-tenant by definition.
+/// The remote backend goes through HTTP and authenticates via OIDC, so it
+/// does not need a tenant_id literal here — the API server enforces tenancy.
+const MCP_LOCAL_TENANT_ID: &str = "local";
+
 #[derive(Debug, Clone)]
 pub enum McpIpamBackend {
     Local(Arc<IpamOps>),
@@ -29,14 +34,14 @@ pub enum McpIpamBackend {
 impl McpIpamBackend {
     pub async fn create_supernet(&self, input: &CreateSupernet) -> crate::error::Result<Supernet> {
         match self {
-            Self::Local(ops) => ops.create_supernet(input).await,
+            Self::Local(ops) => ops.create_supernet(MCP_LOCAL_TENANT_ID, input).await,
             Self::Remote(client) => client.create_supernet(input).await,
         }
     }
 
     pub async fn list_supernets(&self) -> crate::error::Result<Vec<Supernet>> {
         match self {
-            Self::Local(ops) => ops.list_supernets().await,
+            Self::Local(ops) => ops.list_supernets(MCP_LOCAL_TENANT_ID).await,
             Self::Remote(client) => client.list_supernets().await,
         }
     }
@@ -46,7 +51,7 @@ impl McpIpamBackend {
         request: &AutoAllocateRequest,
     ) -> crate::error::Result<Vec<Allocation>> {
         match self {
-            Self::Local(ops) => ops.allocate_auto(request).await,
+            Self::Local(ops) => ops.allocate_auto(MCP_LOCAL_TENANT_ID, request).await,
             Self::Remote(client) => client.allocate_auto(request).await,
         }
     }
@@ -56,14 +61,14 @@ impl McpIpamBackend {
         input: &CreateAllocation,
     ) -> crate::error::Result<Allocation> {
         match self {
-            Self::Local(ops) => ops.allocate_specific(input).await,
+            Self::Local(ops) => ops.allocate_specific(MCP_LOCAL_TENANT_ID, input).await,
             Self::Remote(client) => client.allocate_specific(input).await,
         }
     }
 
     pub async fn release_allocation(&self, id: &str) -> crate::error::Result<Allocation> {
         match self {
-            Self::Local(ops) => ops.release_allocation(id).await,
+            Self::Local(ops) => ops.release_allocation(MCP_LOCAL_TENANT_ID, id).await,
             Self::Remote(client) => client.release_allocation(id).await,
         }
     }
@@ -73,7 +78,7 @@ impl McpIpamBackend {
         filter: &AllocationFilter,
     ) -> crate::error::Result<Vec<Allocation>> {
         match self {
-            Self::Local(ops) => ops.list_allocations(filter).await,
+            Self::Local(ops) => ops.list_allocations(MCP_LOCAL_TENANT_ID, filter).await,
             Self::Remote(client) => client.list_allocations(filter).await,
         }
     }
@@ -84,21 +89,21 @@ impl McpIpamBackend {
         prefix: Option<u8>,
     ) -> crate::error::Result<FreeBlocksReport> {
         match self {
-            Self::Local(ops) => ops.free_blocks(supernet_id, prefix).await,
+            Self::Local(ops) => ops.free_blocks(MCP_LOCAL_TENANT_ID, supernet_id, prefix).await,
             Self::Remote(client) => client.free_blocks(supernet_id, prefix).await,
         }
     }
 
     pub async fn utilization(&self, supernet_id: &str) -> crate::error::Result<UtilizationReport> {
         match self {
-            Self::Local(ops) => ops.utilization(supernet_id).await,
+            Self::Local(ops) => ops.utilization(MCP_LOCAL_TENANT_ID, supernet_id).await,
             Self::Remote(client) => client.utilization(supernet_id).await,
         }
     }
 
     pub async fn find_by_ip(&self, address: &str) -> crate::error::Result<Vec<Allocation>> {
         match self {
-            Self::Local(ops) => ops.find_by_ip(address).await,
+            Self::Local(ops) => ops.find_by_ip(MCP_LOCAL_TENANT_ID, address).await,
             Self::Remote(client) => client.find_by_ip(address).await,
         }
     }
@@ -108,7 +113,7 @@ impl McpIpamBackend {
         resource_id: &str,
     ) -> crate::error::Result<Vec<Allocation>> {
         match self {
-            Self::Local(ops) => ops.find_by_resource(resource_id).await,
+            Self::Local(ops) => ops.find_by_resource(MCP_LOCAL_TENANT_ID, resource_id).await,
             Self::Remote(client) => client.find_by_resource(resource_id).await,
         }
     }
@@ -118,7 +123,7 @@ impl McpIpamBackend {
         items: &[BatchAllocateItem],
     ) -> crate::error::Result<BatchAllocateResult> {
         match self {
-            Self::Local(ops) => ops.batch_allocate(items).await,
+            Self::Local(ops) => ops.batch_allocate(MCP_LOCAL_TENANT_ID, items).await,
             Self::Remote(client) => client.batch_allocate(items).await,
         }
     }
@@ -128,7 +133,7 @@ impl McpIpamBackend {
         request: &BatchReleaseRequest,
     ) -> crate::error::Result<BatchReleaseResult> {
         match self {
-            Self::Local(ops) => ops.batch_release(request).await,
+            Self::Local(ops) => ops.batch_release(MCP_LOCAL_TENANT_ID, request).await,
             Self::Remote(client) => client.batch_release(request).await,
         }
     }
@@ -138,7 +143,7 @@ impl McpIpamBackend {
         supernet_id: Option<&str>,
     ) -> crate::error::Result<AllocationSummary> {
         match self {
-            Self::Local(ops) => ops.allocation_summary(supernet_id).await,
+            Self::Local(ops) => ops.allocation_summary(MCP_LOCAL_TENANT_ID, supernet_id).await,
             Self::Remote(client) => client.allocation_summary(supernet_id).await,
         }
     }

--- a/src/tenant.rs
+++ b/src/tenant.rs
@@ -25,10 +25,7 @@ where
 {
     type Rejection = (StatusCode, &'static str);
 
-    async fn from_request_parts(
-        parts: &mut Parts,
-        _state: &S,
-    ) -> Result<Self, Self::Rejection> {
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         parts
             .extensions
             .get::<Tenant>()

--- a/src/tenant.rs
+++ b/src/tenant.rs
@@ -1,0 +1,61 @@
+//! Per-request tenant identity, set by auth middleware.
+//!
+//! HTTP handlers extract [`Tenant`] from request extensions and pass its
+//! inner string to [`crate::ipam::operations::IpamOps`]. Unauthenticated
+//! routes never have it set; tenant-scoped routes are unreachable without
+//! it because [`crate::auth::require_auth`] runs first.
+
+use axum::{
+    extract::FromRequestParts,
+    http::{StatusCode, request::Parts},
+};
+
+#[derive(Debug, Clone)]
+pub struct Tenant(pub String);
+
+impl Tenant {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<S> FromRequestParts<S> for Tenant
+where
+    S: Send + Sync,
+{
+    type Rejection = (StatusCode, &'static str);
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        _state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        parts
+            .extensions
+            .get::<Tenant>()
+            .cloned()
+            .ok_or((StatusCode::UNAUTHORIZED, "tenant not set"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::Request;
+
+    #[tokio::test]
+    async fn extractor_returns_tenant_when_set() {
+        let mut req = Request::builder().body(()).unwrap();
+        req.extensions_mut().insert(Tenant("a@x".to_string()));
+        let (mut parts, _) = req.into_parts();
+        let extracted = Tenant::from_request_parts(&mut parts, &()).await.unwrap();
+        assert_eq!(extracted.as_str(), "a@x");
+    }
+
+    #[tokio::test]
+    async fn extractor_returns_401_when_missing() {
+        let req = Request::builder().body(()).unwrap();
+        let (mut parts, _) = req.into_parts();
+        let result = Tenant::from_request_parts(&mut parts, &()).await;
+        assert_eq!(result.unwrap_err().0, StatusCode::UNAUTHORIZED);
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -62,6 +62,9 @@ pub fn json_request(
         builder = builder.header(header::CONTENT_TYPE, "application/json");
     }
     builder
-        .body(body.map(|b| Body::from(b.to_string())).unwrap_or_else(Body::empty))
+        .body(
+            body.map(|b| Body::from(b.to_string()))
+                .unwrap_or_else(Body::empty),
+        )
         .unwrap()
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,67 @@
+//! Shared test helpers for HTTP-level IPAM tests.
+//!
+//! The HTTP integration tests in this repository run against `auth_mode: None`
+//! routers built via `tower::ServiceExt::oneshot`. Production auth middleware
+//! sets a `Tenant` extension on each request from the verified OIDC email
+//! (or the bearer-token subject) — under `AuthMode::None` no extension is
+//! ever set, so every IPAM handler would 401 on the `Tenant` extractor.
+//!
+//! This module exposes a synthetic middleware that reads an `X-Test-Tenant`
+//! header and inserts a `Tenant` extension. Tests pass the header on every
+//! request to drive a specific tenant identity end-to-end through handler →
+//! ops → store, without bringing up real OIDC.
+
+#![allow(dead_code)]
+
+use axum::{
+    body::Body,
+    extract::Request,
+    http::{HeaderName, header},
+    middleware::{self, Next},
+    response::Response,
+};
+use netcidr::tenant::Tenant;
+
+/// Header read by [`inject_test_tenant`] to populate the `Tenant` extension.
+pub const TENANT_HEADER: &str = "X-Test-Tenant";
+
+/// Default tenant for non-isolation tests.
+pub const TEST_TENANT: &str = "test@example.com";
+
+/// Test-only middleware: copies the `X-Test-Tenant` request header into a
+/// `Tenant` extension so handlers that call `Tenant::from_request_parts`
+/// see a tenant even though auth is disabled.
+pub async fn inject_test_tenant(mut req: Request, next: Next) -> Response {
+    let tenant = req
+        .headers()
+        .get(HeaderName::from_static("x-test-tenant"))
+        .and_then(|h| h.to_str().ok())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| TEST_TENANT.to_string());
+    req.extensions_mut().insert(Tenant(tenant));
+    next.run(req).await
+}
+
+/// Wrap a router with `inject_test_tenant`.
+pub fn with_test_tenant(router: axum::Router) -> axum::Router {
+    router.layer(middleware::from_fn(inject_test_tenant))
+}
+
+/// Build a JSON request with a tenant header. `body` may be `None` for GET.
+pub fn json_request(
+    method: &str,
+    uri: &str,
+    tenant: &str,
+    body: Option<&str>,
+) -> axum::http::Request<Body> {
+    let mut builder = axum::http::Request::builder()
+        .method(method)
+        .uri(uri)
+        .header(TENANT_HEADER, tenant);
+    if body.is_some() {
+        builder = builder.header(header::CONTENT_TYPE, "application/json");
+    }
+    builder
+        .body(body.map(|b| Body::from(b.to_string())).unwrap_or_else(Body::empty))
+        .unwrap()
+}

--- a/tests/ipam_api_tests.rs
+++ b/tests/ipam_api_tests.rs
@@ -11,18 +11,22 @@ use netcidr::ipam::sqlite::SqliteStore;
 use netcidr::ipam::store::IpamStore;
 use tower::ServiceExt;
 
+mod common;
+use common::{TENANT_HEADER, TEST_TENANT, with_test_tenant};
+
 async fn ipam_app() -> axum::Router {
     let store = SqliteStore::in_memory().unwrap();
     store.initialize().await.unwrap();
     store.migrate().await.unwrap();
     let ops = Arc::new(IpamOps::new(Arc::new(store)));
-    create_router(RouterConfig {
+    let router = create_router(RouterConfig {
         server: ServerConfig {
             rate_limit_per_second: 0,
             ..Default::default()
         },
         ipam_ops: Some(ops),
-    })
+    });
+    with_test_tenant(router)
 }
 
 async fn req(
@@ -31,7 +35,10 @@ async fn req(
     uri: &str,
     body: Option<&str>,
 ) -> (StatusCode, serde_json::Value) {
-    let builder = Request::builder().method(method).uri(uri);
+    let builder = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header(TENANT_HEADER, TEST_TENANT);
     let req = if let Some(b) = body {
         builder
             .header(header::CONTENT_TYPE, "application/json")

--- a/tests/ipam_concurrency.rs
+++ b/tests/ipam_concurrency.rs
@@ -12,17 +12,22 @@ use netcidr::ipam::operations::IpamOps;
 use netcidr::ipam::sqlite::SqliteStore;
 use netcidr::ipam::store::IpamStore;
 
+const TEST_TENANT: &str = "test@example.com";
+
 async fn ops_with_supernet(cidr: &str) -> (Arc<IpamOps>, String) {
     let store = SqliteStore::in_memory().unwrap();
     store.initialize().await.unwrap();
     store.migrate().await.unwrap();
     let ops = Arc::new(IpamOps::new(Arc::new(store)));
     let sn = ops
-        .create_supernet(&CreateSupernet {
-            cidr: cidr.to_string(),
-            name: None,
-            description: None,
-        })
+        .create_supernet(
+            TEST_TENANT,
+            &CreateSupernet {
+                cidr: cidr.to_string(),
+                name: None,
+                description: None,
+            },
+        )
         .await
         .unwrap();
     (ops, sn.id)
@@ -40,7 +45,7 @@ async fn concurrent_allocate_specific_same_cidr_yields_exactly_one_winner() {
         let ops = Arc::clone(&ops);
         let sn_id = sn_id.clone();
         handles.push(tokio::spawn(async move {
-            ops.allocate_specific(&CreateAllocation {
+            ops.allocate_specific(TEST_TENANT, &CreateAllocation {
                 supernet_id: sn_id,
                 cidr: "10.0.1.0/24".to_string(),
                 status: None,
@@ -83,7 +88,7 @@ async fn concurrent_auto_allocate_produces_no_overlaps() {
         let ops = Arc::clone(&ops);
         let sn_id = sn_id.clone();
         handles.push(tokio::spawn(async move {
-            ops.allocate_auto(&AutoAllocateRequest {
+            ops.allocate_auto(TEST_TENANT, &AutoAllocateRequest {
                 supernet_id: sn_id,
                 prefix_length: 24,
                 count: Some(1),

--- a/tests/ipam_concurrency.rs
+++ b/tests/ipam_concurrency.rs
@@ -45,20 +45,23 @@ async fn concurrent_allocate_specific_same_cidr_yields_exactly_one_winner() {
         let ops = Arc::clone(&ops);
         let sn_id = sn_id.clone();
         handles.push(tokio::spawn(async move {
-            ops.allocate_specific(TEST_TENANT, &CreateAllocation {
-                supernet_id: sn_id,
-                cidr: "10.0.1.0/24".to_string(),
-                status: None,
-                resource_id: None,
-                resource_type: None,
-                name: None,
-                description: None,
-                environment: None,
-                owner: None,
-                parent_allocation_id: None,
-                tags: None,
-                ttl_seconds: None,
-            })
+            ops.allocate_specific(
+                TEST_TENANT,
+                &CreateAllocation {
+                    supernet_id: sn_id,
+                    cidr: "10.0.1.0/24".to_string(),
+                    status: None,
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: None,
+                },
+            )
             .await
         }));
     }
@@ -88,21 +91,24 @@ async fn concurrent_auto_allocate_produces_no_overlaps() {
         let ops = Arc::clone(&ops);
         let sn_id = sn_id.clone();
         handles.push(tokio::spawn(async move {
-            ops.allocate_auto(TEST_TENANT, &AutoAllocateRequest {
-                supernet_id: sn_id,
-                prefix_length: 24,
-                count: Some(1),
-                status: None,
-                resource_id: None,
-                resource_type: None,
-                name: None,
-                description: None,
-                environment: None,
-                owner: None,
-                parent_allocation_id: None,
-                tags: None,
-                ttl_seconds: None,
-            })
+            ops.allocate_auto(
+                TEST_TENANT,
+                &AutoAllocateRequest {
+                    supernet_id: sn_id,
+                    prefix_length: 24,
+                    count: Some(1),
+                    status: None,
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: None,
+                },
+            )
             .await
         }));
     }

--- a/tests/ipam_idempotency.rs
+++ b/tests/ipam_idempotency.rs
@@ -13,18 +13,22 @@ use netcidr::ipam::sqlite::SqliteStore;
 use netcidr::ipam::store::IpamStore;
 use tower::ServiceExt;
 
+mod common;
+use common::{TENANT_HEADER, TEST_TENANT, with_test_tenant};
+
 async fn ipam_app() -> axum::Router {
     let store = SqliteStore::in_memory().unwrap();
     store.initialize().await.unwrap();
     store.migrate().await.unwrap();
     let ops = Arc::new(IpamOps::new(Arc::new(store)));
-    create_router(RouterConfig {
+    let router = create_router(RouterConfig {
         server: ServerConfig {
             rate_limit_per_second: 0,
             ..Default::default()
         },
         ipam_ops: Some(ops),
-    })
+    });
+    with_test_tenant(router)
 }
 
 struct ReqResult {
@@ -37,7 +41,8 @@ async fn post_with_key(app: &axum::Router, uri: &str, body: &str, key: Option<&s
     let mut builder = Request::builder()
         .method("POST")
         .uri(uri)
-        .header(header::CONTENT_TYPE, "application/json");
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(TENANT_HEADER, TEST_TENANT);
     if let Some(k) = key {
         builder = builder.header("Idempotency-Key", k);
     }
@@ -168,6 +173,7 @@ async fn auto_allocate_replays_on_same_key() {
     let list_req = Request::builder()
         .method("GET")
         .uri(format!("/ipam/supernets/{sn}/allocations"))
+        .header(TENANT_HEADER, TEST_TENANT)
         .body(Body::empty())
         .unwrap();
     let resp = app.clone().oneshot(list_req).await.unwrap();

--- a/tests/ipam_isolation.rs
+++ b/tests/ipam_isolation.rs
@@ -1,0 +1,268 @@
+//! HTTP-level multi-tenant isolation matrix.
+//!
+//! Boots an in-memory netcidr API with a synthetic tenant-injection
+//! middleware (see `tests/common/mod.rs`). The middleware reads
+//! `X-Test-Tenant` and inserts a `Tenant` extension on each request, so
+//! the production handler -> ops -> store path runs end-to-end without
+//! standing up a real OIDC IdP.
+//!
+//! Two tenants `a@example.com` and `b@example.com` exercise the five
+//! cross-tenant guarantees: supernets, allocations, audit log, idempotency
+//! keys, and same-CIDR reuse.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode, header};
+use http_body_util::BodyExt;
+use netcidr::api::{RouterConfig, create_router};
+use netcidr::config::ServerConfig;
+use netcidr::ipam::operations::IpamOps;
+use netcidr::ipam::sqlite::SqliteStore;
+use netcidr::ipam::store::IpamStore;
+use tower::ServiceExt;
+
+mod common;
+use common::{TENANT_HEADER, with_test_tenant};
+
+const TENANT_A: &str = "a@example.com";
+const TENANT_B: &str = "b@example.com";
+
+async fn isolation_app() -> axum::Router {
+    let store = SqliteStore::in_memory().unwrap();
+    store.initialize().await.unwrap();
+    store.migrate().await.unwrap();
+    let ops = Arc::new(IpamOps::new(Arc::new(store)));
+    let router = create_router(RouterConfig {
+        server: ServerConfig {
+            rate_limit_per_second: 0,
+            ..Default::default()
+        },
+        ipam_ops: Some(ops),
+    });
+    with_test_tenant(router)
+}
+
+struct ReqResult {
+    status: StatusCode,
+    body: serde_json::Value,
+    replay: bool,
+}
+
+async fn send(
+    app: &axum::Router,
+    method: &str,
+    uri: &str,
+    tenant: &str,
+    body: Option<&str>,
+    idem_key: Option<&str>,
+) -> ReqResult {
+    let mut builder = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header(TENANT_HEADER, tenant);
+    if body.is_some() {
+        builder = builder.header(header::CONTENT_TYPE, "application/json");
+    }
+    if let Some(k) = idem_key {
+        builder = builder.header("Idempotency-Key", k);
+    }
+    let req = builder
+        .body(body.map(|b| Body::from(b.to_string())).unwrap_or_else(Body::empty))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let replay = resp
+        .headers()
+        .get("Idempotent-Replay")
+        .map(|v| v == "true")
+        .unwrap_or(false);
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let text = String::from_utf8(bytes.to_vec()).unwrap();
+    let json = if text.is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::from_str(&text).unwrap_or(serde_json::Value::String(text))
+    };
+    ReqResult {
+        status,
+        body: json,
+        replay,
+    }
+}
+
+async fn create_supernet(app: &axum::Router, tenant: &str, cidr: &str) -> String {
+    let r = send(
+        app,
+        "POST",
+        "/ipam/supernets",
+        tenant,
+        Some(&format!(r#"{{"cidr":"{cidr}"}}"#)),
+        None,
+    )
+    .await;
+    assert_eq!(r.status, StatusCode::CREATED, "create_supernet failed: {:?}", r.body);
+    r.body["id"].as_str().unwrap().to_string()
+}
+
+#[tokio::test]
+async fn supernets_are_isolated_per_tenant() {
+    let app = isolation_app().await;
+    let s_a_id = create_supernet(&app, TENANT_A, "10.0.0.0/8").await;
+
+    // B sees zero supernets.
+    let r = send(&app, "GET", "/ipam/supernets", TENANT_B, None, None).await;
+    assert_eq!(r.status, StatusCode::OK);
+    assert_eq!(r.body["count"], 0, "tenant B must not see tenant A's supernet");
+
+    // A sees its own one supernet.
+    let r = send(&app, "GET", "/ipam/supernets", TENANT_A, None, None).await;
+    assert_eq!(r.status, StatusCode::OK);
+    assert_eq!(r.body["count"], 1);
+
+    // B requesting A's supernet by ID gets 404, not 403.
+    let r = send(
+        &app,
+        "GET",
+        &format!("/ipam/supernets/{s_a_id}"),
+        TENANT_B,
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(
+        r.status,
+        StatusCode::NOT_FOUND,
+        "cross-tenant supernet read must 404 (no existence leak)"
+    );
+}
+
+#[tokio::test]
+async fn same_cidr_in_two_tenants_both_succeed() {
+    let app = isolation_app().await;
+    for tenant in [TENANT_A, TENANT_B] {
+        let r = send(
+            &app,
+            "POST",
+            "/ipam/supernets",
+            tenant,
+            Some(r#"{"cidr":"10.0.0.0/8"}"#),
+            None,
+        )
+        .await;
+        assert_eq!(
+            r.status,
+            StatusCode::CREATED,
+            "tenant {tenant} should accept its own 10.0.0.0/8: {:?}",
+            r.body
+        );
+    }
+}
+
+#[tokio::test]
+async fn allocations_are_isolated_per_tenant() {
+    let app = isolation_app().await;
+    let s_a_id = create_supernet(&app, TENANT_A, "10.0.0.0/8").await;
+
+    let alloc = send(
+        &app,
+        "POST",
+        &format!("/ipam/supernets/{s_a_id}/allocate-specific"),
+        TENANT_A,
+        Some(r#"{"cidr":"10.1.0.0/16"}"#),
+        None,
+    )
+    .await;
+    assert_eq!(alloc.status, StatusCode::CREATED);
+    let alloc_id = alloc.body["id"].as_str().unwrap().to_string();
+
+    // B requesting A's allocation by ID gets 404.
+    let r = send(
+        &app,
+        "GET",
+        &format!("/ipam/allocations/{alloc_id}"),
+        TENANT_B,
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(r.status, StatusCode::NOT_FOUND);
+
+    // B trying to allocate inside A's supernet gets 404 (supernet hidden).
+    let r = send(
+        &app,
+        "POST",
+        &format!("/ipam/supernets/{s_a_id}/allocate-specific"),
+        TENANT_B,
+        Some(r#"{"cidr":"10.2.0.0/16"}"#),
+        None,
+    )
+    .await;
+    assert_eq!(
+        r.status,
+        StatusCode::NOT_FOUND,
+        "cross-tenant allocation under A's supernet must 404"
+    );
+}
+
+#[tokio::test]
+async fn audit_log_is_isolated_per_tenant() {
+    let app = isolation_app().await;
+    let _s_a_id = create_supernet(&app, TENANT_A, "10.0.0.0/8").await;
+
+    // B's audit log is empty.
+    let r = send(&app, "GET", "/ipam/audit", TENANT_B, None, None).await;
+    assert_eq!(r.status, StatusCode::OK);
+    let entries = r.body["entries"].as_array().expect("entries array");
+    assert_eq!(entries.len(), 0, "tenant B must see no audit entries");
+
+    // A's audit log has at least one entry.
+    let r = send(&app, "GET", "/ipam/audit", TENANT_A, None, None).await;
+    assert_eq!(r.status, StatusCode::OK);
+    let entries = r.body["entries"].as_array().expect("entries array");
+    assert!(!entries.is_empty(), "tenant A must see its own audit entries");
+}
+
+#[tokio::test]
+async fn idempotency_keys_are_isolated_per_tenant() {
+    let app = isolation_app().await;
+    let s_a_id = create_supernet(&app, TENANT_A, "10.0.0.0/8").await;
+    let s_b_id = create_supernet(&app, TENANT_B, "10.0.0.0/8").await;
+
+    let key = "shared-key-1";
+
+    // A allocates with the key.
+    let r_a = send(
+        &app,
+        "POST",
+        &format!("/ipam/supernets/{s_a_id}/allocate-specific"),
+        TENANT_A,
+        Some(r#"{"cidr":"10.1.0.0/16"}"#),
+        Some(key),
+    )
+    .await;
+    assert_eq!(r_a.status, StatusCode::CREATED);
+    assert!(!r_a.replay);
+
+    // B uses the same key against its own supernet — must execute fresh.
+    let r_b = send(
+        &app,
+        "POST",
+        &format!("/ipam/supernets/{s_b_id}/allocate-specific"),
+        TENANT_B,
+        Some(r#"{"cidr":"10.2.0.0/16"}"#),
+        Some(key),
+    )
+    .await;
+    assert_eq!(r_b.status, StatusCode::CREATED);
+    assert!(
+        !r_b.replay,
+        "tenant B's idempotency key must be in its own namespace, not replay A's"
+    );
+
+    // Their allocation IDs must differ — proves no cross-tenant key collision.
+    assert_ne!(
+        r_a.body["id"].as_str().unwrap(),
+        r_b.body["id"].as_str().unwrap()
+    );
+}

--- a/tests/ipam_isolation.rs
+++ b/tests/ipam_isolation.rs
@@ -68,7 +68,10 @@ async fn send(
         builder = builder.header("Idempotency-Key", k);
     }
     let req = builder
-        .body(body.map(|b| Body::from(b.to_string())).unwrap_or_else(Body::empty))
+        .body(
+            body.map(|b| Body::from(b.to_string()))
+                .unwrap_or_else(Body::empty),
+        )
         .unwrap();
     let resp = app.clone().oneshot(req).await.unwrap();
     let status = resp.status();
@@ -101,7 +104,12 @@ async fn create_supernet(app: &axum::Router, tenant: &str, cidr: &str) -> String
         None,
     )
     .await;
-    assert_eq!(r.status, StatusCode::CREATED, "create_supernet failed: {:?}", r.body);
+    assert_eq!(
+        r.status,
+        StatusCode::CREATED,
+        "create_supernet failed: {:?}",
+        r.body
+    );
     r.body["id"].as_str().unwrap().to_string()
 }
 
@@ -113,7 +121,10 @@ async fn supernets_are_isolated_per_tenant() {
     // B sees zero supernets.
     let r = send(&app, "GET", "/ipam/supernets", TENANT_B, None, None).await;
     assert_eq!(r.status, StatusCode::OK);
-    assert_eq!(r.body["count"], 0, "tenant B must not see tenant A's supernet");
+    assert_eq!(
+        r.body["count"], 0,
+        "tenant B must not see tenant A's supernet"
+    );
 
     // A sees its own one supernet.
     let r = send(&app, "GET", "/ipam/supernets", TENANT_A, None, None).await;
@@ -220,7 +231,10 @@ async fn audit_log_is_isolated_per_tenant() {
     let r = send(&app, "GET", "/ipam/audit", TENANT_A, None, None).await;
     assert_eq!(r.status, StatusCode::OK);
     let entries = r.body["entries"].as_array().expect("entries array");
-    assert!(!entries.is_empty(), "tenant A must see its own audit entries");
+    assert!(
+        !entries.is_empty(),
+        "tenant A must see its own audit entries"
+    );
 }
 
 #[tokio::test]

--- a/tests/ipam_store_contract.rs
+++ b/tests/ipam_store_contract.rs
@@ -33,11 +33,14 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             let sn = store
-                .create_supernet(TEST_TENANT, &CreateSupernet {
-                    cidr: "10.0.0.0/8".to_string(),
-                    name: Some("Corp".to_string()),
-                    description: Some("Corporate network".to_string()),
-                })
+                .create_supernet(
+                    TEST_TENANT,
+                    &CreateSupernet {
+                        cidr: "10.0.0.0/8".to_string(),
+                        name: Some("Corp".to_string()),
+                        description: Some("Corporate network".to_string()),
+                    },
+                )
                 .await
                 .unwrap();
 
@@ -62,19 +65,25 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             store
-                .create_supernet(TEST_TENANT, &CreateSupernet {
-                    cidr: "10.0.0.0/8".to_string(),
-                    name: None,
-                    description: None,
-                })
+                .create_supernet(
+                    TEST_TENANT,
+                    &CreateSupernet {
+                        cidr: "10.0.0.0/8".to_string(),
+                        name: None,
+                        description: None,
+                    },
+                )
                 .await
                 .unwrap();
             store
-                .create_supernet(TEST_TENANT, &CreateSupernet {
-                    cidr: "172.16.0.0/12".to_string(),
-                    name: None,
-                    description: None,
-                })
+                .create_supernet(
+                    TEST_TENANT,
+                    &CreateSupernet {
+                        cidr: "172.16.0.0/12".to_string(),
+                        name: None,
+                        description: None,
+                    },
+                )
                 .await
                 .unwrap();
 
@@ -87,11 +96,14 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             let sn = store
-                .create_supernet(TEST_TENANT, &CreateSupernet {
-                    cidr: "10.0.0.0/8".to_string(),
-                    name: None,
-                    description: None,
-                })
+                .create_supernet(
+                    TEST_TENANT,
+                    &CreateSupernet {
+                        cidr: "10.0.0.0/8".to_string(),
+                        name: None,
+                        description: None,
+                    },
+                )
                 .await
                 .unwrap();
 
@@ -105,33 +117,42 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             let sn = store
-                .create_supernet(TEST_TENANT, &CreateSupernet {
-                    cidr: "10.0.0.0/8".to_string(),
-                    name: None,
-                    description: None,
-                })
+                .create_supernet(
+                    TEST_TENANT,
+                    &CreateSupernet {
+                        cidr: "10.0.0.0/8".to_string(),
+                        name: None,
+                        description: None,
+                    },
+                )
                 .await
                 .unwrap();
 
             store
-                .create_allocation(TEST_TENANT, &CreateAllocation {
-                    supernet_id: sn.id.clone(),
-                    cidr: "10.0.0.0/24".to_string(),
-                    status: None,
-                    resource_id: None,
-                    resource_type: None,
-                    name: None,
-                    description: None,
-                    environment: None,
-                    owner: None,
-                    parent_allocation_id: None,
-                    tags: None,
-                    ttl_seconds: None,
-                })
+                .create_allocation(
+                    TEST_TENANT,
+                    &CreateAllocation {
+                        supernet_id: sn.id.clone(),
+                        cidr: "10.0.0.0/24".to_string(),
+                        status: None,
+                        resource_id: None,
+                        resource_type: None,
+                        name: None,
+                        description: None,
+                        environment: None,
+                        owner: None,
+                        parent_allocation_id: None,
+                        tags: None,
+                        ttl_seconds: None,
+                    },
+                )
                 .await
                 .unwrap();
 
-            let err = store.delete_supernet(TEST_TENANT, &sn.id).await.unwrap_err();
+            let err = store
+                .delete_supernet(TEST_TENANT, &sn.id)
+                .await
+                .unwrap_err();
             assert!(
                 matches!(err, NetcidrError::SupernetHasActiveAllocations(_)),
                 "expected SupernetHasActiveAllocations, got: {:?}",
@@ -142,7 +163,10 @@ macro_rules! store_contract_tests {
         #[tokio::test]
         async fn contract_supernet_get_not_found() {
             let store = $factory().await;
-            let err = store.get_supernet(TEST_TENANT, "nonexistent-id").await.unwrap_err();
+            let err = store
+                .get_supernet(TEST_TENANT, "nonexistent-id")
+                .await
+                .unwrap_err();
             assert!(
                 matches!(err, NetcidrError::SupernetNotFound(_)),
                 "expected SupernetNotFound, got: {:?}",
@@ -155,20 +179,26 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             store
-                .create_supernet(TEST_TENANT, &CreateSupernet {
-                    cidr: "10.0.0.0/8".to_string(),
-                    name: None,
-                    description: None,
-                })
+                .create_supernet(
+                    TEST_TENANT,
+                    &CreateSupernet {
+                        cidr: "10.0.0.0/8".to_string(),
+                        name: None,
+                        description: None,
+                    },
+                )
                 .await
                 .unwrap();
 
             let err = store
-                .create_supernet(TEST_TENANT, &CreateSupernet {
-                    cidr: "10.0.0.0/8".to_string(),
-                    name: None,
-                    description: None,
-                })
+                .create_supernet(
+                    TEST_TENANT,
+                    &CreateSupernet {
+                        cidr: "10.0.0.0/8".to_string(),
+                        name: None,
+                        description: None,
+                    },
+                )
                 .await
                 .unwrap_err();
 
@@ -187,29 +217,35 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             let sn = store
-                .create_supernet(TEST_TENANT, &CreateSupernet {
-                    cidr: "10.0.0.0/8".to_string(),
-                    name: None,
-                    description: None,
-                })
+                .create_supernet(
+                    TEST_TENANT,
+                    &CreateSupernet {
+                        cidr: "10.0.0.0/8".to_string(),
+                        name: None,
+                        description: None,
+                    },
+                )
                 .await
                 .unwrap();
 
             let alloc = store
-                .create_allocation(TEST_TENANT, &CreateAllocation {
-                    supernet_id: sn.id.clone(),
-                    cidr: "10.0.0.0/24".to_string(),
-                    status: None,
-                    resource_id: None,
-                    resource_type: None,
-                    name: None,
-                    description: None,
-                    environment: None,
-                    owner: None,
-                    parent_allocation_id: None,
-                    tags: None,
-                    ttl_seconds: None,
-                })
+                .create_allocation(
+                    TEST_TENANT,
+                    &CreateAllocation {
+                        supernet_id: sn.id.clone(),
+                        cidr: "10.0.0.0/24".to_string(),
+                        status: None,
+                        resource_id: None,
+                        resource_type: None,
+                        name: None,
+                        description: None,
+                        environment: None,
+                        owner: None,
+                        parent_allocation_id: None,
+                        tags: None,
+                        ttl_seconds: None,
+                    },
+                )
                 .await
                 .unwrap();
 
@@ -229,38 +265,44 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             let sn = store
-                .create_supernet(TEST_TENANT, &CreateSupernet {
-                    cidr: "10.0.0.0/8".to_string(),
-                    name: None,
-                    description: None,
-                })
+                .create_supernet(
+                    TEST_TENANT,
+                    &CreateSupernet {
+                        cidr: "10.0.0.0/8".to_string(),
+                        name: None,
+                        description: None,
+                    },
+                )
                 .await
                 .unwrap();
 
             let alloc = store
-                .create_allocation(TEST_TENANT, &CreateAllocation {
-                    supernet_id: sn.id.clone(),
-                    cidr: "10.0.0.0/24".to_string(),
-                    status: Some(AllocationStatus::Reserved),
-                    resource_id: Some("vpc-123".to_string()),
-                    resource_type: Some("vpc".to_string()),
-                    name: Some("web-tier".to_string()),
-                    description: Some("Web tier subnet".to_string()),
-                    environment: Some("production".to_string()),
-                    owner: Some("team-a".to_string()),
-                    parent_allocation_id: None,
-                    tags: Some(vec![
-                        Tag {
-                            key: "env".to_string(),
-                            value: "prod".to_string(),
-                        },
-                        Tag {
-                            key: "cost-center".to_string(),
-                            value: "eng".to_string(),
-                        },
-                    ]),
-                    ttl_seconds: None,
-                })
+                .create_allocation(
+                    TEST_TENANT,
+                    &CreateAllocation {
+                        supernet_id: sn.id.clone(),
+                        cidr: "10.0.0.0/24".to_string(),
+                        status: Some(AllocationStatus::Reserved),
+                        resource_id: Some("vpc-123".to_string()),
+                        resource_type: Some("vpc".to_string()),
+                        name: Some("web-tier".to_string()),
+                        description: Some("Web tier subnet".to_string()),
+                        environment: Some("production".to_string()),
+                        owner: Some("team-a".to_string()),
+                        parent_allocation_id: None,
+                        tags: Some(vec![
+                            Tag {
+                                key: "env".to_string(),
+                                value: "prod".to_string(),
+                            },
+                            Tag {
+                                key: "cost-center".to_string(),
+                                value: "eng".to_string(),
+                            },
+                        ]),
+                        ttl_seconds: None,
+                    },
+                )
                 .await
                 .unwrap();
 
@@ -284,29 +326,35 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             let sn = store
-                .create_supernet(TEST_TENANT, &CreateSupernet {
-                    cidr: "10.0.0.0/8".to_string(),
-                    name: None,
-                    description: None,
-                })
+                .create_supernet(
+                    TEST_TENANT,
+                    &CreateSupernet {
+                        cidr: "10.0.0.0/8".to_string(),
+                        name: None,
+                        description: None,
+                    },
+                )
                 .await
                 .unwrap();
 
             let alloc = store
-                .create_allocation(TEST_TENANT, &CreateAllocation {
-                    supernet_id: sn.id.clone(),
-                    cidr: "10.0.0.0/24".to_string(),
-                    status: None,
-                    resource_id: Some("vpc-123".to_string()),
-                    resource_type: None,
-                    name: Some("original".to_string()),
-                    description: None,
-                    environment: None,
-                    owner: None,
-                    parent_allocation_id: None,
-                    tags: None,
-                    ttl_seconds: None,
-                })
+                .create_allocation(
+                    TEST_TENANT,
+                    &CreateAllocation {
+                        supernet_id: sn.id.clone(),
+                        cidr: "10.0.0.0/24".to_string(),
+                        status: None,
+                        resource_id: Some("vpc-123".to_string()),
+                        resource_type: None,
+                        name: Some("original".to_string()),
+                        description: None,
+                        environment: None,
+                        owner: None,
+                        parent_allocation_id: None,
+                        tags: None,
+                        ttl_seconds: None,
+                    },
+                )
                 .await
                 .unwrap();
 
@@ -338,33 +386,42 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             let sn = store
-                .create_supernet(TEST_TENANT, &CreateSupernet {
-                    cidr: "10.0.0.0/8".to_string(),
-                    name: None,
-                    description: None,
-                })
+                .create_supernet(
+                    TEST_TENANT,
+                    &CreateSupernet {
+                        cidr: "10.0.0.0/8".to_string(),
+                        name: None,
+                        description: None,
+                    },
+                )
                 .await
                 .unwrap();
 
             let alloc = store
-                .create_allocation(TEST_TENANT, &CreateAllocation {
-                    supernet_id: sn.id.clone(),
-                    cidr: "10.0.0.0/24".to_string(),
-                    status: None,
-                    resource_id: None,
-                    resource_type: None,
-                    name: None,
-                    description: None,
-                    environment: None,
-                    owner: None,
-                    parent_allocation_id: None,
-                    tags: None,
-                    ttl_seconds: None,
-                })
+                .create_allocation(
+                    TEST_TENANT,
+                    &CreateAllocation {
+                        supernet_id: sn.id.clone(),
+                        cidr: "10.0.0.0/24".to_string(),
+                        status: None,
+                        resource_id: None,
+                        resource_type: None,
+                        name: None,
+                        description: None,
+                        environment: None,
+                        owner: None,
+                        parent_allocation_id: None,
+                        tags: None,
+                        ttl_seconds: None,
+                    },
+                )
                 .await
                 .unwrap();
 
-            let released = store.release_allocation(TEST_TENANT, &alloc.id).await.unwrap();
+            let released = store
+                .release_allocation(TEST_TENANT, &alloc.id)
+                .await
+                .unwrap();
             assert_eq!(released.status, AllocationStatus::Released);
             assert!(released.released_at.is_some());
         }
@@ -372,7 +429,10 @@ macro_rules! store_contract_tests {
         #[tokio::test]
         async fn contract_allocation_get_not_found() {
             let store = $factory().await;
-            let err = store.get_allocation(TEST_TENANT, "nonexistent-id").await.unwrap_err();
+            let err = store
+                .get_allocation(TEST_TENANT, "nonexistent-id")
+                .await
+                .unwrap_err();
             assert!(
                 matches!(err, NetcidrError::AllocationNotFound(_)),
                 "expected AllocationNotFound, got: {:?}",
@@ -387,66 +447,81 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             let sn = store
-                .create_supernet(TEST_TENANT, &CreateSupernet {
-                    cidr: "10.0.0.0/8".to_string(),
-                    name: None,
-                    description: None,
-                })
+                .create_supernet(
+                    TEST_TENANT,
+                    &CreateSupernet {
+                        cidr: "10.0.0.0/8".to_string(),
+                        name: None,
+                        description: None,
+                    },
+                )
                 .await
                 .unwrap();
 
             store
-                .create_allocation(TEST_TENANT, &CreateAllocation {
-                    supernet_id: sn.id.clone(),
-                    cidr: "10.0.0.0/24".to_string(),
-                    status: None,
-                    resource_id: Some("vpc-1".to_string()),
-                    resource_type: Some("vpc".to_string()),
-                    name: None,
-                    description: None,
-                    environment: Some("prod".to_string()),
-                    owner: Some("team-a".to_string()),
-                    parent_allocation_id: None,
-                    tags: None,
-                    ttl_seconds: None,
-                })
+                .create_allocation(
+                    TEST_TENANT,
+                    &CreateAllocation {
+                        supernet_id: sn.id.clone(),
+                        cidr: "10.0.0.0/24".to_string(),
+                        status: None,
+                        resource_id: Some("vpc-1".to_string()),
+                        resource_type: Some("vpc".to_string()),
+                        name: None,
+                        description: None,
+                        environment: Some("prod".to_string()),
+                        owner: Some("team-a".to_string()),
+                        parent_allocation_id: None,
+                        tags: None,
+                        ttl_seconds: None,
+                    },
+                )
                 .await
                 .unwrap();
 
             store
-                .create_allocation(TEST_TENANT, &CreateAllocation {
-                    supernet_id: sn.id.clone(),
-                    cidr: "10.0.1.0/24".to_string(),
-                    status: Some(AllocationStatus::Reserved),
-                    resource_id: Some("vpc-2".to_string()),
-                    resource_type: Some("vpc".to_string()),
-                    name: None,
-                    description: None,
-                    environment: Some("staging".to_string()),
-                    owner: Some("team-b".to_string()),
-                    parent_allocation_id: None,
-                    tags: None,
-                    ttl_seconds: None,
-                })
+                .create_allocation(
+                    TEST_TENANT,
+                    &CreateAllocation {
+                        supernet_id: sn.id.clone(),
+                        cidr: "10.0.1.0/24".to_string(),
+                        status: Some(AllocationStatus::Reserved),
+                        resource_id: Some("vpc-2".to_string()),
+                        resource_type: Some("vpc".to_string()),
+                        name: None,
+                        description: None,
+                        environment: Some("staging".to_string()),
+                        owner: Some("team-b".to_string()),
+                        parent_allocation_id: None,
+                        tags: None,
+                        ttl_seconds: None,
+                    },
+                )
                 .await
                 .unwrap();
 
             // Filter by supernet
             let by_sn = store
-                .list_allocations(TEST_TENANT, &AllocationFilter {
-                    supernet_id: Some(sn.id.clone()),
-                    ..Default::default()
-                })
+                .list_allocations(
+                    TEST_TENANT,
+                    &AllocationFilter {
+                        supernet_id: Some(sn.id.clone()),
+                        ..Default::default()
+                    },
+                )
                 .await
                 .unwrap();
             assert_eq!(by_sn.len(), 2);
 
             // Filter by status
             let reserved = store
-                .list_allocations(TEST_TENANT, &AllocationFilter {
-                    status: Some(AllocationStatus::Reserved),
-                    ..Default::default()
-                })
+                .list_allocations(
+                    TEST_TENANT,
+                    &AllocationFilter {
+                        status: Some(AllocationStatus::Reserved),
+                        ..Default::default()
+                    },
+                )
                 .await
                 .unwrap();
             assert_eq!(reserved.len(), 1);
@@ -454,10 +529,13 @@ macro_rules! store_contract_tests {
 
             // Filter by resource_id
             let by_res = store
-                .list_allocations(TEST_TENANT, &AllocationFilter {
-                    resource_id: Some("vpc-1".to_string()),
-                    ..Default::default()
-                })
+                .list_allocations(
+                    TEST_TENANT,
+                    &AllocationFilter {
+                        resource_id: Some("vpc-1".to_string()),
+                        ..Default::default()
+                    },
+                )
                 .await
                 .unwrap();
             assert_eq!(by_res.len(), 1);
@@ -465,20 +543,26 @@ macro_rules! store_contract_tests {
 
             // Filter by environment
             let by_env = store
-                .list_allocations(TEST_TENANT, &AllocationFilter {
-                    environment: Some("staging".to_string()),
-                    ..Default::default()
-                })
+                .list_allocations(
+                    TEST_TENANT,
+                    &AllocationFilter {
+                        environment: Some("staging".to_string()),
+                        ..Default::default()
+                    },
+                )
                 .await
                 .unwrap();
             assert_eq!(by_env.len(), 1);
 
             // Filter by owner
             let by_owner = store
-                .list_allocations(TEST_TENANT, &AllocationFilter {
-                    owner: Some("team-a".to_string()),
-                    ..Default::default()
-                })
+                .list_allocations(
+                    TEST_TENANT,
+                    &AllocationFilter {
+                        owner: Some("team-a".to_string()),
+                        ..Default::default()
+                    },
+                )
                 .await
                 .unwrap();
             assert_eq!(by_owner.len(), 1);
@@ -489,47 +573,56 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             let sn = store
-                .create_supernet(TEST_TENANT, &CreateSupernet {
-                    cidr: "10.0.0.0/8".to_string(),
-                    name: None,
-                    description: None,
-                })
+                .create_supernet(
+                    TEST_TENANT,
+                    &CreateSupernet {
+                        cidr: "10.0.0.0/8".to_string(),
+                        name: None,
+                        description: None,
+                    },
+                )
                 .await
                 .unwrap();
 
             let a1 = store
-                .create_allocation(TEST_TENANT, &CreateAllocation {
-                    supernet_id: sn.id.clone(),
-                    cidr: "10.0.0.0/24".to_string(),
-                    status: None,
-                    resource_id: None,
-                    resource_type: None,
-                    name: None,
-                    description: None,
-                    environment: None,
-                    owner: None,
-                    parent_allocation_id: None,
-                    tags: None,
-                    ttl_seconds: None,
-                })
+                .create_allocation(
+                    TEST_TENANT,
+                    &CreateAllocation {
+                        supernet_id: sn.id.clone(),
+                        cidr: "10.0.0.0/24".to_string(),
+                        status: None,
+                        resource_id: None,
+                        resource_type: None,
+                        name: None,
+                        description: None,
+                        environment: None,
+                        owner: None,
+                        parent_allocation_id: None,
+                        tags: None,
+                        ttl_seconds: None,
+                    },
+                )
                 .await
                 .unwrap();
 
             store
-                .create_allocation(TEST_TENANT, &CreateAllocation {
-                    supernet_id: sn.id.clone(),
-                    cidr: "10.0.1.0/24".to_string(),
-                    status: Some(AllocationStatus::Reserved),
-                    resource_id: None,
-                    resource_type: None,
-                    name: None,
-                    description: None,
-                    environment: None,
-                    owner: None,
-                    parent_allocation_id: None,
-                    tags: None,
-                    ttl_seconds: None,
-                })
+                .create_allocation(
+                    TEST_TENANT,
+                    &CreateAllocation {
+                        supernet_id: sn.id.clone(),
+                        cidr: "10.0.1.0/24".to_string(),
+                        status: Some(AllocationStatus::Reserved),
+                        resource_id: None,
+                        resource_type: None,
+                        name: None,
+                        description: None,
+                        environment: None,
+                        owner: None,
+                        parent_allocation_id: None,
+                        tags: None,
+                        ttl_seconds: None,
+                    },
+                )
                 .await
                 .unwrap();
 
@@ -563,29 +656,35 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             let sn = store
-                .create_supernet(TEST_TENANT, &CreateSupernet {
-                    cidr: "10.0.0.0/8".to_string(),
-                    name: None,
-                    description: None,
-                })
+                .create_supernet(
+                    TEST_TENANT,
+                    &CreateSupernet {
+                        cidr: "10.0.0.0/8".to_string(),
+                        name: None,
+                        description: None,
+                    },
+                )
                 .await
                 .unwrap();
 
             let alloc = store
-                .create_allocation(TEST_TENANT, &CreateAllocation {
-                    supernet_id: sn.id.clone(),
-                    cidr: "10.0.0.0/24".to_string(),
-                    status: None,
-                    resource_id: None,
-                    resource_type: None,
-                    name: None,
-                    description: None,
-                    environment: None,
-                    owner: None,
-                    parent_allocation_id: None,
-                    tags: None,
-                    ttl_seconds: None,
-                })
+                .create_allocation(
+                    TEST_TENANT,
+                    &CreateAllocation {
+                        supernet_id: sn.id.clone(),
+                        cidr: "10.0.0.0/24".to_string(),
+                        status: None,
+                        resource_id: None,
+                        resource_type: None,
+                        name: None,
+                        description: None,
+                        environment: None,
+                        owner: None,
+                        parent_allocation_id: None,
+                        tags: None,
+                        ttl_seconds: None,
+                    },
+                )
                 .await
                 .unwrap();
 
@@ -635,32 +734,38 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             let sn = store
-                .create_supernet(TEST_TENANT, &CreateSupernet {
-                    cidr: "10.0.0.0/8".to_string(),
-                    name: None,
-                    description: None,
-                })
+                .create_supernet(
+                    TEST_TENANT,
+                    &CreateSupernet {
+                        cidr: "10.0.0.0/8".to_string(),
+                        name: None,
+                        description: None,
+                    },
+                )
                 .await
                 .unwrap();
 
             let alloc = store
-                .create_allocation(TEST_TENANT, &CreateAllocation {
-                    supernet_id: sn.id.clone(),
-                    cidr: "10.0.0.0/24".to_string(),
-                    status: None,
-                    resource_id: None,
-                    resource_type: None,
-                    name: None,
-                    description: None,
-                    environment: None,
-                    owner: None,
-                    parent_allocation_id: None,
-                    tags: Some(vec![Tag {
-                        key: "env".to_string(),
-                        value: "prod".to_string(),
-                    }]),
-                    ttl_seconds: None,
-                })
+                .create_allocation(
+                    TEST_TENANT,
+                    &CreateAllocation {
+                        supernet_id: sn.id.clone(),
+                        cidr: "10.0.0.0/24".to_string(),
+                        status: None,
+                        resource_id: None,
+                        resource_type: None,
+                        name: None,
+                        description: None,
+                        environment: None,
+                        owner: None,
+                        parent_allocation_id: None,
+                        tags: Some(vec![Tag {
+                            key: "env".to_string(),
+                            value: "prod".to_string(),
+                        }]),
+                        ttl_seconds: None,
+                    },
+                )
                 .await
                 .unwrap();
 
@@ -705,15 +810,21 @@ macro_rules! store_contract_tests {
                 .unwrap();
 
             // Query all
-            let all = store.query_audit(TEST_TENANT, &AuditFilter::default()).await.unwrap();
+            let all = store
+                .query_audit(TEST_TENANT, &AuditFilter::default())
+                .await
+                .unwrap();
             assert_eq!(all.len(), 2);
 
             // Filter by entity_type
             let supernets = store
-                .query_audit(TEST_TENANT, &AuditFilter {
-                    entity_type: Some("supernet".to_string()),
-                    ..Default::default()
-                })
+                .query_audit(
+                    TEST_TENANT,
+                    &AuditFilter {
+                        entity_type: Some("supernet".to_string()),
+                        ..Default::default()
+                    },
+                )
                 .await
                 .unwrap();
             assert_eq!(supernets.len(), 1);
@@ -721,30 +832,39 @@ macro_rules! store_contract_tests {
 
             // Filter by entity_id
             let by_id = store
-                .query_audit(TEST_TENANT, &AuditFilter {
-                    entity_id: Some("alloc-1".to_string()),
-                    ..Default::default()
-                })
+                .query_audit(
+                    TEST_TENANT,
+                    &AuditFilter {
+                        entity_id: Some("alloc-1".to_string()),
+                        ..Default::default()
+                    },
+                )
                 .await
                 .unwrap();
             assert_eq!(by_id.len(), 1);
 
             // Filter by action
             let by_action = store
-                .query_audit(TEST_TENANT, &AuditFilter {
-                    action: Some("allocate".to_string()),
-                    ..Default::default()
-                })
+                .query_audit(
+                    TEST_TENANT,
+                    &AuditFilter {
+                        action: Some("allocate".to_string()),
+                        ..Default::default()
+                    },
+                )
                 .await
                 .unwrap();
             assert_eq!(by_action.len(), 1);
 
             // Limit
             let limited = store
-                .query_audit(TEST_TENANT, &AuditFilter {
-                    limit: Some(1),
-                    ..Default::default()
-                })
+                .query_audit(
+                    TEST_TENANT,
+                    &AuditFilter {
+                        limit: Some(1),
+                        ..Default::default()
+                    },
+                )
                 .await
                 .unwrap();
             assert_eq!(limited.len(), 1);
@@ -757,47 +877,56 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             let sn = store
-                .create_supernet(TEST_TENANT, &CreateSupernet {
-                    cidr: "10.0.0.0/8".to_string(),
-                    name: None,
-                    description: None,
-                })
+                .create_supernet(
+                    TEST_TENANT,
+                    &CreateSupernet {
+                        cidr: "10.0.0.0/8".to_string(),
+                        name: None,
+                        description: None,
+                    },
+                )
                 .await
                 .unwrap();
 
             let parent = store
-                .create_allocation(TEST_TENANT, &CreateAllocation {
-                    supernet_id: sn.id.clone(),
-                    cidr: "10.0.0.0/16".to_string(),
-                    status: None,
-                    resource_id: None,
-                    resource_type: None,
-                    name: Some("parent".to_string()),
-                    description: None,
-                    environment: None,
-                    owner: None,
-                    parent_allocation_id: None,
-                    tags: None,
-                    ttl_seconds: None,
-                })
+                .create_allocation(
+                    TEST_TENANT,
+                    &CreateAllocation {
+                        supernet_id: sn.id.clone(),
+                        cidr: "10.0.0.0/16".to_string(),
+                        status: None,
+                        resource_id: None,
+                        resource_type: None,
+                        name: Some("parent".to_string()),
+                        description: None,
+                        environment: None,
+                        owner: None,
+                        parent_allocation_id: None,
+                        tags: None,
+                        ttl_seconds: None,
+                    },
+                )
                 .await
                 .unwrap();
 
             let child = store
-                .create_allocation(TEST_TENANT, &CreateAllocation {
-                    supernet_id: sn.id.clone(),
-                    cidr: "10.0.1.0/24".to_string(),
-                    status: None,
-                    resource_id: None,
-                    resource_type: None,
-                    name: Some("child".to_string()),
-                    description: None,
-                    environment: None,
-                    owner: None,
-                    parent_allocation_id: Some(parent.id.clone()),
-                    tags: None,
-                    ttl_seconds: None,
-                })
+                .create_allocation(
+                    TEST_TENANT,
+                    &CreateAllocation {
+                        supernet_id: sn.id.clone(),
+                        cidr: "10.0.1.0/24".to_string(),
+                        status: None,
+                        resource_id: None,
+                        resource_type: None,
+                        name: Some("child".to_string()),
+                        description: None,
+                        environment: None,
+                        owner: None,
+                        parent_allocation_id: Some(parent.id.clone()),
+                        tags: None,
+                        ttl_seconds: None,
+                    },
+                )
                 .await
                 .unwrap();
 
@@ -815,11 +944,14 @@ macro_rules! store_contract_tests {
 
             // Store should still work
             let sn = store
-                .create_supernet(TEST_TENANT, &CreateSupernet {
-                    cidr: "10.0.0.0/8".to_string(),
-                    name: None,
-                    description: None,
-                })
+                .create_supernet(
+                    TEST_TENANT,
+                    &CreateSupernet {
+                        cidr: "10.0.0.0/8".to_string(),
+                        name: None,
+                        description: None,
+                    },
+                )
                 .await
                 .unwrap();
             assert_eq!(sn.cidr, "10.0.0.0/8");
@@ -850,32 +982,38 @@ mod migration_upgrade {
 
         // Insert data at current schema version
         let sn = store
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "10.0.0.0/8".to_string(),
-                name: Some("Corp".to_string()),
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "10.0.0.0/8".to_string(),
+                    name: Some("Corp".to_string()),
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
         let alloc = store
-            .create_allocation(TEST_TENANT, &CreateAllocation {
-                supernet_id: sn.id.clone(),
-                cidr: "10.0.0.0/24".to_string(),
-                status: None,
-                resource_id: Some("vpc-1".to_string()),
-                resource_type: Some("vpc".to_string()),
-                name: Some("web".to_string()),
-                description: Some("Web subnet".to_string()),
-                environment: Some("prod".to_string()),
-                owner: Some("team-a".to_string()),
-                parent_allocation_id: None,
-                tags: Some(vec![Tag {
-                    key: "env".to_string(),
-                    value: "prod".to_string(),
-                }]),
-                ttl_seconds: None,
-            })
+            .create_allocation(
+                TEST_TENANT,
+                &CreateAllocation {
+                    supernet_id: sn.id.clone(),
+                    cidr: "10.0.0.0/24".to_string(),
+                    status: None,
+                    resource_id: Some("vpc-1".to_string()),
+                    resource_type: Some("vpc".to_string()),
+                    name: Some("web".to_string()),
+                    description: Some("Web subnet".to_string()),
+                    environment: Some("prod".to_string()),
+                    owner: Some("team-a".to_string()),
+                    parent_allocation_id: None,
+                    tags: Some(vec![Tag {
+                        key: "env".to_string(),
+                        value: "prod".to_string(),
+                    }]),
+                    ttl_seconds: None,
+                },
+            )
             .await
             .unwrap();
 
@@ -908,10 +1046,13 @@ mod migration_upgrade {
         assert_eq!(fetched_alloc.tags.len(), 1);
 
         let audit = store
-            .query_audit(TEST_TENANT, &AuditFilter {
-                entity_id: Some(alloc.id.clone()),
-                ..Default::default()
-            })
+            .query_audit(
+                TEST_TENANT,
+                &AuditFilter {
+                    entity_id: Some(alloc.id.clone()),
+                    ..Default::default()
+                },
+            )
             .await
             .unwrap();
         assert_eq!(audit.len(), 1);
@@ -925,75 +1066,90 @@ mod migration_upgrade {
 
         // Create two supernets
         let sn1 = store
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "10.0.0.0/8".to_string(),
-                name: Some("Corp".to_string()),
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "10.0.0.0/8".to_string(),
+                    name: Some("Corp".to_string()),
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
         let sn2 = store
-            .create_supernet(TEST_TENANT, &CreateSupernet {
-                cidr: "172.16.0.0/12".to_string(),
-                name: Some("Cloud".to_string()),
-                description: None,
-            })
+            .create_supernet(
+                TEST_TENANT,
+                &CreateSupernet {
+                    cidr: "172.16.0.0/12".to_string(),
+                    name: Some("Cloud".to_string()),
+                    description: None,
+                },
+            )
             .await
             .unwrap();
 
         // Create allocations in both
         let a1 = store
-            .create_allocation(TEST_TENANT, &CreateAllocation {
-                supernet_id: sn1.id.clone(),
-                cidr: "10.0.0.0/24".to_string(),
-                status: None,
-                resource_id: None,
-                resource_type: None,
-                name: None,
-                description: None,
-                environment: None,
-                owner: None,
-                parent_allocation_id: None,
-                tags: None,
-                ttl_seconds: None,
-            })
+            .create_allocation(
+                TEST_TENANT,
+                &CreateAllocation {
+                    supernet_id: sn1.id.clone(),
+                    cidr: "10.0.0.0/24".to_string(),
+                    status: None,
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: None,
+                },
+            )
             .await
             .unwrap();
 
         store
-            .create_allocation(TEST_TENANT, &CreateAllocation {
-                supernet_id: sn1.id.clone(),
-                cidr: "10.0.1.0/24".to_string(),
-                status: Some(AllocationStatus::Reserved),
-                resource_id: None,
-                resource_type: None,
-                name: None,
-                description: None,
-                environment: None,
-                owner: None,
-                parent_allocation_id: None,
-                tags: None,
-                ttl_seconds: None,
-            })
+            .create_allocation(
+                TEST_TENANT,
+                &CreateAllocation {
+                    supernet_id: sn1.id.clone(),
+                    cidr: "10.0.1.0/24".to_string(),
+                    status: Some(AllocationStatus::Reserved),
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: None,
+                },
+            )
             .await
             .unwrap();
 
         store
-            .create_allocation(TEST_TENANT, &CreateAllocation {
-                supernet_id: sn2.id.clone(),
-                cidr: "172.16.0.0/24".to_string(),
-                status: None,
-                resource_id: None,
-                resource_type: None,
-                name: None,
-                description: None,
-                environment: None,
-                owner: None,
-                parent_allocation_id: None,
-                tags: None,
-                ttl_seconds: None,
-            })
+            .create_allocation(
+                TEST_TENANT,
+                &CreateAllocation {
+                    supernet_id: sn2.id.clone(),
+                    cidr: "172.16.0.0/24".to_string(),
+                    status: None,
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: None,
+                    ttl_seconds: None,
+                },
+            )
             .await
             .unwrap();
 

--- a/tests/ipam_store_contract.rs
+++ b/tests/ipam_store_contract.rs
@@ -9,6 +9,8 @@ use netcidr::ipam::models::*;
 use netcidr::ipam::sqlite::SqliteStore;
 use netcidr::ipam::store::IpamStore;
 
+const TEST_TENANT: &str = "test@example.com";
+
 // ---------------------------------------------------------------------------
 // Test harness: macro generates identical tests for each backend
 // ---------------------------------------------------------------------------
@@ -31,7 +33,7 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             let sn = store
-                .create_supernet(&CreateSupernet {
+                .create_supernet(TEST_TENANT, &CreateSupernet {
                     cidr: "10.0.0.0/8".to_string(),
                     name: Some("Corp".to_string()),
                     description: Some("Corporate network".to_string()),
@@ -50,7 +52,7 @@ macro_rules! store_contract_tests {
             assert!(!sn.id.is_empty());
             assert!(!sn.created_at.is_empty());
 
-            let fetched = store.get_supernet(&sn.id).await.unwrap();
+            let fetched = store.get_supernet(TEST_TENANT, &sn.id).await.unwrap();
             assert_eq!(fetched.cidr, sn.cidr);
             assert_eq!(fetched.name, sn.name);
         }
@@ -60,7 +62,7 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             store
-                .create_supernet(&CreateSupernet {
+                .create_supernet(TEST_TENANT, &CreateSupernet {
                     cidr: "10.0.0.0/8".to_string(),
                     name: None,
                     description: None,
@@ -68,7 +70,7 @@ macro_rules! store_contract_tests {
                 .await
                 .unwrap();
             store
-                .create_supernet(&CreateSupernet {
+                .create_supernet(TEST_TENANT, &CreateSupernet {
                     cidr: "172.16.0.0/12".to_string(),
                     name: None,
                     description: None,
@@ -76,7 +78,7 @@ macro_rules! store_contract_tests {
                 .await
                 .unwrap();
 
-            let all = store.list_supernets().await.unwrap();
+            let all = store.list_supernets(TEST_TENANT).await.unwrap();
             assert_eq!(all.len(), 2);
         }
 
@@ -85,7 +87,7 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             let sn = store
-                .create_supernet(&CreateSupernet {
+                .create_supernet(TEST_TENANT, &CreateSupernet {
                     cidr: "10.0.0.0/8".to_string(),
                     name: None,
                     description: None,
@@ -93,8 +95,8 @@ macro_rules! store_contract_tests {
                 .await
                 .unwrap();
 
-            store.delete_supernet(&sn.id).await.unwrap();
-            let all = store.list_supernets().await.unwrap();
+            store.delete_supernet(TEST_TENANT, &sn.id).await.unwrap();
+            let all = store.list_supernets(TEST_TENANT).await.unwrap();
             assert!(all.is_empty());
         }
 
@@ -103,7 +105,7 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             let sn = store
-                .create_supernet(&CreateSupernet {
+                .create_supernet(TEST_TENANT, &CreateSupernet {
                     cidr: "10.0.0.0/8".to_string(),
                     name: None,
                     description: None,
@@ -112,7 +114,7 @@ macro_rules! store_contract_tests {
                 .unwrap();
 
             store
-                .create_allocation(&CreateAllocation {
+                .create_allocation(TEST_TENANT, &CreateAllocation {
                     supernet_id: sn.id.clone(),
                     cidr: "10.0.0.0/24".to_string(),
                     status: None,
@@ -129,7 +131,7 @@ macro_rules! store_contract_tests {
                 .await
                 .unwrap();
 
-            let err = store.delete_supernet(&sn.id).await.unwrap_err();
+            let err = store.delete_supernet(TEST_TENANT, &sn.id).await.unwrap_err();
             assert!(
                 matches!(err, NetcidrError::SupernetHasActiveAllocations(_)),
                 "expected SupernetHasActiveAllocations, got: {:?}",
@@ -140,7 +142,7 @@ macro_rules! store_contract_tests {
         #[tokio::test]
         async fn contract_supernet_get_not_found() {
             let store = $factory().await;
-            let err = store.get_supernet("nonexistent-id").await.unwrap_err();
+            let err = store.get_supernet(TEST_TENANT, "nonexistent-id").await.unwrap_err();
             assert!(
                 matches!(err, NetcidrError::SupernetNotFound(_)),
                 "expected SupernetNotFound, got: {:?}",
@@ -153,7 +155,7 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             store
-                .create_supernet(&CreateSupernet {
+                .create_supernet(TEST_TENANT, &CreateSupernet {
                     cidr: "10.0.0.0/8".to_string(),
                     name: None,
                     description: None,
@@ -162,7 +164,7 @@ macro_rules! store_contract_tests {
                 .unwrap();
 
             let err = store
-                .create_supernet(&CreateSupernet {
+                .create_supernet(TEST_TENANT, &CreateSupernet {
                     cidr: "10.0.0.0/8".to_string(),
                     name: None,
                     description: None,
@@ -185,7 +187,7 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             let sn = store
-                .create_supernet(&CreateSupernet {
+                .create_supernet(TEST_TENANT, &CreateSupernet {
                     cidr: "10.0.0.0/8".to_string(),
                     name: None,
                     description: None,
@@ -194,7 +196,7 @@ macro_rules! store_contract_tests {
                 .unwrap();
 
             let alloc = store
-                .create_allocation(&CreateAllocation {
+                .create_allocation(TEST_TENANT, &CreateAllocation {
                     supernet_id: sn.id.clone(),
                     cidr: "10.0.0.0/24".to_string(),
                     status: None,
@@ -227,7 +229,7 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             let sn = store
-                .create_supernet(&CreateSupernet {
+                .create_supernet(TEST_TENANT, &CreateSupernet {
                     cidr: "10.0.0.0/8".to_string(),
                     name: None,
                     description: None,
@@ -236,7 +238,7 @@ macro_rules! store_contract_tests {
                 .unwrap();
 
             let alloc = store
-                .create_allocation(&CreateAllocation {
+                .create_allocation(TEST_TENANT, &CreateAllocation {
                     supernet_id: sn.id.clone(),
                     cidr: "10.0.0.0/24".to_string(),
                     status: Some(AllocationStatus::Reserved),
@@ -272,7 +274,7 @@ macro_rules! store_contract_tests {
             assert_eq!(alloc.tags.len(), 2);
 
             // Verify get returns the same data
-            let fetched = store.get_allocation(&alloc.id).await.unwrap();
+            let fetched = store.get_allocation(TEST_TENANT, &alloc.id).await.unwrap();
             assert_eq!(fetched.resource_id, alloc.resource_id);
             assert_eq!(fetched.tags.len(), 2);
         }
@@ -282,7 +284,7 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             let sn = store
-                .create_supernet(&CreateSupernet {
+                .create_supernet(TEST_TENANT, &CreateSupernet {
                     cidr: "10.0.0.0/8".to_string(),
                     name: None,
                     description: None,
@@ -291,7 +293,7 @@ macro_rules! store_contract_tests {
                 .unwrap();
 
             let alloc = store
-                .create_allocation(&CreateAllocation {
+                .create_allocation(TEST_TENANT, &CreateAllocation {
                     supernet_id: sn.id.clone(),
                     cidr: "10.0.0.0/24".to_string(),
                     status: None,
@@ -311,6 +313,7 @@ macro_rules! store_contract_tests {
             // Update only description — name and resource_id should be preserved
             let updated = store
                 .update_allocation(
+                    TEST_TENANT,
                     &alloc.id,
                     &UpdateAllocation {
                         name: None,
@@ -335,7 +338,7 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             let sn = store
-                .create_supernet(&CreateSupernet {
+                .create_supernet(TEST_TENANT, &CreateSupernet {
                     cidr: "10.0.0.0/8".to_string(),
                     name: None,
                     description: None,
@@ -344,7 +347,7 @@ macro_rules! store_contract_tests {
                 .unwrap();
 
             let alloc = store
-                .create_allocation(&CreateAllocation {
+                .create_allocation(TEST_TENANT, &CreateAllocation {
                     supernet_id: sn.id.clone(),
                     cidr: "10.0.0.0/24".to_string(),
                     status: None,
@@ -361,7 +364,7 @@ macro_rules! store_contract_tests {
                 .await
                 .unwrap();
 
-            let released = store.release_allocation(&alloc.id).await.unwrap();
+            let released = store.release_allocation(TEST_TENANT, &alloc.id).await.unwrap();
             assert_eq!(released.status, AllocationStatus::Released);
             assert!(released.released_at.is_some());
         }
@@ -369,7 +372,7 @@ macro_rules! store_contract_tests {
         #[tokio::test]
         async fn contract_allocation_get_not_found() {
             let store = $factory().await;
-            let err = store.get_allocation("nonexistent-id").await.unwrap_err();
+            let err = store.get_allocation(TEST_TENANT, "nonexistent-id").await.unwrap_err();
             assert!(
                 matches!(err, NetcidrError::AllocationNotFound(_)),
                 "expected AllocationNotFound, got: {:?}",
@@ -384,7 +387,7 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             let sn = store
-                .create_supernet(&CreateSupernet {
+                .create_supernet(TEST_TENANT, &CreateSupernet {
                     cidr: "10.0.0.0/8".to_string(),
                     name: None,
                     description: None,
@@ -393,7 +396,7 @@ macro_rules! store_contract_tests {
                 .unwrap();
 
             store
-                .create_allocation(&CreateAllocation {
+                .create_allocation(TEST_TENANT, &CreateAllocation {
                     supernet_id: sn.id.clone(),
                     cidr: "10.0.0.0/24".to_string(),
                     status: None,
@@ -411,7 +414,7 @@ macro_rules! store_contract_tests {
                 .unwrap();
 
             store
-                .create_allocation(&CreateAllocation {
+                .create_allocation(TEST_TENANT, &CreateAllocation {
                     supernet_id: sn.id.clone(),
                     cidr: "10.0.1.0/24".to_string(),
                     status: Some(AllocationStatus::Reserved),
@@ -430,7 +433,7 @@ macro_rules! store_contract_tests {
 
             // Filter by supernet
             let by_sn = store
-                .list_allocations(&AllocationFilter {
+                .list_allocations(TEST_TENANT, &AllocationFilter {
                     supernet_id: Some(sn.id.clone()),
                     ..Default::default()
                 })
@@ -440,7 +443,7 @@ macro_rules! store_contract_tests {
 
             // Filter by status
             let reserved = store
-                .list_allocations(&AllocationFilter {
+                .list_allocations(TEST_TENANT, &AllocationFilter {
                     status: Some(AllocationStatus::Reserved),
                     ..Default::default()
                 })
@@ -451,7 +454,7 @@ macro_rules! store_contract_tests {
 
             // Filter by resource_id
             let by_res = store
-                .list_allocations(&AllocationFilter {
+                .list_allocations(TEST_TENANT, &AllocationFilter {
                     resource_id: Some("vpc-1".to_string()),
                     ..Default::default()
                 })
@@ -462,7 +465,7 @@ macro_rules! store_contract_tests {
 
             // Filter by environment
             let by_env = store
-                .list_allocations(&AllocationFilter {
+                .list_allocations(TEST_TENANT, &AllocationFilter {
                     environment: Some("staging".to_string()),
                     ..Default::default()
                 })
@@ -472,7 +475,7 @@ macro_rules! store_contract_tests {
 
             // Filter by owner
             let by_owner = store
-                .list_allocations(&AllocationFilter {
+                .list_allocations(TEST_TENANT, &AllocationFilter {
                     owner: Some("team-a".to_string()),
                     ..Default::default()
                 })
@@ -486,7 +489,7 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             let sn = store
-                .create_supernet(&CreateSupernet {
+                .create_supernet(TEST_TENANT, &CreateSupernet {
                     cidr: "10.0.0.0/8".to_string(),
                     name: None,
                     description: None,
@@ -495,7 +498,7 @@ macro_rules! store_contract_tests {
                 .unwrap();
 
             let a1 = store
-                .create_allocation(&CreateAllocation {
+                .create_allocation(TEST_TENANT, &CreateAllocation {
                     supernet_id: sn.id.clone(),
                     cidr: "10.0.0.0/24".to_string(),
                     status: None,
@@ -513,7 +516,7 @@ macro_rules! store_contract_tests {
                 .unwrap();
 
             store
-                .create_allocation(&CreateAllocation {
+                .create_allocation(TEST_TENANT, &CreateAllocation {
                     supernet_id: sn.id.clone(),
                     cidr: "10.0.1.0/24".to_string(),
                     status: Some(AllocationStatus::Reserved),
@@ -530,11 +533,12 @@ macro_rules! store_contract_tests {
                 .await
                 .unwrap();
 
-            store.release_allocation(&a1.id).await.unwrap();
+            store.release_allocation(TEST_TENANT, &a1.id).await.unwrap();
 
             // Only reserved should remain in active+reserved query
             let active = store
                 .find_allocations_in_supernet(
+                    TEST_TENANT,
                     &sn.id,
                     &[AllocationStatus::Active, AllocationStatus::Reserved],
                 )
@@ -545,7 +549,7 @@ macro_rules! store_contract_tests {
 
             // Released query
             let released = store
-                .find_allocations_in_supernet(&sn.id, &[AllocationStatus::Released])
+                .find_allocations_in_supernet(TEST_TENANT, &sn.id, &[AllocationStatus::Released])
                 .await
                 .unwrap();
             assert_eq!(released.len(), 1);
@@ -559,7 +563,7 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             let sn = store
-                .create_supernet(&CreateSupernet {
+                .create_supernet(TEST_TENANT, &CreateSupernet {
                     cidr: "10.0.0.0/8".to_string(),
                     name: None,
                     description: None,
@@ -568,7 +572,7 @@ macro_rules! store_contract_tests {
                 .unwrap();
 
             let alloc = store
-                .create_allocation(&CreateAllocation {
+                .create_allocation(TEST_TENANT, &CreateAllocation {
                     supernet_id: sn.id.clone(),
                     cidr: "10.0.0.0/24".to_string(),
                     status: None,
@@ -588,6 +592,7 @@ macro_rules! store_contract_tests {
             // Set initial tags
             store
                 .set_tags(
+                    TEST_TENANT,
                     &alloc.id,
                     &[
                         Tag {
@@ -603,12 +608,13 @@ macro_rules! store_contract_tests {
                 .await
                 .unwrap();
 
-            let tags = store.get_tags(&alloc.id).await.unwrap();
+            let tags = store.get_tags(TEST_TENANT, &alloc.id).await.unwrap();
             assert_eq!(tags.len(), 2);
 
             // Replace with different tags
             store
                 .set_tags(
+                    TEST_TENANT,
                     &alloc.id,
                     &[Tag {
                         key: "env".to_string(),
@@ -618,7 +624,7 @@ macro_rules! store_contract_tests {
                 .await
                 .unwrap();
 
-            let tags = store.get_tags(&alloc.id).await.unwrap();
+            let tags = store.get_tags(TEST_TENANT, &alloc.id).await.unwrap();
             assert_eq!(tags.len(), 1);
             assert_eq!(tags[0].key, "env");
             assert_eq!(tags[0].value, "staging");
@@ -629,7 +635,7 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             let sn = store
-                .create_supernet(&CreateSupernet {
+                .create_supernet(TEST_TENANT, &CreateSupernet {
                     cidr: "10.0.0.0/8".to_string(),
                     name: None,
                     description: None,
@@ -638,7 +644,7 @@ macro_rules! store_contract_tests {
                 .unwrap();
 
             let alloc = store
-                .create_allocation(&CreateAllocation {
+                .create_allocation(TEST_TENANT, &CreateAllocation {
                     supernet_id: sn.id.clone(),
                     cidr: "10.0.0.0/24".to_string(),
                     status: None,
@@ -659,7 +665,7 @@ macro_rules! store_contract_tests {
                 .unwrap();
 
             // Tags should be present when fetching the allocation
-            let fetched = store.get_allocation(&alloc.id).await.unwrap();
+            let fetched = store.get_allocation(TEST_TENANT, &alloc.id).await.unwrap();
             assert_eq!(fetched.tags.len(), 1);
             assert_eq!(fetched.tags[0].key, "env");
         }
@@ -673,6 +679,7 @@ macro_rules! store_contract_tests {
             store
                 .append_audit(&AuditEntry {
                     id: String::new(),
+                    tenant_id: TEST_TENANT.to_string(),
                     entity_type: "supernet".to_string(),
                     entity_id: "sn-1".to_string(),
                     action: "create_supernet".to_string(),
@@ -686,6 +693,7 @@ macro_rules! store_contract_tests {
             store
                 .append_audit(&AuditEntry {
                     id: String::new(),
+                    tenant_id: TEST_TENANT.to_string(),
                     entity_type: "allocation".to_string(),
                     entity_id: "alloc-1".to_string(),
                     action: "allocate".to_string(),
@@ -697,12 +705,12 @@ macro_rules! store_contract_tests {
                 .unwrap();
 
             // Query all
-            let all = store.query_audit(&AuditFilter::default()).await.unwrap();
+            let all = store.query_audit(TEST_TENANT, &AuditFilter::default()).await.unwrap();
             assert_eq!(all.len(), 2);
 
             // Filter by entity_type
             let supernets = store
-                .query_audit(&AuditFilter {
+                .query_audit(TEST_TENANT, &AuditFilter {
                     entity_type: Some("supernet".to_string()),
                     ..Default::default()
                 })
@@ -713,7 +721,7 @@ macro_rules! store_contract_tests {
 
             // Filter by entity_id
             let by_id = store
-                .query_audit(&AuditFilter {
+                .query_audit(TEST_TENANT, &AuditFilter {
                     entity_id: Some("alloc-1".to_string()),
                     ..Default::default()
                 })
@@ -723,7 +731,7 @@ macro_rules! store_contract_tests {
 
             // Filter by action
             let by_action = store
-                .query_audit(&AuditFilter {
+                .query_audit(TEST_TENANT, &AuditFilter {
                     action: Some("allocate".to_string()),
                     ..Default::default()
                 })
@@ -733,7 +741,7 @@ macro_rules! store_contract_tests {
 
             // Limit
             let limited = store
-                .query_audit(&AuditFilter {
+                .query_audit(TEST_TENANT, &AuditFilter {
                     limit: Some(1),
                     ..Default::default()
                 })
@@ -749,7 +757,7 @@ macro_rules! store_contract_tests {
             let store = $factory().await;
 
             let sn = store
-                .create_supernet(&CreateSupernet {
+                .create_supernet(TEST_TENANT, &CreateSupernet {
                     cidr: "10.0.0.0/8".to_string(),
                     name: None,
                     description: None,
@@ -758,7 +766,7 @@ macro_rules! store_contract_tests {
                 .unwrap();
 
             let parent = store
-                .create_allocation(&CreateAllocation {
+                .create_allocation(TEST_TENANT, &CreateAllocation {
                     supernet_id: sn.id.clone(),
                     cidr: "10.0.0.0/16".to_string(),
                     status: None,
@@ -776,7 +784,7 @@ macro_rules! store_contract_tests {
                 .unwrap();
 
             let child = store
-                .create_allocation(&CreateAllocation {
+                .create_allocation(TEST_TENANT, &CreateAllocation {
                     supernet_id: sn.id.clone(),
                     cidr: "10.0.1.0/24".to_string(),
                     status: None,
@@ -807,7 +815,7 @@ macro_rules! store_contract_tests {
 
             // Store should still work
             let sn = store
-                .create_supernet(&CreateSupernet {
+                .create_supernet(TEST_TENANT, &CreateSupernet {
                     cidr: "10.0.0.0/8".to_string(),
                     name: None,
                     description: None,
@@ -842,7 +850,7 @@ mod migration_upgrade {
 
         // Insert data at current schema version
         let sn = store
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "10.0.0.0/8".to_string(),
                 name: Some("Corp".to_string()),
                 description: None,
@@ -851,7 +859,7 @@ mod migration_upgrade {
             .unwrap();
 
         let alloc = store
-            .create_allocation(&CreateAllocation {
+            .create_allocation(TEST_TENANT, &CreateAllocation {
                 supernet_id: sn.id.clone(),
                 cidr: "10.0.0.0/24".to_string(),
                 status: None,
@@ -874,6 +882,7 @@ mod migration_upgrade {
         store
             .append_audit(&AuditEntry {
                 id: String::new(),
+                tenant_id: TEST_TENANT.to_string(),
                 entity_type: "allocation".to_string(),
                 entity_id: alloc.id.clone(),
                 action: "allocate".to_string(),
@@ -888,18 +897,18 @@ mod migration_upgrade {
         store.migrate().await.unwrap();
 
         // Verify all data intact
-        let fetched_sn = store.get_supernet(&sn.id).await.unwrap();
+        let fetched_sn = store.get_supernet(TEST_TENANT, &sn.id).await.unwrap();
         assert_eq!(fetched_sn.cidr, "10.0.0.0/8");
         assert_eq!(fetched_sn.name, Some("Corp".to_string()));
 
-        let fetched_alloc = store.get_allocation(&alloc.id).await.unwrap();
+        let fetched_alloc = store.get_allocation(TEST_TENANT, &alloc.id).await.unwrap();
         assert_eq!(fetched_alloc.cidr, "10.0.0.0/24");
         assert_eq!(fetched_alloc.resource_id, Some("vpc-1".to_string()));
         assert_eq!(fetched_alloc.name, Some("web".to_string()));
         assert_eq!(fetched_alloc.tags.len(), 1);
 
         let audit = store
-            .query_audit(&AuditFilter {
+            .query_audit(TEST_TENANT, &AuditFilter {
                 entity_id: Some(alloc.id.clone()),
                 ..Default::default()
             })
@@ -916,7 +925,7 @@ mod migration_upgrade {
 
         // Create two supernets
         let sn1 = store
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "10.0.0.0/8".to_string(),
                 name: Some("Corp".to_string()),
                 description: None,
@@ -925,7 +934,7 @@ mod migration_upgrade {
             .unwrap();
 
         let sn2 = store
-            .create_supernet(&CreateSupernet {
+            .create_supernet(TEST_TENANT, &CreateSupernet {
                 cidr: "172.16.0.0/12".to_string(),
                 name: Some("Cloud".to_string()),
                 description: None,
@@ -935,7 +944,7 @@ mod migration_upgrade {
 
         // Create allocations in both
         let a1 = store
-            .create_allocation(&CreateAllocation {
+            .create_allocation(TEST_TENANT, &CreateAllocation {
                 supernet_id: sn1.id.clone(),
                 cidr: "10.0.0.0/24".to_string(),
                 status: None,
@@ -953,7 +962,7 @@ mod migration_upgrade {
             .unwrap();
 
         store
-            .create_allocation(&CreateAllocation {
+            .create_allocation(TEST_TENANT, &CreateAllocation {
                 supernet_id: sn1.id.clone(),
                 cidr: "10.0.1.0/24".to_string(),
                 status: Some(AllocationStatus::Reserved),
@@ -971,7 +980,7 @@ mod migration_upgrade {
             .unwrap();
 
         store
-            .create_allocation(&CreateAllocation {
+            .create_allocation(TEST_TENANT, &CreateAllocation {
                 supernet_id: sn2.id.clone(),
                 cidr: "172.16.0.0/24".to_string(),
                 status: None,
@@ -989,11 +998,12 @@ mod migration_upgrade {
             .unwrap();
 
         // Release one
-        store.release_allocation(&a1.id).await.unwrap();
+        store.release_allocation(TEST_TENANT, &a1.id).await.unwrap();
 
         // Set tags
         store
             .set_tags(
+                TEST_TENANT,
                 &a1.id,
                 &[Tag {
                     key: "decom".to_string(),
@@ -1007,22 +1017,22 @@ mod migration_upgrade {
         store.migrate().await.unwrap();
 
         // Verify counts
-        let supernets = store.list_supernets().await.unwrap();
+        let supernets = store.list_supernets(TEST_TENANT).await.unwrap();
         assert_eq!(supernets.len(), 2);
 
         let all_allocs = store
-            .list_allocations(&AllocationFilter::default())
+            .list_allocations(TEST_TENANT, &AllocationFilter::default())
             .await
             .unwrap();
         assert_eq!(all_allocs.len(), 3);
 
         // Verify release survived
-        let released = store.get_allocation(&a1.id).await.unwrap();
+        let released = store.get_allocation(TEST_TENANT, &a1.id).await.unwrap();
         assert_eq!(released.status, AllocationStatus::Released);
         assert!(released.released_at.is_some());
 
         // Verify tags survived
-        let tags = store.get_tags(&a1.id).await.unwrap();
+        let tags = store.get_tags(TEST_TENANT, &a1.id).await.unwrap();
         assert_eq!(tags.len(), 1);
         assert_eq!(tags[0].key, "decom");
     }
@@ -1035,12 +1045,12 @@ mod migration_upgrade {
         store.migrate().await.unwrap();
 
         // The store should work after migration
-        let supernets = store.list_supernets().await.unwrap();
+        let supernets = store.list_supernets(TEST_TENANT).await.unwrap();
         assert!(supernets.is_empty());
 
         // Re-migrate should be safe
         store.migrate().await.unwrap();
-        let supernets = store.list_supernets().await.unwrap();
+        let supernets = store.list_supernets(TEST_TENANT).await.unwrap();
         assert!(supernets.is_empty());
     }
 }

--- a/tests/postgres_integration.rs
+++ b/tests/postgres_integration.rs
@@ -18,6 +18,8 @@ use netcidr::ipam::operations::IpamOps;
 use netcidr::ipam::postgres::PostgresStore;
 use netcidr::ipam::store::IpamStore;
 
+const TEST_TENANT: &str = "test@example.com";
+
 const CONTAINER_NAME: &str = "netcidr-test-pg";
 const PG_PORT: u16 = 15432;
 const PG_DB: &str = "netcidr_test";
@@ -128,7 +130,7 @@ async fn test_postgres_backend() {
 
 async fn supernet_crud(store: &PostgresStore) {
     let sn = store
-        .create_supernet(&CreateSupernet {
+        .create_supernet(TEST_TENANT, &CreateSupernet {
             cidr: "10.0.0.0/8".to_string(),
             name: Some("RFC1918 Class A".to_string()),
             description: None,
@@ -141,21 +143,21 @@ async fn supernet_crud(store: &PostgresStore) {
     assert_eq!(sn.prefix_length, 8);
     assert_eq!(sn.ip_version, 4);
 
-    let fetched = store.get_supernet(&sn.id).await.unwrap();
+    let fetched = store.get_supernet(TEST_TENANT, &sn.id).await.unwrap();
     assert_eq!(fetched.cidr, "10.0.0.0/8");
     assert_eq!(fetched.name, Some("RFC1918 Class A".to_string()));
 
-    let all = store.list_supernets().await.unwrap();
+    let all = store.list_supernets(TEST_TENANT).await.unwrap();
     assert!(all.iter().any(|s| s.id == sn.id));
 
-    store.delete_supernet(&sn.id).await.unwrap();
-    let err = store.get_supernet(&sn.id).await;
+    store.delete_supernet(TEST_TENANT, &sn.id).await.unwrap();
+    let err = store.get_supernet(TEST_TENANT, &sn.id).await;
     assert!(err.is_err());
 }
 
 async fn allocation_lifecycle(store: &PostgresStore) {
     let sn = store
-        .create_supernet(&CreateSupernet {
+        .create_supernet(TEST_TENANT, &CreateSupernet {
             cidr: "172.16.0.0/12".to_string(),
             name: Some("Private".to_string()),
             description: None,
@@ -165,7 +167,7 @@ async fn allocation_lifecycle(store: &PostgresStore) {
 
     // Allocate with tags
     let alloc = store
-        .create_allocation(&CreateAllocation {
+        .create_allocation(TEST_TENANT, &CreateAllocation {
             supernet_id: sn.id.clone(),
             cidr: "172.16.0.0/24".to_string(),
             status: None,
@@ -189,7 +191,7 @@ async fn allocation_lifecycle(store: &PostgresStore) {
     assert_eq!(alloc.prefix_length, 24);
 
     // Get
-    let fetched = store.get_allocation(&alloc.id).await.unwrap();
+    let fetched = store.get_allocation(TEST_TENANT, &alloc.id).await.unwrap();
     assert_eq!(fetched.resource_id, Some("vpc-abc".to_string()));
     assert_eq!(fetched.tags.len(), 1);
     assert_eq!(fetched.tags[0].key, "team");
@@ -197,6 +199,7 @@ async fn allocation_lifecycle(store: &PostgresStore) {
     // Update
     let updated = store
         .update_allocation(
+            TEST_TENANT,
             &alloc.id,
             &UpdateAllocation {
                 name: None,
@@ -215,7 +218,7 @@ async fn allocation_lifecycle(store: &PostgresStore) {
 
     // List with filter
     let filtered = store
-        .list_allocations(&AllocationFilter {
+        .list_allocations(TEST_TENANT, &AllocationFilter {
             supernet_id: Some(sn.id.clone()),
             status: Some(AllocationStatus::Active),
             ..Default::default()
@@ -225,13 +228,14 @@ async fn allocation_lifecycle(store: &PostgresStore) {
     assert_eq!(filtered.len(), 1);
 
     // Release
-    let released = store.release_allocation(&alloc.id).await.unwrap();
+    let released = store.release_allocation(TEST_TENANT, &alloc.id).await.unwrap();
     assert_eq!(released.status, AllocationStatus::Released);
     assert!(released.released_at.is_some());
 
     // Find by status — should be empty (all released)
     let active = store
         .find_allocations_in_supernet(
+            TEST_TENANT,
             &sn.id,
             &[AllocationStatus::Active, AllocationStatus::Reserved],
         )
@@ -240,12 +244,12 @@ async fn allocation_lifecycle(store: &PostgresStore) {
     assert!(active.is_empty());
 
     // Delete supernet (allocations are released)
-    store.delete_supernet(&sn.id).await.unwrap();
+    store.delete_supernet(TEST_TENANT, &sn.id).await.unwrap();
 }
 
 async fn tags(store: &PostgresStore) {
     let sn = store
-        .create_supernet(&CreateSupernet {
+        .create_supernet(TEST_TENANT, &CreateSupernet {
             cidr: "192.168.0.0/16".to_string(),
             name: None,
             description: None,
@@ -254,7 +258,7 @@ async fn tags(store: &PostgresStore) {
         .unwrap();
 
     let alloc = store
-        .create_allocation(&CreateAllocation {
+        .create_allocation(TEST_TENANT, &CreateAllocation {
             supernet_id: sn.id.clone(),
             cidr: "192.168.1.0/24".to_string(),
             status: None,
@@ -274,6 +278,7 @@ async fn tags(store: &PostgresStore) {
     // Set tags
     store
         .set_tags(
+            TEST_TENANT,
             &alloc.id,
             &[
                 Tag {
@@ -288,12 +293,13 @@ async fn tags(store: &PostgresStore) {
         )
         .await
         .unwrap();
-    let tags = store.get_tags(&alloc.id).await.unwrap();
+    let tags = store.get_tags(TEST_TENANT, &alloc.id).await.unwrap();
     assert_eq!(tags.len(), 2);
 
     // Replace tags
     store
         .set_tags(
+            TEST_TENANT,
             &alloc.id,
             &[Tag {
                 key: "env".to_string(),
@@ -302,19 +308,20 @@ async fn tags(store: &PostgresStore) {
         )
         .await
         .unwrap();
-    let tags = store.get_tags(&alloc.id).await.unwrap();
+    let tags = store.get_tags(TEST_TENANT, &alloc.id).await.unwrap();
     assert_eq!(tags.len(), 1);
     assert_eq!(tags[0].value, "staging");
 
     // Cleanup
-    store.release_allocation(&alloc.id).await.unwrap();
-    store.delete_supernet(&sn.id).await.unwrap();
+    store.release_allocation(TEST_TENANT, &alloc.id).await.unwrap();
+    store.delete_supernet(TEST_TENANT, &sn.id).await.unwrap();
 }
 
 async fn audit_log(store: &PostgresStore) {
     store
         .append_audit(&AuditEntry {
             id: String::new(),
+            tenant_id: TEST_TENANT.to_string(),
             entity_type: "supernet".to_string(),
             entity_id: "sn-1".to_string(),
             action: "create_supernet".to_string(),
@@ -328,6 +335,7 @@ async fn audit_log(store: &PostgresStore) {
     store
         .append_audit(&AuditEntry {
             id: String::new(),
+            tenant_id: TEST_TENANT.to_string(),
             entity_type: "allocation".to_string(),
             entity_id: "alloc-1".to_string(),
             action: "allocate".to_string(),
@@ -339,12 +347,12 @@ async fn audit_log(store: &PostgresStore) {
         .unwrap();
 
     // Query all
-    let entries = store.query_audit(&AuditFilter::default()).await.unwrap();
+    let entries = store.query_audit(TEST_TENANT, &AuditFilter::default()).await.unwrap();
     assert!(entries.len() >= 2);
 
     // Query filtered by entity_id
     let entries = store
-        .query_audit(&AuditFilter {
+        .query_audit(TEST_TENANT, &AuditFilter {
             entity_id: Some("sn-1".to_string()),
             ..Default::default()
         })
@@ -355,7 +363,7 @@ async fn audit_log(store: &PostgresStore) {
 
     // Query with limit
     let entries = store
-        .query_audit(&AuditFilter {
+        .query_audit(TEST_TENANT, &AuditFilter {
             limit: Some(1),
             ..Default::default()
         })
@@ -368,7 +376,7 @@ async fn operations_layer(store: PostgresStore) {
     let ops = IpamOps::new(Arc::new(store));
 
     let sn = ops
-        .create_supernet(&CreateSupernet {
+        .create_supernet(TEST_TENANT, &CreateSupernet {
             cidr: "10.100.0.0/16".to_string(),
             name: Some("ops-test".to_string()),
             description: None,
@@ -378,7 +386,7 @@ async fn operations_layer(store: PostgresStore) {
 
     // Auto-allocate 3 x /24
     let allocs = ops
-        .allocate_auto(&AutoAllocateRequest {
+        .allocate_auto(TEST_TENANT, &AutoAllocateRequest {
             supernet_id: sn.id.clone(),
             prefix_length: 24,
             count: Some(3),
@@ -401,12 +409,12 @@ async fn operations_layer(store: PostgresStore) {
     assert_eq!(allocs[2].cidr, "10.100.2.0/24");
 
     // Utilization
-    let util = ops.utilization(&sn.id).await.unwrap();
+    let util = ops.utilization(TEST_TENANT, &sn.id).await.unwrap();
     assert_eq!(util.allocation_count, 3);
     assert!(util.utilization_percent > 0.0);
 
     // Free blocks
-    let free = ops.free_blocks(&sn.id, None).await.unwrap();
+    let free = ops.free_blocks(TEST_TENANT, &sn.id, None).await.unwrap();
     assert!(!free.blocks.is_empty());
     assert!(free.total_free > 0);
 }

--- a/tests/postgres_integration.rs
+++ b/tests/postgres_integration.rs
@@ -130,11 +130,14 @@ async fn test_postgres_backend() {
 
 async fn supernet_crud(store: &PostgresStore) {
     let sn = store
-        .create_supernet(TEST_TENANT, &CreateSupernet {
-            cidr: "10.0.0.0/8".to_string(),
-            name: Some("RFC1918 Class A".to_string()),
-            description: None,
-        })
+        .create_supernet(
+            TEST_TENANT,
+            &CreateSupernet {
+                cidr: "10.0.0.0/8".to_string(),
+                name: Some("RFC1918 Class A".to_string()),
+                description: None,
+            },
+        )
         .await
         .unwrap();
     assert_eq!(sn.cidr, "10.0.0.0/8");
@@ -157,33 +160,39 @@ async fn supernet_crud(store: &PostgresStore) {
 
 async fn allocation_lifecycle(store: &PostgresStore) {
     let sn = store
-        .create_supernet(TEST_TENANT, &CreateSupernet {
-            cidr: "172.16.0.0/12".to_string(),
-            name: Some("Private".to_string()),
-            description: None,
-        })
+        .create_supernet(
+            TEST_TENANT,
+            &CreateSupernet {
+                cidr: "172.16.0.0/12".to_string(),
+                name: Some("Private".to_string()),
+                description: None,
+            },
+        )
         .await
         .unwrap();
 
     // Allocate with tags
     let alloc = store
-        .create_allocation(TEST_TENANT, &CreateAllocation {
-            supernet_id: sn.id.clone(),
-            cidr: "172.16.0.0/24".to_string(),
-            status: None,
-            resource_id: Some("vpc-abc".to_string()),
-            resource_type: Some("vpc".to_string()),
-            name: Some("web-tier".to_string()),
-            description: None,
-            environment: Some("production".to_string()),
-            owner: Some("platform".to_string()),
-            parent_allocation_id: None,
-            tags: Some(vec![Tag {
-                key: "team".to_string(),
-                value: "infra".to_string(),
-            }]),
-            ttl_seconds: None,
-        })
+        .create_allocation(
+            TEST_TENANT,
+            &CreateAllocation {
+                supernet_id: sn.id.clone(),
+                cidr: "172.16.0.0/24".to_string(),
+                status: None,
+                resource_id: Some("vpc-abc".to_string()),
+                resource_type: Some("vpc".to_string()),
+                name: Some("web-tier".to_string()),
+                description: None,
+                environment: Some("production".to_string()),
+                owner: Some("platform".to_string()),
+                parent_allocation_id: None,
+                tags: Some(vec![Tag {
+                    key: "team".to_string(),
+                    value: "infra".to_string(),
+                }]),
+                ttl_seconds: None,
+            },
+        )
         .await
         .unwrap();
     assert_eq!(alloc.status, AllocationStatus::Active);
@@ -218,17 +227,23 @@ async fn allocation_lifecycle(store: &PostgresStore) {
 
     // List with filter
     let filtered = store
-        .list_allocations(TEST_TENANT, &AllocationFilter {
-            supernet_id: Some(sn.id.clone()),
-            status: Some(AllocationStatus::Active),
-            ..Default::default()
-        })
+        .list_allocations(
+            TEST_TENANT,
+            &AllocationFilter {
+                supernet_id: Some(sn.id.clone()),
+                status: Some(AllocationStatus::Active),
+                ..Default::default()
+            },
+        )
         .await
         .unwrap();
     assert_eq!(filtered.len(), 1);
 
     // Release
-    let released = store.release_allocation(TEST_TENANT, &alloc.id).await.unwrap();
+    let released = store
+        .release_allocation(TEST_TENANT, &alloc.id)
+        .await
+        .unwrap();
     assert_eq!(released.status, AllocationStatus::Released);
     assert!(released.released_at.is_some());
 
@@ -249,29 +264,35 @@ async fn allocation_lifecycle(store: &PostgresStore) {
 
 async fn tags(store: &PostgresStore) {
     let sn = store
-        .create_supernet(TEST_TENANT, &CreateSupernet {
-            cidr: "192.168.0.0/16".to_string(),
-            name: None,
-            description: None,
-        })
+        .create_supernet(
+            TEST_TENANT,
+            &CreateSupernet {
+                cidr: "192.168.0.0/16".to_string(),
+                name: None,
+                description: None,
+            },
+        )
         .await
         .unwrap();
 
     let alloc = store
-        .create_allocation(TEST_TENANT, &CreateAllocation {
-            supernet_id: sn.id.clone(),
-            cidr: "192.168.1.0/24".to_string(),
-            status: None,
-            resource_id: None,
-            resource_type: None,
-            name: None,
-            description: None,
-            environment: None,
-            owner: None,
-            parent_allocation_id: None,
-            tags: None,
-            ttl_seconds: None,
-        })
+        .create_allocation(
+            TEST_TENANT,
+            &CreateAllocation {
+                supernet_id: sn.id.clone(),
+                cidr: "192.168.1.0/24".to_string(),
+                status: None,
+                resource_id: None,
+                resource_type: None,
+                name: None,
+                description: None,
+                environment: None,
+                owner: None,
+                parent_allocation_id: None,
+                tags: None,
+                ttl_seconds: None,
+            },
+        )
         .await
         .unwrap();
 
@@ -313,7 +334,10 @@ async fn tags(store: &PostgresStore) {
     assert_eq!(tags[0].value, "staging");
 
     // Cleanup
-    store.release_allocation(TEST_TENANT, &alloc.id).await.unwrap();
+    store
+        .release_allocation(TEST_TENANT, &alloc.id)
+        .await
+        .unwrap();
     store.delete_supernet(TEST_TENANT, &sn.id).await.unwrap();
 }
 
@@ -347,15 +371,21 @@ async fn audit_log(store: &PostgresStore) {
         .unwrap();
 
     // Query all
-    let entries = store.query_audit(TEST_TENANT, &AuditFilter::default()).await.unwrap();
+    let entries = store
+        .query_audit(TEST_TENANT, &AuditFilter::default())
+        .await
+        .unwrap();
     assert!(entries.len() >= 2);
 
     // Query filtered by entity_id
     let entries = store
-        .query_audit(TEST_TENANT, &AuditFilter {
-            entity_id: Some("sn-1".to_string()),
-            ..Default::default()
-        })
+        .query_audit(
+            TEST_TENANT,
+            &AuditFilter {
+                entity_id: Some("sn-1".to_string()),
+                ..Default::default()
+            },
+        )
         .await
         .unwrap();
     assert_eq!(entries.len(), 1);
@@ -363,10 +393,13 @@ async fn audit_log(store: &PostgresStore) {
 
     // Query with limit
     let entries = store
-        .query_audit(TEST_TENANT, &AuditFilter {
-            limit: Some(1),
-            ..Default::default()
-        })
+        .query_audit(
+            TEST_TENANT,
+            &AuditFilter {
+                limit: Some(1),
+                ..Default::default()
+            },
+        )
         .await
         .unwrap();
     assert_eq!(entries.len(), 1);
@@ -376,31 +409,37 @@ async fn operations_layer(store: PostgresStore) {
     let ops = IpamOps::new(Arc::new(store));
 
     let sn = ops
-        .create_supernet(TEST_TENANT, &CreateSupernet {
-            cidr: "10.100.0.0/16".to_string(),
-            name: Some("ops-test".to_string()),
-            description: None,
-        })
+        .create_supernet(
+            TEST_TENANT,
+            &CreateSupernet {
+                cidr: "10.100.0.0/16".to_string(),
+                name: Some("ops-test".to_string()),
+                description: None,
+            },
+        )
         .await
         .unwrap();
 
     // Auto-allocate 3 x /24
     let allocs = ops
-        .allocate_auto(TEST_TENANT, &AutoAllocateRequest {
-            supernet_id: sn.id.clone(),
-            prefix_length: 24,
-            count: Some(3),
-            status: None,
-            resource_id: None,
-            resource_type: None,
-            name: None,
-            description: None,
-            environment: None,
-            owner: None,
-            parent_allocation_id: None,
-            tags: None,
-            ttl_seconds: None,
-        })
+        .allocate_auto(
+            TEST_TENANT,
+            &AutoAllocateRequest {
+                supernet_id: sn.id.clone(),
+                prefix_length: 24,
+                count: Some(3),
+                status: None,
+                resource_id: None,
+                resource_type: None,
+                name: None,
+                description: None,
+                environment: None,
+                owner: None,
+                parent_allocation_id: None,
+                tags: None,
+                ttl_seconds: None,
+            },
+        )
         .await
         .unwrap();
     assert_eq!(allocs.len(), 3);


### PR DESCRIPTION
## Summary

Sub-project 1 of 3 toward a remote MCP endpoint. Establishes per-OIDC-identity isolation of all IPAM data (supernets, allocations, audit log, idempotency keys), keyed by email today and column-named (`tenant_id`) so a future per-org tenancy migration is a value swap, not a rename.

- **Storage:** Destructive migration `006` on both SQLite + Postgres drops and recreates IPAM tables with `tenant_id TEXT NOT NULL`, replaces `UNIQUE(cidr)` with `UNIQUE(tenant_id, cidr)` on supernets, adds composite tenant indexes, and enforces the cross-table invariant `allocations.tenant_id == supernets.tenant_id` via DB trigger.
- **Type-system enforcement:** Every `IpamStore` and `IpamOps` method gains `tenant_id: &str` as an explicit parameter. The compiler refuses to forget it.
- **Auth → tenant flow:** New `src/tenant.rs` (Tenant newtype + Axum extractor). `require_auth` inserts `Tenant` extension after the allowlist check, sourcing it from the OIDC principal's verified email. Bearer-mode (single-operator) falls back to `principal.subject` so existing deployments keep a coherent tenant.
- **Cross-tenant access returns 404, not 403** — prevents existence enumeration. Five-test isolation matrix in `tests/ipam_isolation.rs` proves it (uses a synthetic `X-Test-Tenant` middleware to bypass OIDC-mocking complexity).
- **CLI + stdio MCP** pass the literal `"local"` — single-tenant by definition.

Spec: `docs/superpowers/specs/2026-05-02-multi-tenant-isolation-design.md`
Plan: `docs/superpowers/plans/2026-05-02-multi-tenant-isolation.md` (15 tasks, all checkboxes ticked).

## Out of scope (deferred to follow-on PRs)

- **Sub-project 2:** Personal Access Tokens (DB-backed PATs scoped to an OIDC identity, mint/list/revoke).
- **Sub-project 3:** `/mcp` mounting on the deployed Lambda using the same auth gate.

## Test plan

- [x] `cargo test --features ipam-postgres,mcp` — 457 tests across 11 binaries, all green
- [x] Five-test isolation matrix in `tests/ipam_isolation.rs` passes (supernets, same-CIDR-different-tenant, allocations, audit log, idempotency keys)
- [x] Phase 1 trigger test (`allocation_with_mismatched_tenant_id_is_rejected_by_trigger`) passes on SQLite; Postgres twin skips cleanly when no `NETCIDR_TEST_DATABASE_URL`
- [ ] Verify CI green
- [ ] Verify v0.24.0 release auto-triggers on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)