### PR TITLE
[codex] Fix Lambda PAT and Postgres schema checks

### DIFF
--- a/src/bin/lambda.rs
+++ b/src/bin/lambda.rs
@@ -70,10 +70,20 @@ async fn main() -> Result<(), Error> {
         None
     };
 
+    // Keep Lambda startup aligned with `netcidr serve`: OIDC deployments
+    // that can mint PATs must also configure the pepper used to hash and
+    // verify them. Without this, the dashboard can ship token UI while the
+    // Lambda router never mounts /me/tokens.
+    let pat_pepper = if matches!(server.auth_mode, AuthMode::Oidc) {
+        Some(Arc::new(netcidr::pat::PatPepper::from_env()?))
+    } else {
+        None
+    };
+
     let router = create_router(RouterConfig {
         server,
         ipam_ops,
-        pat_pepper: None,
+        pat_pepper,
     });
 
     run(router).await

--- a/src/ipam/postgres/mod.rs
+++ b/src/ipam/postgres/mod.rs
@@ -149,6 +149,7 @@ impl IpamStore for PostgresStore {
                     .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
             }
         }
+        Self::validate_schema(&self.pool).await?;
         Ok(())
     }
 
@@ -985,6 +986,36 @@ fn pg_row_to_pat(row: sqlx::postgres::PgRow) -> PersonalAccessToken {
 }
 
 impl PostgresStore {
+    async fn validate_schema(pool: &PgPool) -> Result<()> {
+        let rows = sqlx::query(
+            "SELECT required.name \
+             FROM (VALUES \
+                ('cidr_blocks'), \
+                ('allocations'), \
+                ('audit_log'), \
+                ('idempotency_keys'), \
+                ('personal_access_tokens') \
+             ) AS required(name) \
+             WHERE to_regclass(required.name) IS NULL",
+        )
+        .fetch_all(pool)
+        .await
+        .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
+
+        if !rows.is_empty() {
+            let missing = rows
+                .iter()
+                .map(|row| row.get::<String, _>("name"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(NetcidrError::DatabaseError(format!(
+                "PostgreSQL schema is incomplete after migrations; missing required table(s): {missing}"
+            )));
+        }
+
+        Ok(())
+    }
+
     /// Execute a migration SQL blob. Postgres prepared statements only support
     /// one statement, so we split on `;` — but plpgsql function bodies
     /// (`$$ ... $$`) themselves contain `;`. Track whether we're inside a


### PR DESCRIPTION
Summary

Fix Lambda-specific PAT configuration and add a Postgres schema sanity check after migrations.

Changes

- Read NETCIDR_PAT_PEPPER in the Lambda entrypoint for OIDC deployments and pass it into the API router.
- Validate required Postgres IPAM tables after migrations complete, so partial schema state fails at startup with a clear error instead of request-time 500s.

Validation

- Ran cargo test --features lambda,ipam-postgres --no-run.