### PR TITLE
chore: release v0.24.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.2](https://github.com/wingnut128/netcidr/compare/v0.24.1...v0.24.2) - 2026-05-11
+
+### Other
+
+- Disable StepSecurity workflows ([#162](https://github.com/wingnut128/netcidr/pull/162))
+
 ## [0.24.1](https://github.com/wingnut128/netcidr/compare/v0.24.0...v0.24.1) - 2026-05-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2212,7 +2212,7 @@ dependencies = [
 
 [[package]]
 name = "netcidr"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netcidr"
-version = "0.24.1"
+version = "0.24.2"
 edition = "2024"
 license = "MIT"
 description = "A fast IPv4 and IPv6 subnet calculator CLI and API"


### PR DESCRIPTION



## 🤖 New release

* `netcidr`: 0.24.1 -> 0.24.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.24.2](https://github.com/wingnut128/netcidr/compare/v0.24.1...v0.24.2) - 2026-05-11

### Other

- Disable StepSecurity workflows ([#162](https://github.com/wingnut128/netcidr/pull/162))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).