### PR TITLE
docs(api): document auth endpoints + bearerAuth in OpenAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **OpenAPI coverage for auth endpoints.** `/me`, `/admin/allowlist`, `/me/tokens` (GET/POST), `/me/tokens/{id}` (DELETE), and `/features` are now annotated with `utoipa::path` and registered in the `ApiDoc`. A new `bearerAuth` security scheme (HTTP Bearer; accepts OIDC JWT, PAT, or static bearer) is declared via a `SecurityAddon` modifier and attached to every protected handler — `/ipam/*` plus the new `/me/*` and `/admin/*` paths — so Swagger UI's "Authorize" button now works. Added an `auth` tag for the identity/allowlist/PAT endpoints and exposed `MeResponse`, `AllowlistResponse`, `FeaturesResponse`, `CreateTokenRequest`, `CreateTokenResponse`, `TokenListResponse`, and `PersonalAccessTokenSummary` as schemas.
+
 ## [0.24.2](https://github.com/wingnut128/netcidr/compare/v0.24.1...v0.24.2) - 2026-05-11
 
 ### Other

--- a/src/api.rs
+++ b/src/api.rs
@@ -19,7 +19,10 @@ use tower_http::timeout::TimeoutLayer;
 use tower_http::trace::TraceLayer;
 use tracing::{info, instrument, warn};
 #[cfg(feature = "swagger")]
-use utoipa::{IntoParams, OpenApi, ToSchema};
+use utoipa::{
+    IntoParams, Modify, OpenApi, ToSchema,
+    openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme},
+};
 #[cfg(feature = "swagger")]
 use utoipa_swagger_ui::SwaggerUi;
 
@@ -53,6 +56,37 @@ use crate::ipam::models::{
 #[cfg(feature = "swagger")]
 use crate::ipam_api::{AllocateSpecificRequest, AutoAllocateBody, IpamErrorResponse, TagsBody};
 
+/// Registers the `bearerAuth` security scheme used by `/ipam/*`, `/me/*`,
+/// and `/admin/*`. Accepts an OIDC JWT, a personal access token
+/// (`ncdr_pat_…`), or a configured static bearer — the server decides
+/// which by inspecting the token shape (see `auth.rs`). `/me/tokens`
+/// additionally rejects PATs at the handler layer (OIDC-only).
+#[cfg(feature = "swagger")]
+pub struct SecurityAddon;
+
+#[cfg(feature = "swagger")]
+impl Modify for SecurityAddon {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        let components = openapi
+            .components
+            .get_or_insert_with(utoipa::openapi::Components::new);
+        components.add_security_scheme(
+            "bearerAuth",
+            SecurityScheme::Http(
+                HttpBuilder::new()
+                    .scheme(HttpAuthScheme::Bearer)
+                    .bearer_format("JWT or ncdr_pat_… personal access token")
+                    .description(Some(
+                        "Bearer token. Accepts an OIDC JWT, a personal access token \
+                         (`ncdr_pat_…`), or a configured static bearer. `/me/tokens*` \
+                         rejects PAT and static-bearer auth and requires an OIDC JWT.",
+                    ))
+                    .build(),
+            ),
+        );
+    }
+}
+
 #[cfg(feature = "swagger")]
 #[derive(OpenApi)]
 #[openapi(
@@ -70,6 +104,12 @@ use crate::ipam_api::{AllocateSpecificRequest, AutoAllocateBody, IpamErrorRespon
         from_range_ipv4_handler,
         from_range_ipv6_handler,
         batch_handler,
+        features_handler,
+        me_handler,
+        allowlist_handler,
+        crate::me_api::create_token,
+        crate::me_api::list_tokens,
+        crate::me_api::revoke_token,
         crate::ipam_api::ipam_create_cidr_block,
         crate::ipam_api::ipam_list_cidr_blocks,
         crate::ipam_api::ipam_get_cidr_block,
@@ -93,15 +133,21 @@ use crate::ipam_api::{AllocateSpecificRequest, AutoAllocateBody, IpamErrorRespon
             ContainsResult, Ipv4SummaryResult, Ipv6SummaryResult, Ipv4FromRangeResult,
             Ipv6FromRangeResult, SubnetQuery, SplitQuery, ContainsQuery, SummarizeQuery,
             FromRangeQuery, BatchRequest, BatchResult, ErrorResponse, VersionResponse,
+            FeaturesResponse, MeResponse, AllowlistResponse,
+            crate::me_api::CreateTokenRequest, crate::me_api::CreateTokenResponse,
+            crate::me_api::TokenListResponse,
+            crate::ipam::models::PersonalAccessTokenSummary,
             CidrBlock, CidrBlockList, CreateCidrBlock, Allocation, AllocationList,
             AllocationStatus, Tag, UpdateAllocation, AllocateSpecificRequest,
             AutoAllocateBody, TagsBody, AuditEntry, AuditList, UtilizationReport,
             FreeBlock, FreeBlocksReport, IpamErrorResponse,
         )
     ),
+    modifiers(&SecurityAddon),
     tags(
         (name = "netcidr", description = "IP subnet calculator API"),
         (name = "ipam", description = "IP Address Management API"),
+        (name = "auth", description = "Identity, allowlist, and personal access token management"),
     ),
     info(
         title = "netcidr API",
@@ -420,10 +466,9 @@ pub fn create_router(config: RouterConfig) -> Router {
         ipam: ipam_enabled,
         swagger: swagger_enabled,
     };
-    let router = router.route(
-        "/features",
-        get(move || async move { Json(features.clone()) }),
-    );
+    let router = router
+        .route("/features", get(features_handler))
+        .layer(Extension(features));
 
     // /me + admin allowlist read endpoint. Both are auth-aware but live
     // outside the /ipam middleware (so an unallowlisted user can hit /me
@@ -1035,12 +1080,16 @@ async fn batch_handler(
 }
 
 #[derive(Clone, Serialize)]
+#[cfg_attr(feature = "swagger", derive(ToSchema))]
 struct FeaturesResponse {
+    /// Whether the IPAM subsystem is enabled on this server.
     ipam: bool,
+    /// Whether Swagger UI / OpenAPI docs are exposed.
     swagger: bool,
 }
 
 #[derive(Serialize)]
+#[cfg_attr(feature = "swagger", derive(ToSchema))]
 struct MeResponse {
     /// Verified email of the signed-in principal (may be null for bearer tokens).
     email: Option<String>,
@@ -1054,6 +1103,7 @@ struct MeResponse {
 }
 
 #[derive(Serialize)]
+#[cfg_attr(feature = "swagger", derive(ToSchema))]
 struct AllowlistResponse {
     /// Email addresses authorized to call /ipam/*.
     emails: Vec<String>,
@@ -1066,6 +1116,16 @@ struct AllowlistResponse {
     management: &'static str,
 }
 
+#[cfg_attr(feature = "swagger", utoipa::path(
+    get,
+    path = "/me",
+    responses(
+        (status = 200, description = "Authenticated principal identity and allowlist status", body = MeResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+    ),
+    security(("bearerAuth" = [])),
+    tag = "auth"
+))]
 async fn me_handler(
     Extension(auth_config): Extension<crate::auth::AuthConfig>,
     request: axum::extract::Request,
@@ -1089,6 +1149,17 @@ async fn me_handler(
     .into_response()
 }
 
+#[cfg_attr(feature = "swagger", utoipa::path(
+    get,
+    path = "/admin/allowlist",
+    responses(
+        (status = 200, description = "Current allowlist + admin list", body = AllowlistResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+    security(("bearerAuth" = [])),
+    tag = "auth"
+))]
 async fn allowlist_handler(
     Extension(auth_config): Extension<crate::auth::AuthConfig>,
     request: axum::extract::Request,
@@ -1106,6 +1177,20 @@ async fn allowlist_handler(
         management: "env",
     })
     .into_response()
+}
+
+#[cfg_attr(feature = "swagger", utoipa::path(
+    get,
+    path = "/features",
+    responses(
+        (status = 200, description = "Capability flags advertised by this server", body = FeaturesResponse),
+    ),
+    tag = "netcidr"
+))]
+async fn features_handler(
+    Extension(features): Extension<FeaturesResponse>,
+) -> Json<FeaturesResponse> {
+    Json(features)
 }
 
 #[cfg(feature = "dashboard")]

--- a/src/ipam/models.rs
+++ b/src/ipam/models.rs
@@ -492,6 +492,7 @@ pub struct CreatePersonalAccessToken {
 
 /// Public-safe view of a PAT — no plaintext, no hash. Used by `GET /me/tokens`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "swagger", derive(utoipa::ToSchema))]
 pub struct PersonalAccessTokenSummary {
     pub id: String,
     pub name: String,

--- a/src/ipam_api.rs
+++ b/src/ipam_api.rs
@@ -345,6 +345,7 @@ pub fn create_ipam_router() -> Router {
         (status = 400, description = "Invalid CIDR", body = IpamErrorResponse),
         (status = 409, description = "Overlapping cidr_block", body = IpamErrorResponse),
     ),
+    security(("bearerAuth" = [])),
     tag = "ipam"
 ))]
 async fn ipam_create_cidr_block(
@@ -364,6 +365,7 @@ async fn ipam_create_cidr_block(
     responses(
         (status = 200, description = "List of cidr_blocks", body = CidrBlockList),
     ),
+    security(("bearerAuth" = [])),
     tag = "ipam"
 ))]
 async fn ipam_list_cidr_blocks(
@@ -392,6 +394,7 @@ async fn ipam_list_cidr_blocks(
         (status = 200, description = "CIDR block details", body = CidrBlock),
         (status = 404, description = "CIDR block not found", body = IpamErrorResponse),
     ),
+    security(("bearerAuth" = [])),
     tag = "ipam"
 ))]
 async fn ipam_get_cidr_block(
@@ -416,6 +419,7 @@ async fn ipam_get_cidr_block(
         (status = 404, description = "CIDR block not found", body = IpamErrorResponse),
         (status = 409, description = "CIDR block has active allocations", body = IpamErrorResponse),
     ),
+    security(("bearerAuth" = [])),
     tag = "ipam"
 ))]
 async fn ipam_delete_cidr_block(
@@ -442,6 +446,7 @@ async fn ipam_delete_cidr_block(
         (status = 404, description = "CIDR block not found", body = IpamErrorResponse),
         (status = 409, description = "Overlapping allocation", body = IpamErrorResponse),
     ),
+    security(("bearerAuth" = [])),
     tag = "ipam"
 ))]
 async fn ipam_allocate_specific(
@@ -498,6 +503,7 @@ async fn ipam_allocate_specific(
         (status = 404, description = "CIDR block not found", body = IpamErrorResponse),
         (status = 422, description = "No free space available", body = IpamErrorResponse),
     ),
+    security(("bearerAuth" = [])),
     tag = "ipam"
 ))]
 async fn ipam_auto_allocate(
@@ -558,6 +564,7 @@ async fn ipam_auto_allocate(
         (status = 200, description = "List of allocations", body = AllocationList),
         (status = 404, description = "CIDR block not found", body = IpamErrorResponse),
     ),
+    security(("bearerAuth" = [])),
     tag = "ipam"
 ))]
 async fn ipam_list_cidr_block_allocations(
@@ -598,6 +605,7 @@ async fn ipam_list_cidr_block_allocations(
         (status = 200, description = "Free blocks report", body = FreeBlocksReport),
         (status = 404, description = "CIDR block not found", body = IpamErrorResponse),
     ),
+    security(("bearerAuth" = [])),
     tag = "ipam"
 ))]
 async fn ipam_free_blocks(
@@ -625,6 +633,7 @@ async fn ipam_free_blocks(
         (status = 200, description = "Utilization report", body = UtilizationReport),
         (status = 404, description = "CIDR block not found", body = IpamErrorResponse),
     ),
+    security(("bearerAuth" = [])),
     tag = "ipam"
 ))]
 async fn ipam_utilization(
@@ -648,6 +657,7 @@ async fn ipam_utilization(
         (status = 200, description = "Allocation details", body = Allocation),
         (status = 404, description = "Allocation not found", body = IpamErrorResponse),
     ),
+    security(("bearerAuth" = [])),
     tag = "ipam"
 ))]
 async fn ipam_get_allocation(
@@ -672,6 +682,7 @@ async fn ipam_get_allocation(
         (status = 200, description = "Allocation updated", body = Allocation),
         (status = 404, description = "Allocation not found", body = IpamErrorResponse),
     ),
+    security(("bearerAuth" = [])),
     tag = "ipam"
 ))]
 async fn ipam_update_allocation(
@@ -696,6 +707,7 @@ async fn ipam_update_allocation(
         (status = 200, description = "Allocation released", body = Allocation),
         (status = 404, description = "Allocation not found", body = IpamErrorResponse),
     ),
+    security(("bearerAuth" = [])),
     tag = "ipam"
 ))]
 async fn ipam_release_allocation(
@@ -718,6 +730,7 @@ async fn ipam_release_allocation(
     responses(
         (status = 200, description = "Matching allocations", body = AllocationList),
     ),
+    security(("bearerAuth" = [])),
     tag = "ipam"
 ))]
 async fn ipam_find_ip(
@@ -746,6 +759,7 @@ async fn ipam_find_ip(
     responses(
         (status = 200, description = "Matching allocations", body = AllocationList),
     ),
+    security(("bearerAuth" = [])),
     tag = "ipam"
 ))]
 async fn ipam_find_resource(
@@ -772,6 +786,7 @@ async fn ipam_find_resource(
     responses(
         (status = 200, description = "Audit log entries", body = AuditList),
     ),
+    security(("bearerAuth" = [])),
     tag = "ipam"
 ))]
 async fn ipam_query_audit(
@@ -808,6 +823,7 @@ async fn ipam_query_audit(
         (status = 200, description = "Tags updated, returns allocation", body = Allocation),
         (status = 404, description = "Allocation not found", body = IpamErrorResponse),
     ),
+    security(("bearerAuth" = [])),
     tag = "ipam"
 ))]
 async fn ipam_set_tags(

--- a/src/me_api.rs
+++ b/src/me_api.rs
@@ -44,7 +44,9 @@ use crate::pat::PatPepper;
 use crate::pat_lifecycle::{CreatePatRequest, PatLifecycle, PatOwner};
 
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "swagger", derive(utoipa::ToSchema))]
 pub struct CreateTokenRequest {
+    /// Human-readable label for the token (shown in the UI / list response).
     pub name: String,
     /// Number of days from now until the token expires. `None` defaults
     /// to the lifecycle default; values outside `1..=365` are 400.
@@ -54,6 +56,7 @@ pub struct CreateTokenRequest {
 /// One-time response to a successful mint. The `token` field is the
 /// plaintext secret — surfaced exactly once and never again.
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "swagger", derive(utoipa::ToSchema))]
 pub struct CreateTokenResponse {
     pub id: String,
     pub name: String,
@@ -68,12 +71,14 @@ pub struct CreateTokenResponse {
 /// `GET /me/tokens` envelope. Mirrors the `CidrBlockList` shape used by
 /// `/ipam/cidr-blocks` — `{ tokens: [...], count: N }`.
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "swagger", derive(utoipa::ToSchema))]
 pub struct TokenListResponse {
     pub tokens: Vec<PersonalAccessTokenSummary>,
     pub count: usize,
 }
 
 #[derive(Debug, Serialize)]
+#[cfg_attr(feature = "swagger", derive(utoipa::ToSchema))]
 struct ErrorBody {
     error: String,
 }
@@ -126,8 +131,21 @@ pub fn create_me_router() -> Router {
         .layer(middleware::from_fn(require_oidc))
 }
 
+#[cfg_attr(feature = "swagger", utoipa::path(
+    post,
+    path = "/me/tokens",
+    request_body = CreateTokenRequest,
+    responses(
+        (status = 201, description = "PAT minted. The plaintext `token` is returned exactly once.", body = CreateTokenResponse),
+        (status = 400, description = "Invalid request body"),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "OIDC authentication required (PAT and static-bearer auth are rejected here)"),
+    ),
+    security(("bearerAuth" = [])),
+    tag = "auth"
+))]
 #[instrument(skip_all, fields(owner_email = %principal.email.as_deref().unwrap_or("<none>")))]
-async fn create_token(
+pub(crate) async fn create_token(
     Extension(ops): Extension<Arc<IpamOps>>,
     Extension(pepper): Extension<Arc<PatPepper>>,
     Extension(principal): Extension<AuthenticatedPrincipal>,
@@ -177,8 +195,19 @@ async fn create_token(
     (StatusCode::CREATED, Json(resp)).into_response()
 }
 
+#[cfg_attr(feature = "swagger", utoipa::path(
+    get,
+    path = "/me/tokens",
+    responses(
+        (status = 200, description = "All PATs (including revoked) owned by the caller", body = TokenListResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "OIDC authentication required"),
+    ),
+    security(("bearerAuth" = [])),
+    tag = "auth"
+))]
 #[instrument(skip_all, fields(owner_email = %principal.email.as_deref().unwrap_or("<none>")))]
-async fn list_tokens(
+pub(crate) async fn list_tokens(
     Extension(ops): Extension<Arc<IpamOps>>,
     Extension(pepper): Extension<Arc<PatPepper>>,
     Extension(principal): Extension<AuthenticatedPrincipal>,
@@ -208,8 +237,23 @@ async fn list_tokens(
     }
 }
 
+#[cfg_attr(feature = "swagger", utoipa::path(
+    delete,
+    path = "/me/tokens/{id}",
+    params(
+        ("id" = String, Path, description = "PAT id (from the create/list response)"),
+    ),
+    responses(
+        (status = 204, description = "Token revoked (idempotent — already-revoked tokens also return 204)"),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "OIDC authentication required"),
+        (status = 404, description = "Token id not found in the caller's bucket"),
+    ),
+    security(("bearerAuth" = [])),
+    tag = "auth"
+))]
 #[instrument(skip_all, fields(pat_id = %id, owner_email = %principal.email.as_deref().unwrap_or("<none>")))]
-async fn revoke_token(
+pub(crate) async fn revoke_token(
     Extension(ops): Extension<Arc<IpamOps>>,
     Extension(pepper): Extension<Arc<PatPepper>>,
     Extension(principal): Extension<AuthenticatedPrincipal>,


### PR DESCRIPTION
## Summary

- Adds OpenAPI coverage for the previously-undocumented auth endpoints: `/me`, `/admin/allowlist`, `/me/tokens` (GET/POST), `/me/tokens/{id}` (DELETE), and `/features`.
- Declares a `bearerAuth` HTTP security scheme (accepts OIDC JWT, PAT `ncdr_pat_…`, or static bearer) via a `SecurityAddon` modifier and attaches `security(("bearerAuth" = []))` to every protected handler — `/ipam/*` plus the new `/me/*` and `/admin/*` paths — so Swagger UI's Authorize flow now works.
- Surfaces the auth-related schemas (`MeResponse`, `AllowlistResponse`, `FeaturesResponse`, `CreateTokenRequest`, `CreateTokenResponse`, `TokenListResponse`, `PersonalAccessTokenSummary`) and adds a new `auth` tag.

## Test plan

- [x] `cargo check --all-features` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all --check` passes
- [x] `cargo test --all-features` passes (excluding `test_postgres_backend`, which requires a running Postgres)
- [x] Live spec fetch from `netcidr serve --enable-swagger` at `/api-docs/openapi.json` confirms `/me`, `/me/tokens*`, `/admin/allowlist`, `/features` are present with `security: [{ bearerAuth: [] }]` on the protected ones, and `components.securitySchemes.bearerAuth` is populated.
- [ ] Manual: open Swagger UI, click Authorize, paste an OIDC JWT, exercise a `/me/tokens` POST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)