### PR TITLE
refactor: extract single error-presentation seam across HTTP, /me, and MCP frontends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Error presenter seam (`src/error_presenter.rs`).** A single `present(&NetcidrError) → PresentedError { status, client_msg, log_level }` is now the only place `NetcidrError` becomes a caller-visible response. IPAM HTTP API, `/me/tokens` HTTP API, and MCP tool results all call it; classification, scrubbing, and the "log this at error" decision live in one place. Table-driven unit tests assert every variant against `(status, message, log_level)`; the match has no catch-all, so adding a new variant produces a compile error rather than a silent 500. Added `Error Presenter` and `Presented Error` to `CONTEXT.md`.
+
+- **`NetcidrError::Upstream { status, message }`** for HTTP-client adapters. Replaces the previous flattening of upstream HTTP non-2xx responses to `DatabaseError(body)`, which lost the status code and overloaded a name that should mean "the SQL backend failed."
+
 - **OpenAPI coverage for auth endpoints.** `/me`, `/admin/allowlist`, `/me/tokens` (GET/POST), `/me/tokens/{id}` (DELETE), and `/features` are now annotated with `utoipa::path` and registered in the `ApiDoc`. A new `bearerAuth` security scheme (HTTP Bearer; accepts OIDC JWT, PAT, or static bearer) is declared via a `SecurityAddon` modifier and attached to every protected handler — `/ipam/*` plus the new `/me/*` and `/admin/*` paths — so Swagger UI's "Authorize" button now works. Added an `auth` tag for the identity/allowlist/PAT endpoints and exposed `MeResponse`, `AllowlistResponse`, `FeaturesResponse`, `CreateTokenRequest`, `CreateTokenResponse`, `TokenListResponse`, and `PersonalAccessTokenSummary` as schemas.
+
+### Fixed
+
+- **MCP no longer leaks SQL backend text.** Before, MCP tool errors used `format!("Error: {e}")` directly on `NetcidrError`, so a `DatabaseError` would expose raw SQL driver messages (table names, file paths, constraint names) to the MCP client. The MCP frontend now goes through the error presenter and surfaces `"Error: internal server error"` plus a server-side `tracing::error!`.
+
+- **`mcp_client.rs` and `token_cli.rs` preserve upstream status.** Both used to flatten every non-2xx upstream HTTP response (incl. 401/403/404/409/422) to `DatabaseError(body)`, which the IPAM frontend then mapped back to 500. They now emit `NetcidrError::Upstream { status, message }`, so a 409 from the upstream stays a 409 at the MCP boundary, and a 401 stays a 401 at the CLI.
+
+### Changed
+
+- **Dropped substring-based `DatabaseError` classification in `ipam_api`.** The legacy shim mapped `DatabaseError(msg)` containing `"overlap"`/`"conflict"`/`"not found"` to 409/404. Verified vestigial — overlap rejection has gone through the typed `AllocationConflict` variant since well before this change. All `DatabaseError` now collapses to 500. If a future SQL backend error needs a non-500 status, classify it at the source (in `operations.rs` or the store adapter), not by sniffing strings at the response boundary.
+
+- **`PatNotFound` is canonicalised to `"token not found"` across all HTTP paths.** Previously this was only enforced in the `/me/tokens` mapper; PAT lookups via `/ipam/*` paths fell through to 500. Both surfaces now agree, and the caller-supplied id is never echoed back.
 
 ## [0.24.2](https://github.com/wingnut128/netcidr/compare/v0.24.1...v0.24.2) - 2026-05-11
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,3 +24,21 @@ subject, email, and tenant id used for scoped listing and revocation.
 
 The plaintext token returned only once when a PAT is minted. Stored state keeps
 only the public prefix and peppered hash.
+
+### Error Presenter
+
+The single module (`src/error_presenter.rs`) that translates a `NetcidrError`
+into a `PresentedError`. Every caller-facing surface — IPAM HTTP API,
+`/me/tokens` HTTP API, MCP tool results — calls `present()` so error
+classification, message scrubbing, and the "log this at error" decision
+are made in one place.
+
+### Presented Error
+
+The wire-format-neutral view of an error: `{ status: u16, client_msg: String,
+log_level: LogLevel }`. HTTP frontends serialize it to `{"error": ...}` with
+the given status; the MCP frontend serializes it to a scrubbed string. The
+`client_msg` is always safe to expose; raw database, transport, and
+unrecognized errors are flattened to `"internal server error"`. `PatNotFound`
+is canonicalised to `"token not found"` so the caller-supplied id is never
+echoed back.

--- a/src/error.rs
+++ b/src/error.rs
@@ -90,6 +90,14 @@ pub enum NetcidrError {
 
     #[error("Personal access token not found: {0}")]
     PatNotFound(String),
+
+    /// A response from an upstream HTTP API (e.g. the MCP server's
+    /// remote-API backend, or the `netcidr token` CLI talking to a
+    /// remote `netcidr serve`). Carries the status code and a message
+    /// the upstream chose to expose; both have already passed through
+    /// that upstream's own error presenter.
+    #[error("upstream error (HTTP {status}): {message}")]
+    Upstream { status: u16, message: String },
 }
 
 pub type Result<T> = std::result::Result<T, NetcidrError>;

--- a/src/error_presenter.rs
+++ b/src/error_presenter.rs
@@ -1,0 +1,413 @@
+//! Single point where a [`NetcidrError`] becomes a caller-visible
+//! response. Every frontend — IPAM HTTP API, `/me/tokens` HTTP API,
+//! MCP tool results — passes its errors through [`present`] so the
+//! status code, scrubbed client message, and logging policy live in
+//! one place.
+//!
+//! See the `Error Presenter` and `Presented Error` entries in
+//! `CONTEXT.md`.
+
+use crate::error::NetcidrError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogLevel {
+    /// Frontend should not log; the caller is responsible for handling
+    /// their own bad input. Used for 4xx classes.
+    None,
+    /// Frontend should emit `tracing::error!` with the original `err`
+    /// before responding. Used for 5xx classes and unrecognized
+    /// variants, where the operator needs the full unscrubbed message
+    /// to diagnose.
+    Error,
+}
+
+/// Wire-format-neutral view of a [`NetcidrError`]. HTTP frontends
+/// serialize it to `{ "error": client_msg }` with `status`; the MCP
+/// frontend renders it as a scrubbed string. `client_msg` is always
+/// safe to expose — raw database, transport, and unrecognized errors
+/// are flattened to `"internal server error"`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PresentedError {
+    pub status: u16,
+    pub client_msg: String,
+    pub log_level: LogLevel,
+}
+
+/// Translate a [`NetcidrError`] into the canonical [`PresentedError`].
+///
+/// Policy:
+/// - All validation / shape variants → 400, message passes through `Display`.
+/// - Domain "not found" variants → 404; `PatNotFound` is canonicalised
+///   to `"token not found"` so the caller-supplied id is never echoed back.
+/// - Conflict variants → 409, message passes through.
+/// - `NoFreeSpace` → 422, message passes through.
+/// - `Upstream { status, message }` → that exact status and message
+///   (the upstream has already scrubbed and classified).
+/// - `DatabaseError`, `Io`, `Json`, `Csv`, `Yaml`, `ConfigParse`, and
+///   any future variant → 500 `"internal server error"`, log at error.
+pub fn present(err: &NetcidrError) -> PresentedError {
+    use NetcidrError::*;
+
+    match err {
+        // 400 — validation / input shape
+        InvalidIpv4Address(_)
+        | InvalidIpv6Address(_)
+        | InvalidCidr(_)
+        | InvalidPrefixLength(_)
+        | InvalidInput(_)
+        | InvalidSubnetSplit { .. }
+        | InvalidRange(_, _)
+        | EmptyCidrList
+        | InsufficientSubnets { .. }
+        | SubnetLimitExceeded { .. }
+        | BatchSizeExceeded { .. }
+        | FromRangeLimitExceeded { .. }
+        | SummarizeInputLimitExceeded { .. }
+        | InputTooLong { .. } => PresentedError {
+            status: 400,
+            client_msg: err.to_string(),
+            log_level: LogLevel::None,
+        },
+
+        // 404 — domain "not found"
+        CidrBlockNotFound(_) | AllocationNotFound(_) => PresentedError {
+            status: 404,
+            client_msg: err.to_string(),
+            log_level: LogLevel::None,
+        },
+
+        // 404 — PAT not found; do NOT echo the caller-supplied id.
+        PatNotFound(_) => PresentedError {
+            status: 404,
+            client_msg: "token not found".to_string(),
+            log_level: LogLevel::None,
+        },
+
+        // 409 — conflict
+        AllocationConflict { .. } | CidrBlockHasActiveAllocations(_) => PresentedError {
+            status: 409,
+            client_msg: err.to_string(),
+            log_level: LogLevel::None,
+        },
+
+        // 422 — domain rule violated by an otherwise-valid request
+        NoFreeSpace { .. } => PresentedError {
+            status: 422,
+            client_msg: err.to_string(),
+            log_level: LogLevel::None,
+        },
+
+        // Passthrough from an upstream API (HTTP-client adapters set
+        // this variant after the upstream's presenter ran). Trust the
+        // upstream's status; log 5xx classes at error so an operator
+        // notices repeated upstream failures.
+        Upstream { status, message } => PresentedError {
+            status: *status,
+            client_msg: message.clone(),
+            log_level: if *status >= 500 {
+                LogLevel::Error
+            } else {
+                LogLevel::None
+            },
+        },
+
+        // 500 — never expose raw text. DB driver messages, IO/serde
+        // failures, and anything we forgot to classify all collapse here.
+        DatabaseError(_) | Io(_) | Json(_) | Csv(_) | Yaml(_) | ConfigParse(_) => PresentedError {
+            status: 500,
+            client_msg: "internal server error".to_string(),
+            log_level: LogLevel::Error,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn case(err: NetcidrError, status: u16, msg: &str, log: LogLevel) {
+        let p = present(&err);
+        assert_eq!(
+            p,
+            PresentedError {
+                status,
+                client_msg: msg.to_string(),
+                log_level: log,
+            },
+            "variant {err:?} presented incorrectly",
+        );
+    }
+
+    #[test]
+    fn validation_variants_are_400_and_passthrough() {
+        case(
+            NetcidrError::InvalidIpv4Address("1.2.3".into()),
+            400,
+            "Invalid IPv4 address: 1.2.3",
+            LogLevel::None,
+        );
+        case(
+            NetcidrError::InvalidIpv6Address("::xyz".into()),
+            400,
+            "Invalid IPv6 address: ::xyz",
+            LogLevel::None,
+        );
+        case(
+            NetcidrError::InvalidCidr("nope".into()),
+            400,
+            "Invalid CIDR notation: nope",
+            LogLevel::None,
+        );
+        case(
+            NetcidrError::InvalidPrefixLength(99),
+            400,
+            "Invalid prefix length: 99 (must be 0-32 for IPv4, 0-128 for IPv6)",
+            LogLevel::None,
+        );
+        case(
+            NetcidrError::InvalidInput("bad".into()),
+            400,
+            "Invalid input: bad",
+            LogLevel::None,
+        );
+        case(
+            NetcidrError::InvalidSubnetSplit {
+                new_prefix: 16,
+                original_prefix: 24,
+            },
+            400,
+            "New prefix length 16 must be greater than original prefix 24",
+            LogLevel::None,
+        );
+        case(
+            NetcidrError::InvalidRange("10.0.0.5".into(), "10.0.0.1".into()),
+            400,
+            "Invalid range: start 10.0.0.5 is greater than end 10.0.0.1",
+            LogLevel::None,
+        );
+        case(
+            NetcidrError::EmptyCidrList,
+            400,
+            "No CIDRs provided for summarization",
+            LogLevel::None,
+        );
+    }
+
+    #[test]
+    fn limit_variants_are_400() {
+        case(
+            NetcidrError::InsufficientSubnets {
+                requested: 10,
+                available: 4,
+                new_prefix: 24,
+                original_prefix: 22,
+            },
+            400,
+            "Cannot generate 10 /24 subnets from /22 (only 4 available)",
+            LogLevel::None,
+        );
+        case(
+            NetcidrError::SubnetLimitExceeded {
+                count: "1000".into(),
+                limit: 100,
+            },
+            400,
+            "Generating 1000 subnets exceeds the limit of 100. Use --count-only to see the count, or -n to generate a smaller number.",
+            LogLevel::None,
+        );
+        case(
+            NetcidrError::BatchSizeExceeded {
+                count: 5000,
+                limit: 1000,
+            },
+            400,
+            "Batch size 5000 exceeds maximum of 1000",
+            LogLevel::None,
+        );
+        case(
+            NetcidrError::FromRangeLimitExceeded {
+                count: 9000,
+                limit: 1000,
+            },
+            400,
+            "Generated CIDR count 9000 exceeds maximum of 1000",
+            LogLevel::None,
+        );
+        case(
+            NetcidrError::SummarizeInputLimitExceeded {
+                count: 9000,
+                limit: 1000,
+            },
+            400,
+            "Summarize input count 9000 exceeds maximum of 1000",
+            LogLevel::None,
+        );
+        case(
+            NetcidrError::InputTooLong {
+                length: 2048,
+                limit: 1024,
+            },
+            400,
+            "Input string exceeds maximum length of 1024 bytes",
+            LogLevel::None,
+        );
+    }
+
+    #[test]
+    fn not_found_variants_are_404() {
+        case(
+            NetcidrError::CidrBlockNotFound("abc".into()),
+            404,
+            "CIDR block not found: abc",
+            LogLevel::None,
+        );
+        case(
+            NetcidrError::AllocationNotFound("def".into()),
+            404,
+            "Allocation not found: def",
+            LogLevel::None,
+        );
+    }
+
+    #[test]
+    fn pat_not_found_is_scrubbed() {
+        case(
+            NetcidrError::PatNotFound("pat_secret_id_123".into()),
+            404,
+            "token not found",
+            LogLevel::None,
+        );
+    }
+
+    #[test]
+    fn conflict_variants_are_409() {
+        case(
+            NetcidrError::AllocationConflict {
+                existing: "10.0.0.0/24".into(),
+                candidate: "10.0.0.0/16".into(),
+            },
+            409,
+            "Allocation conflict: 10.0.0.0/16 overlaps with existing 10.0.0.0/24",
+            LogLevel::None,
+        );
+        case(
+            NetcidrError::CidrBlockHasActiveAllocations("sn1".into()),
+            409,
+            "CIDR block sn1 has active allocations and cannot be deleted",
+            LogLevel::None,
+        );
+    }
+
+    #[test]
+    fn no_free_space_is_422() {
+        case(
+            NetcidrError::NoFreeSpace {
+                cidr_block: "10.0.0.0/24".into(),
+                prefix: 28,
+            },
+            422,
+            "No free space in 10.0.0.0/24 for a /28 allocation",
+            LogLevel::None,
+        );
+    }
+
+    #[test]
+    fn upstream_passes_status_and_message_through() {
+        case(
+            NetcidrError::Upstream {
+                status: 409,
+                message: "allocation conflict".into(),
+            },
+            409,
+            "allocation conflict",
+            LogLevel::None,
+        );
+        case(
+            NetcidrError::Upstream {
+                status: 401,
+                message: "missing bearer".into(),
+            },
+            401,
+            "missing bearer",
+            LogLevel::None,
+        );
+        // 5xx upstreams are surfaced as 5xx and logged so the operator
+        // sees repeated upstream failures.
+        case(
+            NetcidrError::Upstream {
+                status: 503,
+                message: "upstream unavailable".into(),
+            },
+            503,
+            "upstream unavailable",
+            LogLevel::Error,
+        );
+    }
+
+    #[test]
+    fn database_error_is_scrubbed_to_500() {
+        // Even if the raw message contains "overlap" or "not found"
+        // (legacy substring shim) it is NOT classified — it goes to 500.
+        case(
+            NetcidrError::DatabaseError(
+                "UNIQUE constraint failed: allocations.cidr; range overlaps".into(),
+            ),
+            500,
+            "internal server error",
+            LogLevel::Error,
+        );
+        case(
+            NetcidrError::DatabaseError("PostgreSQL connection failed".into()),
+            500,
+            "internal server error",
+            LogLevel::Error,
+        );
+    }
+
+    #[test]
+    fn infrastructure_errors_are_scrubbed_to_500() {
+        case(
+            NetcidrError::Io(std::io::Error::other("disk gone")),
+            500,
+            "internal server error",
+            LogLevel::Error,
+        );
+        case(
+            NetcidrError::Csv("bad csv".into()),
+            500,
+            "internal server error",
+            LogLevel::Error,
+        );
+        case(
+            NetcidrError::Yaml("bad yaml".into()),
+            500,
+            "internal server error",
+            LogLevel::Error,
+        );
+        case(
+            NetcidrError::ConfigParse("missing key".into()),
+            500,
+            "internal server error",
+            LogLevel::Error,
+        );
+        // Json error — synthesize via a deliberate parse failure
+        let json_err: serde_json::Error = serde_json::from_str::<u32>("not a number").unwrap_err();
+        case(
+            NetcidrError::Json(json_err),
+            500,
+            "internal server error",
+            LogLevel::Error,
+        );
+    }
+
+    /// Compile-time guard: every `NetcidrError` variant has a presenter
+    /// arm. Adding a new variant without updating `present` produces a
+    /// non-exhaustive-match error here.
+    #[test]
+    fn every_variant_is_explicit_in_presenter() {
+        // No assertion needed — this test exists so reviewers see the
+        // exhaustive match in `present` is the source of truth. If a
+        // new variant slips in without an arm, `present` itself fails
+        // to compile (no `_ =>` catch-all).
+    }
+}

--- a/src/ipam_api.rs
+++ b/src/ipam_api.rs
@@ -13,73 +13,28 @@ use serde::Deserialize;
 use utoipa::{IntoParams, ToSchema};
 
 use crate::error::NetcidrError;
+use crate::error_presenter::{LogLevel, present};
 use crate::ipam::idempotency;
 use crate::ipam::models::*;
 use crate::ipam::operations::IpamOps;
 
 // ---------------------------------------------------------------------------
-// Error mapping
+// Error mapping — thin adapter over `error_presenter::present`. All
+// classification, scrubbing, and log-policy lives there.
 // ---------------------------------------------------------------------------
 
 pub(crate) fn error_to_status_value(err: NetcidrError) -> (StatusCode, serde_json::Value) {
-    let (status, client_msg) = error_to_parts(&err);
-    (status, serde_json::json!({ "error": client_msg }))
+    let p = present(&err);
+    if p.log_level == LogLevel::Error {
+        tracing::error!(error = %err, "ipam request failed");
+    }
+    let status = StatusCode::from_u16(p.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    (status, serde_json::json!({ "error": p.client_msg }))
 }
 
 fn ipam_error_response(err: NetcidrError) -> Response {
-    let (status, client_msg) = error_to_parts(&err);
-    let body = serde_json::json!({ "error": client_msg });
+    let (status, body) = error_to_status_value(err);
     (status, Json(body)).into_response()
-}
-
-fn error_to_parts(err: &NetcidrError) -> (StatusCode, String) {
-    match err {
-        NetcidrError::InvalidCidr(_)
-        | NetcidrError::InvalidPrefixLength { .. }
-        | NetcidrError::InvalidInput(_)
-        | NetcidrError::InvalidSubnetSplit { .. }
-        | NetcidrError::InvalidIpv4Address(_)
-        | NetcidrError::InvalidIpv6Address(_) => (StatusCode::BAD_REQUEST, err.to_string()),
-
-        NetcidrError::CidrBlockNotFound(_) | NetcidrError::AllocationNotFound(_) => {
-            (StatusCode::NOT_FOUND, err.to_string())
-        }
-
-        NetcidrError::AllocationConflict { .. }
-        | NetcidrError::CidrBlockHasActiveAllocations(_) => (StatusCode::CONFLICT, err.to_string()),
-
-        NetcidrError::NoFreeSpace { .. } => (StatusCode::UNPROCESSABLE_ENTITY, err.to_string()),
-
-        // DatabaseError: classify by content for status code, but never expose
-        // raw DB messages (table names, file paths, constraint names) to clients.
-        NetcidrError::DatabaseError(msg)
-            if msg.contains("not found") || msg.contains("No cidr_block") =>
-        {
-            tracing::error!(error = %err, "database error");
-            (StatusCode::NOT_FOUND, "not found".to_string())
-        }
-
-        NetcidrError::DatabaseError(msg) if msg.contains("overlap") || msg.contains("conflict") => {
-            tracing::error!(error = %err, "database error");
-            (StatusCode::CONFLICT, "allocation conflict".to_string())
-        }
-
-        NetcidrError::DatabaseError(_) => {
-            tracing::error!(error = %err, "database error");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "internal server error".to_string(),
-            )
-        }
-
-        _ => {
-            tracing::error!(error = %err, "unexpected error");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "internal server error".to_string(),
-            )
-        }
-    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub mod dns;
 pub mod config;
 pub mod daemon;
 pub mod error;
+pub mod error_presenter;
 pub mod logging;
 pub mod validation;
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -366,7 +366,13 @@ fn is_ipv6(s: &str) -> bool {
 fn result_to_string<T: serde::Serialize>(result: crate::error::Result<T>) -> String {
     match result {
         Ok(val) => serde_json::to_string_pretty(&val).unwrap_or_else(|e| format!("Error: {e}")),
-        Err(e) => format!("Error: {e}"),
+        Err(e) => {
+            let p = crate::error_presenter::present(&e);
+            if p.log_level == crate::error_presenter::LogLevel::Error {
+                tracing::error!(error = %e, "mcp tool failed");
+            }
+            format!("Error: {}", p.client_msg)
+        }
     }
 }
 

--- a/src/mcp_client.rs
+++ b/src/mcp_client.rs
@@ -34,26 +34,20 @@ impl HttpIpamClient {
         format!("{}/ipam{}", self.base_url, path)
     }
 
-    /// Map a non-success HTTP response to an `NetcidrError`.
+    /// Map a non-success HTTP response from the upstream API to a
+    /// `NetcidrError::Upstream`. The upstream's `error_presenter`
+    /// already scrubbed the body and chose the status, so this side
+    /// just forwards both; the MCP presenter then renders the upstream
+    /// status to the MCP caller exactly as if the request had been
+    /// served locally.
     async fn map_error(resp: reqwest::Response) -> NetcidrError {
         let status = resp.status().as_u16();
-        let body = resp
+        let message = resp
             .json::<ApiError>()
             .await
             .map(|e| e.error)
             .unwrap_or_else(|_| format!("HTTP {status}"));
-        match status {
-            404 => {
-                if body.contains("upernet") {
-                    NetcidrError::CidrBlockNotFound(body)
-                } else {
-                    NetcidrError::AllocationNotFound(body)
-                }
-            }
-            409 => NetcidrError::InvalidInput(body),
-            422 => NetcidrError::InvalidInput(body),
-            _ => NetcidrError::DatabaseError(body),
-        }
+        NetcidrError::Upstream { status, message }
     }
 
     // -----------------------------------------------------------------------

--- a/src/me_api.rs
+++ b/src/me_api.rs
@@ -38,6 +38,7 @@ use tracing::{info, instrument, warn};
 
 use crate::auth::{AuthMethod, AuthenticatedPrincipal};
 use crate::error::NetcidrError;
+use crate::error_presenter::{LogLevel, present};
 use crate::ipam::models::PersonalAccessTokenSummary;
 use crate::ipam::operations::IpamOps;
 use crate::pat::PatPepper;
@@ -274,11 +275,9 @@ pub(crate) async fn revoke_token(
         // pat_revoke is idempotent on already-revoked rows by contract,
         // so a successful Ok(_) covers both first-revoke and re-revoke.
         Ok(()) => StatusCode::NO_CONTENT.into_response(),
-        // Per spec: cross-tenant or unknown id → 404, never 403. Don't
-        // leak whether the id exists in another user's bucket.
-        Err(NetcidrError::PatNotFound(_)) => {
-            error_response(StatusCode::NOT_FOUND, "token not found")
-        }
+        // PatNotFound flows through map_pat_error → presenter → 404
+        // "token not found" without echoing the id. Cross-tenant ids
+        // surface as PatNotFound by spec; never 403.
         Err(e) => {
             warn!(error = %e, "pat_revoke failed");
             map_pat_error(e)
@@ -295,22 +294,13 @@ fn owner_from_principal(principal: &AuthenticatedPrincipal) -> Option<PatOwner> 
     })
 }
 
-/// Map storage-layer errors to HTTP. Mirrors the conservative pattern in
-/// `ipam_api`: never echo raw DB messages, and treat anything we don't
-/// explicitly recognize as 500.
+/// Map storage-layer errors to HTTP via the shared error presenter.
+/// Identical classification, scrubbing, and log policy as `ipam_api`.
 fn map_pat_error(err: NetcidrError) -> Response {
-    match err {
-        NetcidrError::InvalidInput(msg) | NetcidrError::InvalidCidr(msg) => {
-            error_response(StatusCode::BAD_REQUEST, msg)
-        }
-        NetcidrError::PatNotFound(_) => error_response(StatusCode::NOT_FOUND, "token not found"),
-        NetcidrError::DatabaseError(_) => {
-            tracing::error!(error = %err, "database error in /me/tokens");
-            error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal server error")
-        }
-        _ => {
-            tracing::error!(error = %err, "unexpected error in /me/tokens");
-            error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal server error")
-        }
+    let p = present(&err);
+    if p.log_level == LogLevel::Error {
+        tracing::error!(error = %err, "error in /me/tokens");
     }
+    let status = StatusCode::from_u16(p.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    error_response(status, p.client_msg)
 }

--- a/src/token_cli.rs
+++ b/src/token_cli.rs
@@ -52,20 +52,19 @@ impl TokenClient {
         format!("{}{}", self.base_url, path)
     }
 
+    /// Map a non-success HTTP response from `netcidr serve` to an
+    /// `Upstream { status, message }`. The CLI surfaces the resulting
+    /// error via its Display impl ("upstream error (HTTP 401): …"), so
+    /// the user gets both the status class and the upstream's chosen
+    /// message without this layer doing its own classification.
     async fn map_error(resp: reqwest::Response) -> NetcidrError {
         let status = resp.status().as_u16();
-        let body = resp
+        let message = resp
             .json::<ApiError>()
             .await
             .map(|e| e.error)
             .unwrap_or_else(|_| format!("HTTP {status}"));
-        match status {
-            400 | 422 => NetcidrError::InvalidInput(body),
-            401 => NetcidrError::InvalidInput(format!("authentication failed: {body}")),
-            403 => NetcidrError::InvalidInput(format!("forbidden: {body}")),
-            404 => NetcidrError::InvalidInput(format!("not found: {body}")),
-            _ => NetcidrError::DatabaseError(body),
-        }
+        NetcidrError::Upstream { status, message }
     }
 
     async fn list(&self) -> Result<TokenListResponse> {


### PR DESCRIPTION
## Summary

`NetcidrError` was mapped to a wire format in three places (`ipam_api::error_to_parts`, `me_api::map_pat_error`, `mcp::result_to_string`) with subtly different policies. Drift had already happened: `PatNotFound` fell through to 500 in the IPAM API, so `/me/tokens` added its own mapper; the MCP path did `format!("Error: {e}")` and **leaked raw SQL backend text** (table names, file paths, constraint names) directly to MCP clients.

This PR consolidates all three behind `error_presenter::present(&NetcidrError) → PresentedError { status, client_msg, log_level }` and fixes the MCP/CLI HTTP-client adapters to preserve upstream status instead of flattening it.

Closes #167.

## What changed

- **New `src/error_presenter.rs`.** Single `present()` over an exhaustive (no catch-all) match. 10 table-driven unit tests assert every `NetcidrError` variant against `(status, message, log_level)`. Adding a new variant produces a compile error here instead of a silent 500.
- **New `NetcidrError::Upstream { status, message }`.** Carries upstream HTTP status through the MCP and `token` CLI HTTP clients.
- **Three frontends migrated.** `ipam_api`, `me_api`, and `mcp` all call `present()` and log when `log_level == Error`. `ipam_api::error_to_parts` (49 lines) and `me_api::map_pat_error` (16 lines) deleted; `result_to_string` rewritten to scrub.
- **HTTP-client adapters fixed.** `mcp_client::map_error` and `token_cli::map_error` emit `Upstream { status, message }` on every non-2xx, replacing ad-hoc `DatabaseError(body)` flattening (which the IPAM presenter would now correctly map to 500). A 409 from `netcidr serve` now reaches the MCP caller as 409, not 500.
- **Substring shim retired.** The `DatabaseError(msg) contains "overlap"/"conflict"/"not found"` → 409/404 hack in `ipam_api` is gone. Verified vestigial — overlap rejection has gone through the typed `AllocationConflict` variant since well before this change.
- **`PatNotFound` canonicalised.** Now `"token not found"` across all HTTP paths; the caller-supplied id is never echoed back.
- **`CONTEXT.md`** gets `Error Presenter` and `Presented Error` entries.

## Design decisions

- **Full presenter, not classifier-only.** Frontends are serialization-only; scrubbing and status policy live in the seam.
- **`PatNotFound` → `"token not found"`** (matching the existing `me_api` choice — short, no id echo).
- **`log_level` in `PresentedError`.** "When to log" policy lives in the presenter, not duplicated.
- **`DatabaseError` → unconditional 500.** Substring matching on driver text was fragile and is now a forcing function for proper typed errors at the source (`operations.rs` and store adapters).
- **`api.rs` (calculator) intentionally untouched.** Its 15 inline `BAD_REQUEST + e.to_string()` sites produce identical output to what the presenter would emit for validation variants. Migration is mechanical, follow-up PR.
- **Transport-level reqwest failures still wrapped in `DatabaseError`.** Variant is misnamed for HTTP transport but presents correctly as scrubbed 500. Rename is separate scope.

## Commits (each independently revertable)

1. `feat(error): add Upstream variant for HTTP-client error class`
2. `feat(error): introduce error_presenter seam`
3. `refactor: migrate IPAM API, /me/tokens, and MCP to error presenter`
4. `fix: HTTP clients emit Upstream { status, message } not DatabaseError`

## Test plan

- [x] `cargo test --all-features` — 0 failures (10 new presenter unit tests, 341 lib unit tests, 67 ipam_api integration, 7 pat_api, 7 pat_auth, 26 ipam_store_contract, all unchanged)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `just check` (incl. semgrep) — 0 findings
- [x] Verified `test_ipam_overlap_rejected` still passes via typed `AllocationConflict` path, not the deleted substring shim
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)