### PR TITLE
docs+refactor: ADR-0001 (tenancy-via-explicit-parameter) + consolidate Tenant::LOCAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **ADR-0001 (`docs/adr/0001-tenancy-via-explicit-parameter.md`).** Formalises the existing multi-tenant isolation design decision: every `IpamOps` and `IpamStore` method that touches tenant-scoped data takes `tenant_id: &str` as an explicit parameter; no task-local context. Records the rejected alternative (task-local tenancy mirroring `audit_context`) and the conditions under which to revisit. Establishes `docs/adr/` as the location for future architectural decisions.
+
+- **`Tenant::LOCAL` constant** on the existing `Tenant` newtype, naming the `"local"` tenant id used by single-tenant frontends. Replaces the duplicated `CLI_TENANT_ID` in `src/ipam_cli.rs` and `MCP_LOCAL_TENANT_ID` in `src/mcp.rs` so they can't drift.
+
 - **Error presenter seam (`src/error_presenter.rs`).** A single `present(&NetcidrError) → PresentedError { status, client_msg, log_level }` is now the only place `NetcidrError` becomes a caller-visible response. IPAM HTTP API, `/me/tokens` HTTP API, and MCP tool results all call it; classification, scrubbing, and the "log this at error" decision live in one place. Table-driven unit tests assert every variant against `(status, message, log_level)`; the match has no catch-all, so adding a new variant produces a compile error rather than a silent 500. Added `Error Presenter` and `Presented Error` to `CONTEXT.md`.
 
 - **`NetcidrError::Upstream { status, message }`** for HTTP-client adapters. Replaces the previous flattening of upstream HTTP non-2xx responses to `DatabaseError(body)`, which lost the status code and overloaded a name that should mean "the SQL backend failed."

--- a/docs/adr/0001-tenancy-via-explicit-parameter.md
+++ b/docs/adr/0001-tenancy-via-explicit-parameter.md
@@ -1,0 +1,70 @@
+# Tenancy is threaded as an explicit parameter, not a task-local
+
+**Status:** Accepted
+**Date:** 2026-05-12
+**Source:** [`docs/superpowers/specs/2026-05-02-multi-tenant-isolation-design.md`](../superpowers/specs/2026-05-02-multi-tenant-isolation-design.md)
+
+Every `IpamOps` and `IpamStore` method that touches tenant-scoped data takes
+`tenant_id: &str` as an explicit parameter. There is no task-local or other
+ambient channel for tenant identity inside `IpamOps`. HTTP handlers extract a
+`Tenant` value from request extensions (via `src/tenant.rs::Tenant` and the
+`require_auth` middleware) and pass `tenant.as_str()` at the call site; the
+CLI and local MCP backend pass `Tenant::LOCAL`.
+
+## Why
+
+The worst class of bug in this system is a silent cross-tenant data leak —
+a query that ships without `WHERE tenant_id = ?` and returns another
+tenant's rows. The type system is the strongest defense: every method
+signature requires the parameter, and any new query that doesn't filter on
+it is a code-review red flag rather than a silent failure. Task-local
+tenancy would make the bug invisible at the call site.
+
+## Considered and rejected: task-local tenant context
+
+Modeled after `src/audit_context.rs`, which is a task-local. Surface
+appeal: collapses 85+ positional `tenant_id` arguments in `operations.rs`
+and removes the duplicated `"local"` constant at frontend boundaries.
+
+Rejected because:
+
+- **Silent failure mode.** A task-local that isn't set returns
+  `Default::default()`; a missing `tenant_id` parameter is a compile error.
+  The default of `audit_context` (all `None`) is harmless because audit
+  fields are observational; the default of a `tenant_context` would be a
+  cross-tenant leak.
+- **Code review surface.** With explicit parameters, `git diff` of a new
+  query shows the tenant filter or shows its absence. With a task-local,
+  the filter is woven into store implementations and easy to forget.
+- **Ergonomics gain is small.** The 85 mentions in `operations.rs` are
+  mostly internal threading between operation helpers — not friction that
+  comes home to roost. The seam-level duplicated `"local"` constant is
+  fixed by a single `Tenant::LOCAL`, not by hiding state.
+
+## Consequences
+
+- The ~85 `tenant_id: &str` thread-throughs in `src/ipam/operations.rs` are
+  intentional. Architecture reviews that propose collapsing them into a
+  task-local should be rejected with a pointer to this ADR.
+- New frontends (gRPC, GraphQL, MCP variants) must extract or supply the
+  tenant explicitly at every call site. Use `Tenant::LOCAL` for
+  single-tenant frontends; extract per-request for multi-tenant ones.
+- Internal helper functions inside `operations.rs` that don't touch the
+  store but compose over tenant-scoped values still carry the parameter,
+  for consistency and to avoid creating a half-explicit half-implicit
+  surface.
+
+## Revisiting
+
+Revisit only if one of the following becomes true:
+
+1. A real cross-tenant leak ships *despite* the type-checked parameter
+   (e.g., a `WHERE` clause is omitted in a backend implementation), proving
+   the parameter alone isn't enough and we need to add (not replace it
+   with) further defenses.
+2. A new frontend or call shape makes explicit threading genuinely
+   awkward in a way `Tenant::LOCAL` can't address.
+3. The operations module splits into many sub-modules where the parameter
+   creates real ceremony.
+
+Marginal ergonomic improvement on its own is not a reason to revisit.

--- a/src/ipam_cli.rs
+++ b/src/ipam_cli.rs
@@ -4,13 +4,13 @@ use netcidr::ipam::config::IpamConfig;
 use netcidr::ipam::models::*;
 use netcidr::ipam::operations::IpamOps;
 use netcidr::output::{CsvOutput, OutputWriter, TextOutput};
+use netcidr::tenant::Tenant;
 use netcidr::validation;
 use serde::Serialize;
 
 use crate::print_stdout;
 
-/// CLI uses local SQLite, single-tenant by definition.
-const CLI_TENANT_ID: &str = "local";
+// CLI uses local SQLite, single-tenant by definition. Pass `Tenant::LOCAL`.
 
 fn output_result<T: Serialize + TextOutput + CsvOutput>(
     writer: &OutputWriter,
@@ -70,7 +70,7 @@ pub async fn handle_ipam_command(
             } => {
                 let sn = ops
                     .create_cidr_block(
-                        CLI_TENANT_ID,
+                        Tenant::LOCAL,
                         &CreateCidrBlock {
                             cidr,
                             name,
@@ -81,7 +81,7 @@ pub async fn handle_ipam_command(
                 output_result(writer, output_file, &sn);
             }
             CidrBlockCommands::List => {
-                let list = ops.list_cidr_blocks(CLI_TENANT_ID).await?;
+                let list = ops.list_cidr_blocks(Tenant::LOCAL).await?;
                 let result = CidrBlockList {
                     count: list.len(),
                     cidr_blocks: list,
@@ -89,11 +89,11 @@ pub async fn handle_ipam_command(
                 output_result(writer, output_file, &result);
             }
             CidrBlockCommands::Get { id } => {
-                let sn = ops.get_cidr_block(CLI_TENANT_ID, &id).await?;
+                let sn = ops.get_cidr_block(Tenant::LOCAL, &id).await?;
                 output_result(writer, output_file, &sn);
             }
             CidrBlockCommands::Delete { id } => {
-                ops.delete_cidr_block(CLI_TENANT_ID, &id).await?;
+                ops.delete_cidr_block(Tenant::LOCAL, &id).await?;
                 eprintln!("CIDR block {} deleted", id);
             }
         },
@@ -114,7 +114,7 @@ pub async fn handle_ipam_command(
             let status = parse_status(&status)?;
             let alloc = ops
                 .allocate_specific(
-                    CLI_TENANT_ID,
+                    Tenant::LOCAL,
                     &CreateAllocation {
                         cidr_block_id,
                         cidr,
@@ -151,7 +151,7 @@ pub async fn handle_ipam_command(
             let status = parse_status(&status)?;
             let allocs = ops
                 .allocate_auto(
-                    CLI_TENANT_ID,
+                    Tenant::LOCAL,
                     &AutoAllocateRequest {
                         cidr_block_id,
                         prefix_length: prefix,
@@ -178,7 +178,7 @@ pub async fn handle_ipam_command(
 
         IpamCommands::Allocation { command } => match command {
             AllocationCommands::Get { id } => {
-                let alloc = ops.get_allocation(CLI_TENANT_ID, &id).await?;
+                let alloc = ops.get_allocation(Tenant::LOCAL, &id).await?;
                 output_result(writer, output_file, &alloc);
             }
             AllocationCommands::List {
@@ -192,7 +192,7 @@ pub async fn handle_ipam_command(
                 let status = parse_status(&status)?;
                 let allocs = ops
                     .list_allocations(
-                        CLI_TENANT_ID,
+                        Tenant::LOCAL,
                         &AllocationFilter {
                             cidr_block_id,
                             status,
@@ -222,7 +222,7 @@ pub async fn handle_ipam_command(
                 let status = parse_status(&status)?;
                 let alloc = ops
                     .update_allocation(
-                        CLI_TENANT_ID,
+                        Tenant::LOCAL,
                         &id,
                         &UpdateAllocation {
                             name,
@@ -240,12 +240,12 @@ pub async fn handle_ipam_command(
         },
 
         IpamCommands::Release { id } => {
-            let alloc = ops.release_allocation(CLI_TENANT_ID, &id).await?;
+            let alloc = ops.release_allocation(Tenant::LOCAL, &id).await?;
             output_result(writer, output_file, &alloc);
         }
 
         IpamCommands::Utilization { cidr_block_id } => {
-            let report = ops.utilization(CLI_TENANT_ID, &cidr_block_id).await?;
+            let report = ops.utilization(Tenant::LOCAL, &cidr_block_id).await?;
             output_result(writer, output_file, &report);
         }
 
@@ -254,13 +254,13 @@ pub async fn handle_ipam_command(
             prefix,
         } => {
             let report = ops
-                .free_blocks(CLI_TENANT_ID, &cidr_block_id, prefix)
+                .free_blocks(Tenant::LOCAL, &cidr_block_id, prefix)
                 .await?;
             output_result(writer, output_file, &report);
         }
 
         IpamCommands::FindIp { address } => {
-            let allocs = ops.find_by_ip(CLI_TENANT_ID, &address).await?;
+            let allocs = ops.find_by_ip(Tenant::LOCAL, &address).await?;
             let result = AllocationList {
                 count: allocs.len(),
                 allocations: allocs,
@@ -269,7 +269,7 @@ pub async fn handle_ipam_command(
         }
 
         IpamCommands::FindResource { resource_id } => {
-            let allocs = ops.find_by_resource(CLI_TENANT_ID, &resource_id).await?;
+            let allocs = ops.find_by_resource(Tenant::LOCAL, &resource_id).await?;
             let result = AllocationList {
                 count: allocs.len(),
                 allocations: allocs,
@@ -285,7 +285,7 @@ pub async fn handle_ipam_command(
         } => {
             let entries = ops
                 .query_audit(
-                    CLI_TENANT_ID,
+                    Tenant::LOCAL,
                     &AuditFilter {
                         entity_type,
                         entity_id,
@@ -302,7 +302,7 @@ pub async fn handle_ipam_command(
         }
 
         IpamCommands::Dump => {
-            let dump = ops.dump(CLI_TENANT_ID).await?;
+            let dump = ops.dump(Tenant::LOCAL).await?;
             let json = serde_json::to_string_pretty(&dump).expect("Failed to serialize dump");
             if output_file.is_none() {
                 print_stdout(&json);
@@ -335,7 +335,7 @@ pub async fn handle_ipam_command(
                     netcidr::error::NetcidrError::InvalidInput(format!("invalid JSON: {}", e))
                 })?;
 
-            let (sn_count, alloc_count) = ops.load(CLI_TENANT_ID, &dump).await?;
+            let (sn_count, alloc_count) = ops.load(Tenant::LOCAL, &dump).await?;
             eprintln!(
                 "Imported {} CIDR blocks and {} allocations",
                 sn_count, alloc_count
@@ -344,7 +344,7 @@ pub async fn handle_ipam_command(
 
         IpamCommands::Tags { command } => match command {
             TagCommands::Get { allocation_id } => {
-                let alloc = ops.get_allocation(CLI_TENANT_ID, &allocation_id).await?;
+                let alloc = ops.get_allocation(Tenant::LOCAL, &allocation_id).await?;
                 output_result(writer, output_file, &alloc);
             }
             TagCommands::Set {
@@ -352,9 +352,9 @@ pub async fn handle_ipam_command(
                 tags,
             } => {
                 let parsed_tags = parse_tags(&tags)?;
-                ops.set_tags(CLI_TENANT_ID, &allocation_id, &parsed_tags)
+                ops.set_tags(Tenant::LOCAL, &allocation_id, &parsed_tags)
                     .await?;
-                let alloc = ops.get_allocation(CLI_TENANT_ID, &allocation_id).await?;
+                let alloc = ops.get_allocation(Tenant::LOCAL, &allocation_id).await?;
                 output_result(writer, output_file, &alloc);
             }
         },

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -15,15 +15,14 @@ use crate::ipv6::Ipv6Subnet;
 use crate::mcp_client::HttpIpamClient;
 use crate::subnet_generator::{count_subnets, generate_ipv4_subnets, generate_ipv6_subnets};
 use crate::summarize::{summarize_ipv4, summarize_ipv6};
+use crate::tenant::Tenant;
 
 // ---------------------------------------------------------------------------
 // IPAM backend abstraction — local IpamOps or remote HTTP client
 // ---------------------------------------------------------------------------
 
-/// Local MCP backend uses local SQLite, single-tenant by definition.
-/// The remote backend goes through HTTP and authenticates via OIDC, so it
-/// does not need a tenant_id literal here — the API server enforces tenancy.
-const MCP_LOCAL_TENANT_ID: &str = "local";
+// Local backend passes `Tenant::LOCAL`. The remote backend authenticates via
+// OIDC, so the API server derives the tenant from the principal there.
 
 #[derive(Debug, Clone)]
 pub enum McpIpamBackend {
@@ -37,14 +36,14 @@ impl McpIpamBackend {
         input: &CreateCidrBlock,
     ) -> crate::error::Result<CidrBlock> {
         match self {
-            Self::Local(ops) => ops.create_cidr_block(MCP_LOCAL_TENANT_ID, input).await,
+            Self::Local(ops) => ops.create_cidr_block(Tenant::LOCAL, input).await,
             Self::Remote(client) => client.create_cidr_block(input).await,
         }
     }
 
     pub async fn list_cidr_blocks(&self) -> crate::error::Result<Vec<CidrBlock>> {
         match self {
-            Self::Local(ops) => ops.list_cidr_blocks(MCP_LOCAL_TENANT_ID).await,
+            Self::Local(ops) => ops.list_cidr_blocks(Tenant::LOCAL).await,
             Self::Remote(client) => client.list_cidr_blocks().await,
         }
     }
@@ -54,7 +53,7 @@ impl McpIpamBackend {
         request: &AutoAllocateRequest,
     ) -> crate::error::Result<Vec<Allocation>> {
         match self {
-            Self::Local(ops) => ops.allocate_auto(MCP_LOCAL_TENANT_ID, request).await,
+            Self::Local(ops) => ops.allocate_auto(Tenant::LOCAL, request).await,
             Self::Remote(client) => client.allocate_auto(request).await,
         }
     }
@@ -64,14 +63,14 @@ impl McpIpamBackend {
         input: &CreateAllocation,
     ) -> crate::error::Result<Allocation> {
         match self {
-            Self::Local(ops) => ops.allocate_specific(MCP_LOCAL_TENANT_ID, input).await,
+            Self::Local(ops) => ops.allocate_specific(Tenant::LOCAL, input).await,
             Self::Remote(client) => client.allocate_specific(input).await,
         }
     }
 
     pub async fn release_allocation(&self, id: &str) -> crate::error::Result<Allocation> {
         match self {
-            Self::Local(ops) => ops.release_allocation(MCP_LOCAL_TENANT_ID, id).await,
+            Self::Local(ops) => ops.release_allocation(Tenant::LOCAL, id).await,
             Self::Remote(client) => client.release_allocation(id).await,
         }
     }
@@ -81,7 +80,7 @@ impl McpIpamBackend {
         filter: &AllocationFilter,
     ) -> crate::error::Result<Vec<Allocation>> {
         match self {
-            Self::Local(ops) => ops.list_allocations(MCP_LOCAL_TENANT_ID, filter).await,
+            Self::Local(ops) => ops.list_allocations(Tenant::LOCAL, filter).await,
             Self::Remote(client) => client.list_allocations(filter).await,
         }
     }
@@ -92,10 +91,7 @@ impl McpIpamBackend {
         prefix: Option<u8>,
     ) -> crate::error::Result<FreeBlocksReport> {
         match self {
-            Self::Local(ops) => {
-                ops.free_blocks(MCP_LOCAL_TENANT_ID, cidr_block_id, prefix)
-                    .await
-            }
+            Self::Local(ops) => ops.free_blocks(Tenant::LOCAL, cidr_block_id, prefix).await,
             Self::Remote(client) => client.free_blocks(cidr_block_id, prefix).await,
         }
     }
@@ -105,14 +101,14 @@ impl McpIpamBackend {
         cidr_block_id: &str,
     ) -> crate::error::Result<UtilizationReport> {
         match self {
-            Self::Local(ops) => ops.utilization(MCP_LOCAL_TENANT_ID, cidr_block_id).await,
+            Self::Local(ops) => ops.utilization(Tenant::LOCAL, cidr_block_id).await,
             Self::Remote(client) => client.utilization(cidr_block_id).await,
         }
     }
 
     pub async fn find_by_ip(&self, address: &str) -> crate::error::Result<Vec<Allocation>> {
         match self {
-            Self::Local(ops) => ops.find_by_ip(MCP_LOCAL_TENANT_ID, address).await,
+            Self::Local(ops) => ops.find_by_ip(Tenant::LOCAL, address).await,
             Self::Remote(client) => client.find_by_ip(address).await,
         }
     }
@@ -122,7 +118,7 @@ impl McpIpamBackend {
         resource_id: &str,
     ) -> crate::error::Result<Vec<Allocation>> {
         match self {
-            Self::Local(ops) => ops.find_by_resource(MCP_LOCAL_TENANT_ID, resource_id).await,
+            Self::Local(ops) => ops.find_by_resource(Tenant::LOCAL, resource_id).await,
             Self::Remote(client) => client.find_by_resource(resource_id).await,
         }
     }
@@ -132,7 +128,7 @@ impl McpIpamBackend {
         items: &[BatchAllocateItem],
     ) -> crate::error::Result<BatchAllocateResult> {
         match self {
-            Self::Local(ops) => ops.batch_allocate(MCP_LOCAL_TENANT_ID, items).await,
+            Self::Local(ops) => ops.batch_allocate(Tenant::LOCAL, items).await,
             Self::Remote(client) => client.batch_allocate(items).await,
         }
     }
@@ -142,7 +138,7 @@ impl McpIpamBackend {
         request: &BatchReleaseRequest,
     ) -> crate::error::Result<BatchReleaseResult> {
         match self {
-            Self::Local(ops) => ops.batch_release(MCP_LOCAL_TENANT_ID, request).await,
+            Self::Local(ops) => ops.batch_release(Tenant::LOCAL, request).await,
             Self::Remote(client) => client.batch_release(request).await,
         }
     }
@@ -152,10 +148,7 @@ impl McpIpamBackend {
         cidr_block_id: Option<&str>,
     ) -> crate::error::Result<AllocationSummary> {
         match self {
-            Self::Local(ops) => {
-                ops.allocation_summary(MCP_LOCAL_TENANT_ID, cidr_block_id)
-                    .await
-            }
+            Self::Local(ops) => ops.allocation_summary(Tenant::LOCAL, cidr_block_id).await,
             Self::Remote(client) => client.allocation_summary(cidr_block_id).await,
         }
     }

--- a/src/tenant.rs
+++ b/src/tenant.rs
@@ -14,6 +14,12 @@ use axum::{
 pub struct Tenant(pub String);
 
 impl Tenant {
+    /// The tenant id used by single-tenant frontends — the CLI and the
+    /// local MCP backend. Multi-tenant frontends (HTTP API, remote MCP)
+    /// derive their tenant from the authenticated principal instead.
+    /// See ADR-0001.
+    pub const LOCAL: &str = "local";
+
     pub fn as_str(&self) -> &str {
         &self.0
     }


### PR DESCRIPTION
## Summary

- Adds `docs/adr/0001-tenancy-via-explicit-parameter.md` formalizing the multi-tenant isolation spec's decision to thread `tenant_id: &str` explicitly through `IpamOps` / `IpamStore` instead of using a task-local context. The spec is buried under `docs/superpowers/specs/`; future architecture reviews wouldn't naturally see it and would re-propose the task-local refactor. The ADR lives at the canonical location with the rejected alternative and revisit criteria written down.
- Consolidates two private constants (`CLI_TENANT_ID` in `ipam_cli.rs`, `MCP_LOCAL_TENANT_ID` in `mcp.rs`) onto `Tenant::LOCAL` on the existing `Tenant` newtype. Same value, single source of truth, can't drift.

Closes #169.

## Why this is paired with the ADR

The duplicated `"local"` constant was the only real friction surfaced by the candidate-2 review of the explicit-threading design. It's a 30-line cleanup and the ADR's job is to explain why the *85 other tenant_id threadings* are deliberate, not friction. Doing both in one PR captures the decision and the small thing it enables.

## Test plan

- [x] `cargo test --all-features` — all suites green (10 presenter unit tests, 341 lib unit tests, 67 ipam_api integration, 7 pat_api, 7 pat_auth, etc.)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean (rustfmt re-collapsed two `match` arms whose long-line trigger was the longer `MCP_LOCAL_TENANT_ID` identifier — expected)
- [x] `just check` (incl. semgrep) — 0 findings
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)