### PR TITLE
refactor(pat): deepen PatLifecycle to own principal-to-owner translation + tidy-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`PatLifecycle` now owns the principal-to-owner translation it was already documented as owning.** New `mint_for_principal` / `list_for_principal` / `revoke_for_principal` methods take `&AuthenticatedPrincipal` directly; failure modes are reported via a new `MintForPrincipalError` enum that distinguishes "no verified email" (403, defense-in-depth) from downstream lifecycle errors. The `*_for_owner` methods remain public for tests and lower-level callers.
+- **`me_api` handlers no longer re-implement principal extraction.** The 15-line `match owner_from_principal(&principal)` boilerplate in each of `create_token`, `list_tokens`, `revoke_token` is gone; handlers are now ~10 lines each.
+- **`PatLifecycle` is injected via Axum `Extension`** instead of being constructed per-request in three handlers. Matches the existing `IpamOps` wiring pattern.
+- **Removed the duplicate `PatLifecycle::verify_bearer_token` method.** It delegated to the standalone `pat_lifecycle::verify_bearer_token` function used by `auth.rs::verify_pat`. Tests now call the free function directly.
+
 ### Added
 
 - **ADR-0001 (`docs/adr/0001-tenancy-via-explicit-parameter.md`).** Formalises the existing multi-tenant isolation design decision: every `IpamOps` and `IpamStore` method that touches tenant-scoped data takes `tenant_id: &str` as an explicit parameter; no task-local context. Records the rejected alternative (task-local tenancy mirroring `audit_context`) and the conditions under which to revisit. Establishes `docs/adr/` as the location for future architectural decisions.

--- a/src/api.rs
+++ b/src/api.rs
@@ -441,9 +441,12 @@ pub fn create_router(config: RouterConfig) -> Router {
         // OIDC, PAT, and bearer.
         if let Some(pepper) = config.pat_pepper.as_ref() {
             let me_auth = auth_config.clone();
+            let lifecycle = Arc::new(crate::pat_lifecycle::PatLifecycle::new(
+                ops.store_arc(),
+                Arc::clone(pepper),
+            ));
             let me_router = crate::me_api::create_me_router()
-                .layer(Extension(Arc::clone(&ops)))
-                .layer(Extension(Arc::clone(pepper)))
+                .layer(Extension(lifecycle))
                 .layer(middleware::from_fn(move |request, next| {
                     let auth_config = me_auth.clone();
                     async move { require_auth(auth_config, request, next).await }

--- a/src/me_api.rs
+++ b/src/me_api.rs
@@ -40,7 +40,7 @@ use crate::auth::{AuthMethod, AuthenticatedPrincipal};
 use crate::error::NetcidrError;
 use crate::error_presenter::{LogLevel, present};
 use crate::ipam::models::PersonalAccessTokenSummary;
-use crate::pat_lifecycle::{CreatePatRequest, PatLifecycle, PatOwner};
+use crate::pat_lifecycle::{CreatePatRequest, MintForPrincipalError, PatLifecycle};
 
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "swagger", derive(utoipa::ToSchema))]
@@ -50,6 +50,15 @@ pub struct CreateTokenRequest {
     /// Number of days from now until the token expires. `None` defaults
     /// to the lifecycle default; values outside `1..=365` are 400.
     pub expires_in_days: Option<u32>,
+}
+
+impl From<CreateTokenRequest> for CreatePatRequest {
+    fn from(r: CreateTokenRequest) -> Self {
+        Self {
+            name: r.name,
+            expires_in_days: r.expires_in_days,
+        }
+    }
 }
 
 /// One-time response to a successful mint. The `token` field is the
@@ -149,34 +158,9 @@ pub(crate) async fn create_token(
     Extension(principal): Extension<AuthenticatedPrincipal>,
     Json(body): Json<CreateTokenRequest>,
 ) -> Response {
-    // 1. Pull required identity fields off the principal. OIDC requires
-    //    a verified email; the require_auth layer already enforces this
-    //    for OIDC mode, but defend in depth.
-    let owner = match owner_from_principal(&principal) {
-        Some(owner) => owner,
-        None => {
-            return error_response(
-                StatusCode::FORBIDDEN,
-                "OIDC principal has no verified email; cannot mint tokens",
-            );
-        }
-    };
-
-    let minted = match lifecycle
-        .mint_for_owner(
-            &owner,
-            CreatePatRequest {
-                name: body.name,
-                expires_in_days: body.expires_in_days,
-            },
-        )
-        .await
-    {
+    let minted = match lifecycle.mint_for_principal(&principal, body.into()).await {
         Ok(minted) => minted,
-        Err(e) => {
-            warn!(error = %e, "PAT mint failed");
-            return map_pat_error(e);
-        }
+        Err(e) => return map_principal_error(e, "mint token"),
     };
 
     info!(pat_id = %minted.summary.id, "PAT minted");
@@ -208,27 +192,14 @@ pub(crate) async fn list_tokens(
     Extension(lifecycle): Extension<Arc<PatLifecycle>>,
     Extension(principal): Extension<AuthenticatedPrincipal>,
 ) -> Response {
-    let owner = match owner_from_principal(&principal) {
-        Some(owner) => owner,
-        None => {
-            return error_response(
-                StatusCode::FORBIDDEN,
-                "OIDC principal has no verified email",
-            );
-        }
-    };
-
-    match lifecycle.list_for_owner(&owner).await {
+    match lifecycle.list_for_principal(&principal).await {
         Ok(tokens) => {
             // Soft-delete contract: revoked rows stay visible to their
             // owner with `revoked_at` set. Don't filter them out here.
             let count = tokens.len();
             Json(TokenListResponse { tokens, count }).into_response()
         }
-        Err(e) => {
-            warn!(error = %e, "pat_list_for_owner failed");
-            map_pat_error(e)
-        }
+        Err(e) => map_principal_error(e, "list tokens"),
     }
 }
 
@@ -253,37 +224,32 @@ pub(crate) async fn revoke_token(
     Extension(principal): Extension<AuthenticatedPrincipal>,
     Path(id): Path<String>,
 ) -> Response {
-    let owner = match owner_from_principal(&principal) {
-        Some(owner) => owner,
-        None => {
-            return error_response(
-                StatusCode::FORBIDDEN,
-                "OIDC principal has no verified email",
-            );
-        }
-    };
-
-    match lifecycle.revoke_for_owner(&owner, &id).await {
-        // pat_revoke is idempotent on already-revoked rows by contract,
-        // so a successful Ok(_) covers both first-revoke and re-revoke.
+    // pat_revoke is idempotent on already-revoked rows by contract,
+    // so a successful Ok(_) covers both first-revoke and re-revoke.
+    // PatNotFound (including cross-tenant ids by spec) flows through
+    // map_pat_error → presenter → 404 "token not found" without
+    // echoing the id; never 403.
+    match lifecycle.revoke_for_principal(&principal, &id).await {
         Ok(()) => StatusCode::NO_CONTENT.into_response(),
-        // PatNotFound flows through map_pat_error → presenter → 404
-        // "token not found" without echoing the id. Cross-tenant ids
-        // surface as PatNotFound by spec; never 403.
-        Err(e) => {
-            warn!(error = %e, "pat_revoke failed");
-            map_pat_error(e)
-        }
+        Err(e) => map_principal_error(e, "revoke token"),
     }
 }
 
-fn owner_from_principal(principal: &AuthenticatedPrincipal) -> Option<PatOwner> {
-    let email = principal.email.clone()?;
-    Some(PatOwner {
-        tenant_id: email.clone(),
-        subject: principal.subject.clone(),
-        email,
-    })
+/// Map a `MintForPrincipalError` to an HTTP response. NoVerifiedEmail
+/// surfaces as 403 (the auth layer should have caught it, but the
+/// lifecycle defends in depth). Lifecycle errors go through the shared
+/// presenter and inherit its scrubbing.
+fn map_principal_error(err: MintForPrincipalError, action: &str) -> Response {
+    match err {
+        MintForPrincipalError::NoVerifiedEmail => error_response(
+            StatusCode::FORBIDDEN,
+            format!("OIDC principal has no verified email; cannot {action}"),
+        ),
+        MintForPrincipalError::Lifecycle(e) => {
+            warn!(error = %e, action = %action, "pat operation failed");
+            map_pat_error(e)
+        }
+    }
 }
 
 /// Map storage-layer errors to HTTP via the shared error presenter.

--- a/src/me_api.rs
+++ b/src/me_api.rs
@@ -40,8 +40,6 @@ use crate::auth::{AuthMethod, AuthenticatedPrincipal};
 use crate::error::NetcidrError;
 use crate::error_presenter::{LogLevel, present};
 use crate::ipam::models::PersonalAccessTokenSummary;
-use crate::ipam::operations::IpamOps;
-use crate::pat::PatPepper;
 use crate::pat_lifecycle::{CreatePatRequest, PatLifecycle, PatOwner};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -147,8 +145,7 @@ pub fn create_me_router() -> Router {
 ))]
 #[instrument(skip_all, fields(owner_email = %principal.email.as_deref().unwrap_or("<none>")))]
 pub(crate) async fn create_token(
-    Extension(ops): Extension<Arc<IpamOps>>,
-    Extension(pepper): Extension<Arc<PatPepper>>,
+    Extension(lifecycle): Extension<Arc<PatLifecycle>>,
     Extension(principal): Extension<AuthenticatedPrincipal>,
     Json(body): Json<CreateTokenRequest>,
 ) -> Response {
@@ -165,7 +162,6 @@ pub(crate) async fn create_token(
         }
     };
 
-    let lifecycle = PatLifecycle::new(ops.store_arc(), pepper);
     let minted = match lifecycle
         .mint_for_owner(
             &owner,
@@ -209,8 +205,7 @@ pub(crate) async fn create_token(
 ))]
 #[instrument(skip_all, fields(owner_email = %principal.email.as_deref().unwrap_or("<none>")))]
 pub(crate) async fn list_tokens(
-    Extension(ops): Extension<Arc<IpamOps>>,
-    Extension(pepper): Extension<Arc<PatPepper>>,
+    Extension(lifecycle): Extension<Arc<PatLifecycle>>,
     Extension(principal): Extension<AuthenticatedPrincipal>,
 ) -> Response {
     let owner = match owner_from_principal(&principal) {
@@ -223,7 +218,6 @@ pub(crate) async fn list_tokens(
         }
     };
 
-    let lifecycle = PatLifecycle::new(ops.store_arc(), pepper);
     match lifecycle.list_for_owner(&owner).await {
         Ok(tokens) => {
             // Soft-delete contract: revoked rows stay visible to their
@@ -255,8 +249,7 @@ pub(crate) async fn list_tokens(
 ))]
 #[instrument(skip_all, fields(pat_id = %id, owner_email = %principal.email.as_deref().unwrap_or("<none>")))]
 pub(crate) async fn revoke_token(
-    Extension(ops): Extension<Arc<IpamOps>>,
-    Extension(pepper): Extension<Arc<PatPepper>>,
+    Extension(lifecycle): Extension<Arc<PatLifecycle>>,
     Extension(principal): Extension<AuthenticatedPrincipal>,
     Path(id): Path<String>,
 ) -> Response {
@@ -270,7 +263,6 @@ pub(crate) async fn revoke_token(
         }
     };
 
-    let lifecycle = PatLifecycle::new(ops.store_arc(), pepper);
     match lifecycle.revoke_for_owner(&owner, &id).await {
         // pat_revoke is idempotent on already-revoked rows by contract,
         // so a successful Ok(_) covers both first-revoke and re-revoke.

--- a/src/pat_lifecycle.rs
+++ b/src/pat_lifecycle.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 use tracing::warn;
 
+use crate::auth::AuthenticatedPrincipal;
 use crate::error::{NetcidrError, Result};
 use crate::ipam::models::{CreatePersonalAccessToken, PersonalAccessTokenSummary};
 use crate::ipam::store::IpamStore;
@@ -108,6 +109,71 @@ impl PatLifecycle {
             .await
             .map(|_| ())
     }
+
+    /// Mint a PAT for the identity carried by `principal`. The lifecycle
+    /// owns the principal-to-owner translation so HTTP handlers don't
+    /// reimplement it. Returns `NoVerifiedEmail` if the principal is
+    /// missing the email that becomes the tenant/owner key.
+    pub async fn mint_for_principal(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        request: CreatePatRequest,
+    ) -> std::result::Result<MintedPat, MintForPrincipalError> {
+        let owner =
+            owner_from_principal(principal).ok_or(MintForPrincipalError::NoVerifiedEmail)?;
+        self.mint_for_owner(&owner, request)
+            .await
+            .map_err(MintForPrincipalError::Lifecycle)
+    }
+
+    /// List the PATs owned by the identity carried by `principal`.
+    pub async fn list_for_principal(
+        &self,
+        principal: &AuthenticatedPrincipal,
+    ) -> std::result::Result<Vec<PersonalAccessTokenSummary>, MintForPrincipalError> {
+        let owner =
+            owner_from_principal(principal).ok_or(MintForPrincipalError::NoVerifiedEmail)?;
+        self.list_for_owner(&owner)
+            .await
+            .map_err(MintForPrincipalError::Lifecycle)
+    }
+
+    /// Revoke a PAT belonging to the identity carried by `principal`.
+    pub async fn revoke_for_principal(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: &str,
+    ) -> std::result::Result<(), MintForPrincipalError> {
+        let owner =
+            owner_from_principal(principal).ok_or(MintForPrincipalError::NoVerifiedEmail)?;
+        self.revoke_for_owner(&owner, id)
+            .await
+            .map_err(MintForPrincipalError::Lifecycle)
+    }
+}
+
+/// Failure modes for the `*_for_principal` family. Separates "the
+/// principal can't be mapped to a PAT owner" (a 403 the auth layer
+/// should have caught — surfaced explicitly for defense in depth)
+/// from downstream lifecycle errors that pass through unchanged.
+#[derive(Debug)]
+pub enum MintForPrincipalError {
+    NoVerifiedEmail,
+    Lifecycle(NetcidrError),
+}
+
+/// Translate an authenticated OIDC principal into the `PatOwner` that
+/// keys storage. Today `tenant_id == email`; both fields are denormalised
+/// for lookup ergonomics. Returns `None` if the principal lacks the
+/// verified email — `require_auth` enforces this for OIDC mode, but the
+/// lifecycle defends in depth.
+fn owner_from_principal(principal: &AuthenticatedPrincipal) -> Option<PatOwner> {
+    let email = principal.email.clone()?;
+    Some(PatOwner {
+        tenant_id: email.clone(),
+        subject: principal.subject.clone(),
+        email,
+    })
 }
 
 pub async fn verify_bearer_token(

--- a/src/pat_lifecycle.rs
+++ b/src/pat_lifecycle.rs
@@ -108,14 +108,6 @@ impl PatLifecycle {
             .await
             .map(|_| ())
     }
-
-    pub async fn verify_bearer_token(
-        &self,
-        token: &str,
-        allowed_emails: &[String],
-    ) -> std::result::Result<VerifiedPat, VerifyPatError> {
-        verify_bearer_token(&self.store, self.pepper.as_ref(), allowed_emails, token).await
-    }
 }
 
 pub async fn verify_bearer_token(

--- a/tests/pat_lifecycle_tests.rs
+++ b/tests/pat_lifecycle_tests.rs
@@ -3,18 +3,22 @@ use std::sync::Arc;
 use netcidr::ipam::sqlite::SqliteStore;
 use netcidr::ipam::store::IpamStore;
 use netcidr::pat::PatPepper;
-use netcidr::pat_lifecycle::{CreatePatRequest, PatLifecycle, PatOwner, VerifyPatError};
+use netcidr::pat_lifecycle::{self, CreatePatRequest, PatLifecycle, PatOwner, VerifyPatError};
 
 const OWNER_EMAIL: &str = "owner@example.com";
 const OWNER_SUB: &str = "oidc-sub-123";
 
-async fn lifecycle() -> (PatLifecycle, Arc<PatPepper>) {
+async fn lifecycle() -> (PatLifecycle, Arc<dyn IpamStore>, Arc<PatPepper>) {
     let store = SqliteStore::in_memory().unwrap();
     store.initialize().await.unwrap();
     store.migrate().await.unwrap();
     let store: Arc<dyn IpamStore> = Arc::new(store);
     let pepper = Arc::new(PatPepper::from_bytes(&[0xA5u8; 32]).unwrap());
-    (PatLifecycle::new(store, Arc::clone(&pepper)), pepper)
+    (
+        PatLifecycle::new(Arc::clone(&store), Arc::clone(&pepper)),
+        store,
+        pepper,
+    )
 }
 
 fn owner() -> PatOwner {
@@ -27,7 +31,7 @@ fn owner() -> PatOwner {
 
 #[tokio::test]
 async fn lifecycle_mints_lists_and_verifies_for_owner() {
-    let (lifecycle, _pepper) = lifecycle().await;
+    let (lifecycle, store, pepper) = lifecycle().await;
 
     let minted = lifecycle
         .mint_for_owner(
@@ -47,8 +51,7 @@ async fn lifecycle_mints_lists_and_verifies_for_owner() {
     let listed = lifecycle.list_for_owner(&owner()).await.unwrap();
     assert_eq!(listed, vec![minted.summary.clone()]);
 
-    let verified = lifecycle
-        .verify_bearer_token(&minted.plaintext, &[])
+    let verified = pat_lifecycle::verify_bearer_token(&store, &pepper, &[], &minted.plaintext)
         .await
         .unwrap();
     assert_eq!(verified.pat_id, minted.summary.id);
@@ -59,7 +62,7 @@ async fn lifecycle_mints_lists_and_verifies_for_owner() {
 
 #[tokio::test]
 async fn lifecycle_rejects_invalid_create_policy_before_storage() {
-    let (lifecycle, _pepper) = lifecycle().await;
+    let (lifecycle, _store, _pepper) = lifecycle().await;
 
     assert!(
         lifecycle
@@ -101,7 +104,7 @@ async fn lifecycle_rejects_invalid_create_policy_before_storage() {
 
 #[tokio::test]
 async fn lifecycle_verify_collapses_shape_miss_and_allowlist_failures() {
-    let (lifecycle, _pepper) = lifecycle().await;
+    let (lifecycle, store, pepper) = lifecycle().await;
     let minted = lifecycle
         .mint_for_owner(
             &owner(),
@@ -114,17 +117,20 @@ async fn lifecycle_verify_collapses_shape_miss_and_allowlist_failures() {
         .unwrap();
 
     assert_eq!(
-        lifecycle
-            .verify_bearer_token("ncdr_pat_too_short", &[])
+        pat_lifecycle::verify_bearer_token(&store, &pepper, &[], "ncdr_pat_too_short")
             .await
             .unwrap_err(),
         VerifyPatError::Unauthorized
     );
     assert_eq!(
-        lifecycle
-            .verify_bearer_token(&minted.plaintext, &["someone@example.com".to_string()])
-            .await
-            .unwrap_err(),
+        pat_lifecycle::verify_bearer_token(
+            &store,
+            &pepper,
+            &["someone@example.com".to_string()],
+            &minted.plaintext,
+        )
+        .await
+        .unwrap_err(),
         VerifyPatError::Unauthorized
     );
 }


### PR DESCRIPTION
## Summary

CONTEXT.md says PatLifecycle "owns owner identity, create validation, expiry calculation, active-token verification, allowlist re-checks, one-time plaintext return, and `last_used_at` updates." In practice "owner identity" was split: the lifecycle took `&PatOwner` as input; `me_api.rs::owner_from_principal` did the `AuthenticatedPrincipal → PatOwner` translation in 3 handler sites with identical 15-line boilerplate.

This PR brings the code in line with the doc, plus two tidy-ups exposed by working in the same area.

Closes #171.

## What changed

**Commit 1 — Extension injection + verify duplicate collapsed (`54d462d`):**
- `Arc<PatLifecycle>` is built once at app boot and layered onto the `/me/tokens` router. The 3 me_api handlers stop constructing fresh `PatLifecycle::new(ops.store_arc(), pepper)` per request and drop the `IpamOps` + `PatPepper` extractors entirely.
- Deleted the unused `PatLifecycle::verify_bearer_token` method (it delegated to the free function). Tests now call `pat_lifecycle::verify_bearer_token(&store, &pepper, ...)` directly with the dependencies they already had in scope.

**Commit 2 — principal-to-owner moves behind the lifecycle (`d448ca5`):**
- New `mint_for_principal` / `list_for_principal` / `revoke_for_principal` methods take `&AuthenticatedPrincipal` and do the email-extraction internally.
- New `MintForPrincipalError` enum cleanly separates "principal lacks verified email" (403, defense-in-depth — auth layer should have caught it) from downstream lifecycle errors (`Lifecycle(NetcidrError)`, passed through to the shared presenter).
- `owner_from_principal` is gone from me_api.rs — it's now a private function in pat_lifecycle.rs, where it belongs.
- Added `From<CreateTokenRequest> for CreatePatRequest` so handlers don't re-spell the request struct.

## Coupling note

`pat_lifecycle` now depends on `auth::AuthenticatedPrincipal`. The reverse coupling (`as_pat_owner()` method on `AuthenticatedPrincipal`) was considered and rejected in the grilling round — putting PAT-specific methods on the generic auth type would smear the lifecycle's responsibility outward. The lifecycle already depends on store/pepper/validation/ipam::models; one more domain type is not structural.

## Test plan

- [x] All 545 tests pass: 341 lib unit, 67 ipam_api integration, 7 pat_api, 7 pat_auth, 3 pat_lifecycle, 26 ipam_store_contract, etc.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `just check` (incl. semgrep) — 0 findings
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)