### PR TITLE
refactor(ipam_api): collapse HTTP body → domain-model field shuffles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`ipam_api`: HTTP body → domain-model field shuffles collapsed.** `AllocateSpecificRequest` and `AutoAllocateBody` each gain an `into_*` method that combines the body with the path-supplied `cidr_block_id`. The handlers' two 12-line field-by-field copies become one-liners; the knowledge of how to translate an HTTP body into a domain input now sits next to the body struct.
+
 - **`PatLifecycle` now owns the principal-to-owner translation it was already documented as owning.** New `mint_for_principal` / `list_for_principal` / `revoke_for_principal` methods take `&AuthenticatedPrincipal` directly; failure modes are reported via a new `MintForPrincipalError` enum that distinguishes "no verified email" (403, defense-in-depth) from downstream lifecycle errors. The `*_for_owner` methods remain public for tests and lower-level callers.
 - **`me_api` handlers no longer re-implement principal extraction.** The 15-line `match owner_from_principal(&principal)` boilerplate in each of `create_token`, `list_tokens`, `revoke_token` is gone; handlers are now ~10 lines each.
 - **`PatLifecycle` is injected via Axum `Extension`** instead of being constructed per-request in three handlers. Matches the existing `IpamOps` wiring pattern.

--- a/src/ipam_api.rs
+++ b/src/ipam_api.rs
@@ -170,6 +170,27 @@ pub struct AllocateSpecificRequest {
     pub ttl_seconds: Option<u64>,
 }
 
+impl AllocateSpecificRequest {
+    /// Combine the body with the path-supplied cidr_block_id. The id can
+    /// only come from the path so the body can't override it.
+    pub fn into_create_allocation(self, cidr_block_id: String) -> CreateAllocation {
+        CreateAllocation {
+            cidr_block_id,
+            cidr: self.cidr,
+            status: self.status,
+            resource_id: self.resource_id,
+            resource_type: self.resource_type,
+            name: self.name,
+            description: self.description,
+            environment: self.environment,
+            owner: self.owner,
+            parent_allocation_id: self.parent_allocation_id,
+            tags: self.tags,
+            ttl_seconds: self.ttl_seconds,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "swagger", derive(ToSchema))]
 pub struct AutoAllocateBody {
@@ -197,6 +218,28 @@ pub struct AutoAllocateBody {
     pub tags: Option<Vec<Tag>>,
     /// TTL in seconds (reservation expires after this duration)
     pub ttl_seconds: Option<u64>,
+}
+
+impl AutoAllocateBody {
+    /// Combine the body with the path-supplied cidr_block_id. The id can
+    /// only come from the path so the body can't override it.
+    pub fn into_auto_allocate_request(self, cidr_block_id: String) -> AutoAllocateRequest {
+        AutoAllocateRequest {
+            cidr_block_id,
+            prefix_length: self.prefix_length,
+            count: self.count,
+            status: self.status,
+            resource_id: self.resource_id,
+            resource_type: self.resource_type,
+            name: self.name,
+            description: self.description,
+            environment: self.environment,
+            owner: self.owner,
+            parent_allocation_id: self.parent_allocation_id,
+            tags: self.tags,
+            ttl_seconds: self.ttl_seconds,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -421,20 +464,7 @@ async fn ipam_allocate_specific(
         move |ops, tenant_id, parsed: AllocateSpecificRequest| {
             let cidr_block_id = cidr_block_id.clone();
             async move {
-                let input = CreateAllocation {
-                    cidr_block_id,
-                    cidr: parsed.cidr,
-                    status: parsed.status,
-                    resource_id: parsed.resource_id,
-                    resource_type: parsed.resource_type,
-                    name: parsed.name,
-                    description: parsed.description,
-                    environment: parsed.environment,
-                    owner: parsed.owner,
-                    parent_allocation_id: parsed.parent_allocation_id,
-                    tags: parsed.tags,
-                    ttl_seconds: parsed.ttl_seconds,
-                };
+                let input = parsed.into_create_allocation(cidr_block_id);
                 let allocation = ops.allocate_specific(&tenant_id, &input).await?;
                 Ok((
                     StatusCode::CREATED,
@@ -478,21 +508,7 @@ async fn ipam_auto_allocate(
         move |ops, tenant_id, parsed: AutoAllocateBody| {
             let cidr_block_id = cidr_block_id.clone();
             async move {
-                let request = AutoAllocateRequest {
-                    cidr_block_id,
-                    prefix_length: parsed.prefix_length,
-                    count: parsed.count,
-                    status: parsed.status,
-                    resource_id: parsed.resource_id,
-                    resource_type: parsed.resource_type,
-                    name: parsed.name,
-                    description: parsed.description,
-                    environment: parsed.environment,
-                    owner: parsed.owner,
-                    parent_allocation_id: parsed.parent_allocation_id,
-                    tags: parsed.tags,
-                    ttl_seconds: parsed.ttl_seconds,
-                };
+                let request = parsed.into_auto_allocate_request(cidr_block_id);
                 let allocations = ops.allocate_auto(&tenant_id, &request).await?;
                 let list = AllocationList {
                     count: allocations.len(),


### PR DESCRIPTION
## Summary

Two HTTP handlers in `src/ipam_api.rs` (`allocate_specific`, `allocate_auto`) each contained a 12-line field-by-field copy from their HTTP body struct into the corresponding domain-model input. The body structs stay (they intentionally omit `cidr_block_id`, which can only come from the URL path), but the field copy moves to a method on the body struct.

This is a tidy-up exposed by the architectural review (candidate 4 from the deepening pass), not a deepening itself — most of candidate 4's original meat was absorbed by #168, #170, and #172. What's left here is mechanical glue cleanup.

Closes #173.

## What changed

- `AllocateSpecificRequest::into_create_allocation(cidr_block_id)`
- `AutoAllocateBody::into_auto_allocate_request(cidr_block_id)`
- Two 17-line `let input = … { /* 13 fields */ }` blocks in handler closures become one line each.

## Locality win, not line count

Net diff is +16 lines because the `impl` methods cost about what the call-site collapse saves. The actual benefit: the knowledge of how to translate an HTTP body into a domain input now sits next to the body struct definition. Adding a new field to `CreateAllocation` updates one impl method, not two handler closures.

## Test plan

- [x] All 545 tests pass; specifically the 17 `ipam_api_tests` (which exercise the converted paths) green.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `just check` (incl. semgrep) — 0 findings
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)