### PR TITLE
chore(release): 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0](https://github.com/wingnut128/netcidr/compare/v0.24.3...v0.25.0) - 2026-05-20
+
 ### Added
 
 - S3-backed SQLite sync for Lambda deployments (`NETCIDR_S3_BUCKET` env var). Setting this variable switches the Lambda binary from Postgres to SQLite, pulling the database from S3 on cold start and pushing it back after every mutating request. Eliminates the need for an RDS instance (~$0.01/mo in S3 costs vs ~$15/mo for RDS). Requires `reserved_concurrency = 1` on the Lambda function to prevent split-brain from concurrent containers.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2213,7 +2213,7 @@ dependencies = [
 
 [[package]]
 name = "netcidr"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netcidr"
-version = "0.24.3"
+version = "0.25.0"
 edition = "2024"
 license = "MIT"
 description = "A fast IPv4 and IPv6 subnet calculator CLI and API"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,9 @@ We actively support and provide security updates for the following versions:
 
 | Version | Supported          | Notes                                    |
 | ------- | ------------------ | ---------------------------------------- |
-| 0.24.x  | :white_check_mark: | Current stable release (recommended)     |
-| 0.23.x  | :white_check_mark: | Supported                                |
-| < 0.23  | :x:                | No longer supported                      |
+| 0.25.x  | :white_check_mark: | Current stable release (recommended)     |
+| 0.24.x  | :white_check_mark: | Supported                                |
+| < 0.24  | :x:                | No longer supported                      |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## ⚠️ BREAKING CHANGE (default-Reader RBAC policy)

After this release lands and the server restarts, any authenticated OIDC user whose email is in **none** of \`NETCIDR_ADMIN_EMAILS\`, \`NETCIDR_ALLOCATOR_EMAILS\`, or \`NETCIDR_READER_EMAILS\` resolves to \`Role::Reader\` and will receive 403 on every write or admin endpoint.

**Operator migration before deploy:**

1. Add every user who needs write access to \`NETCIDR_ALLOCATOR_EMAILS\` (comma-separated)
2. Add every user who needs admin access to \`NETCIDR_ADMIN_EMAILS\` (comma-separated)
3. Restart \`netcidr serve\`

Static bearer-token mode (\`NETCIDR_AUTH_MODE=bearer\`) is the documented carve-out — bearer principals carry no email and resolve to \`Role::Admin\` unchanged. Service-to-service automation using \`NETCIDR_API_TOKEN\` needs no migration. If you need read-only service automation, use OIDC + a reader-role email instead. See [ADR-0002](docs/adr/0002-rbac-role-config-and-per-handler-extractors.md).

## Summary

Cuts \`v0.25.0\` containing this session's work:

- **RBAC** (#102 PR1+PR2) — \`Role\` enum + per-handler \`Require*\` extractors + \`NETCIDR_ALLOCATOR_EMAILS\` / \`NETCIDR_READER_EMAILS\` env vars + \`NetcidrError::Forbidden\` (403, scrubbed body) + default-Reader policy + bearer carve-out. Shipped in #186 and #187.
- **S3-backed SQLite for Lambda** — pre-session work (#177).
- **Stale-IAP cleanup** — #185.

## Release-flow mechanics

This is a release-only PR (Cargo.toml + CHANGELOG + SECURITY.md). On merge, the release workflow's \`detect\` job sees the version bump to a new \`X.Y.Z\` with no matching tag and auto-triggers the \`release\` job, which builds the binary, extracts release notes from CHANGELOG, and creates the GitHub release with tag \`v0.25.0\`.

## Test plan

- [x] \`cargo build\` regenerates Cargo.lock with the new version
- [x] \`just check\` clean (fmt + clippy -D warnings + nextest + semgrep)
- [x] CHANGELOG [0.25.0] section uses the inline compare-link pattern matching 0.24.x entries
- [x] SECURITY.md supported-versions table rotated forward (0.25.x current, 0.24.x supported, < 0.24 unsupported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)