### PR TITLE
chore: release v0.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.2](https://github.com/wingnut128/netcidr/compare/v0.26.1...v0.26.2) - 2026-05-28
+
+### Added
+
+- *(ci)* adopt digestabot for automated base-image digest refresh ([#203](https://github.com/wingnut128/netcidr/pull/203))
+- *(ipam)* log chosen backend at startup with password-safe URL parsing ([#201](https://github.com/wingnut128/netcidr/pull/201))
+
+### Other
+
+- *(image-scan)* only upload SARIF when Grype actually ran ([#202](https://github.com/wingnut128/netcidr/pull/202))
+- *(deps)* bump EmbarkStudios/cargo-deny-action from 2.0.18 to 2.0.19 ([#196](https://github.com/wingnut128/netcidr/pull/196))
+- *(deps)* bump github/codeql-action from 4.35.5 to 4.36.0 ([#197](https://github.com/wingnut128/netcidr/pull/197))
+- name Linear + GitHub as dual trackers; ban linear.app URLs in public artifacts ([#193](https://github.com/wingnut128/netcidr/pull/193))
+
 ### Added
 
 - **Digestabot keeps pinned base-image digests fresh.** New scheduled workflow (`.github/workflows/digestabot.yml`, daily 06:00 UTC + `workflow_dispatch`) runs `chainguard-dev/digestabot@v1.3.1` to resolve the upstream tag for every `image:tag@sha256:…` reference in the `Dockerfile` and open a PR when the digest has drifted. Complements `dependabot.yml`'s `docker` and `github-actions` ecosystems (which handle *tag* bumps) by handling *digest* refreshes for already-pinned references. Pins still gate every build through CI + branch protection; digestabot just turns the refresh into a reviewable PR instead of an unreviewable rot.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2213,7 +2213,7 @@ dependencies = [
 
 [[package]]
 name = "netcidr"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netcidr"
-version = "0.26.1"
+version = "0.26.2"
 edition = "2024"
 license = "MIT"
 description = "A fast IPv4 and IPv6 subnet calculator CLI and API"


### PR DESCRIPTION



## 🤖 New release

* `netcidr`: 0.26.1 -> 0.26.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.26.2](https://github.com/wingnut128/netcidr/compare/v0.26.1...v0.26.2) - 2026-05-28

### Added

- *(ci)* adopt digestabot for automated base-image digest refresh ([#203](https://github.com/wingnut128/netcidr/pull/203))
- *(ipam)* log chosen backend at startup with password-safe URL parsing ([#201](https://github.com/wingnut128/netcidr/pull/201))

### Other

- *(image-scan)* only upload SARIF when Grype actually ran ([#202](https://github.com/wingnut128/netcidr/pull/202))
- *(deps)* bump EmbarkStudios/cargo-deny-action from 2.0.18 to 2.0.19 ([#196](https://github.com/wingnut128/netcidr/pull/196))
- *(deps)* bump github/codeql-action from 4.35.5 to 4.36.0 ([#197](https://github.com/wingnut128/netcidr/pull/197))
- name Linear + GitHub as dual trackers; ban linear.app URLs in public artifacts ([#193](https://github.com/wingnut128/netcidr/pull/193))

### Added

- **Digestabot keeps pinned base-image digests fresh.** New scheduled workflow (`.github/workflows/digestabot.yml`, daily 06:00 UTC + `workflow_dispatch`) runs `chainguard-dev/digestabot@v1.3.1` to resolve the upstream tag for every `image:tag@sha256:…` reference in the `Dockerfile` and open a PR when the digest has drifted. Complements `dependabot.yml`'s `docker` and `github-actions` ecosystems (which handle *tag* bumps) by handling *digest* refreshes for already-pinned references. Pins still gate every build through CI + branch protection; digestabot just turns the refresh into a reviewable PR instead of an unreviewable rot.

### Changed

- **Dockerfile base-image pins refreshed and brought into the digestabot-friendly format.** The runtime stage's `cgr.dev/chainguard/static@sha256:1f14…` (digest-only, untracked by digestabot) became `cgr.dev/chainguard/static:latest@sha256:77d8b89…` (tag + current digest, digestabot-tracked). The dashboard-builder's `oven/bun:1-alpine` digest moved from `sha256:4de4…` to `sha256:5acc90a…` to match upstream. The `rust:1.95-alpine3.23` pin was already current and unchanged. Triggering context: the previous Chainguard pin briefly became unreachable during a Chainguard registry outage on 2026-05-26, which surfaced as a misleading "missing SARIF file" error in the `Image Scan` workflow.

### Fixed

- **`image-scan` workflow no longer masks upstream failures with a misleading SARIF error.** When the `Build image` step failed (e.g. the base-image registry returned a 500 on the HEAD request for the pinned distroless digest), the subsequent `Upload SARIF to code-scanning` step ran anyway because of `if: always()` and then errored with `Input required and not supplied: sarif_file`, burying the real cause. The guard is now `if: always() && steps.grype.outputs.sarif != ''`, so SARIF upload only runs when Grype actually produced output; transient registry hiccups now surface as the original `docker build` error instead of a confusing missing-input error.

### Added

- **Startup log line naming the chosen IPAM backend ([#195](https://github.com/wingnut128/netcidr/issues/195)).** `ipam::create_store` now emits a single `tracing::info!` event when the store is constructed: `backend=sqlite path=...` or `backend=postgres host=... port=... database=...`. Both `netcidr serve` and the AWS Lambda entrypoint benefit — operators can grep CloudWatch / journald to confirm which backend a process is talking to, instead of inferring from env vars or the "data persists across cold starts" smell test. The Postgres branch parses the connection URL with `sqlx::postgres::PgConnectOptions::from_str` and emits only `get_host()` / `get_port()` / `get_database()`; the raw URL is never logged because it normally carries a password. A new unit test (`postgres_log_never_contains_credentials`) captures the log output via a `MakeWriter` buffer and asserts the password and username are absent — the test is the regression gate. In addition, the Lambda entrypoint logs the persistence-mode decision (`mode=s3-sqlite bucket=... key=... db_path=...` vs `mode=direct`) where `s3_syncer` is decided, so Lambda-specific routing is visible alongside the store-level log.

### Documentation

- **`CLAUDE.md` workflow now names both trackers.** The `Workflow` section opens by stating that work is tracked in the Linear project `netcidr` (workspace `beavis`, team `Engineering`, prefix `ENG-`) alongside GitHub Issues at `wingnut128/netcidr`, and step 1 explicitly says to attach the GitHub issue URL to the Linear ticket so cross-references live on the Linear side. Adds a guardrail: never publish `linear.app/...` URLs in public-facing places — PR descriptions, PR/issue comments, commit messages, CHANGELOG, or README. GitHub issue numbers (e.g., `#102`) remain freely usable everywhere.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).