### PR TITLE
feat(ipam): log chosen backend at startup with password-safe URL parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Startup log line naming the chosen IPAM backend ([#195](https://github.com/wingnut128/netcidr/issues/195)).** `ipam::create_store` now emits a single `tracing::info!` event when the store is constructed: `backend=sqlite path=...` or `backend=postgres host=... port=... database=...`. Both `netcidr serve` and the AWS Lambda entrypoint benefit — operators can grep CloudWatch / journald to confirm which backend a process is talking to, instead of inferring from env vars or the "data persists across cold starts" smell test. The Postgres branch parses the connection URL with `sqlx::postgres::PgConnectOptions::from_str` and emits only `get_host()` / `get_port()` / `get_database()`; the raw URL is never logged because it normally carries a password. A new unit test (`postgres_log_never_contains_credentials`) captures the log output via a `MakeWriter` buffer and asserts the password and username are absent — the test is the regression gate. In addition, the Lambda entrypoint logs the persistence-mode decision (`mode=s3-sqlite bucket=... key=... db_path=...` vs `mode=direct`) where `s3_syncer` is decided, so Lambda-specific routing is visible alongside the store-level log.
+
 ### Documentation
 
 - **`CLAUDE.md` workflow now names both trackers.** The `Workflow` section opens by stating that work is tracked in the Linear project `netcidr` (workspace `beavis`, team `Engineering`, prefix `ENG-`) alongside GitHub Issues at `wingnut128/netcidr`, and step 1 explicitly says to attach the GitHub issue URL to the Linear ticket so cross-references live on the Linear side. Adds a guardrail: never publish `linear.app/...` URLs in public-facing places — PR descriptions, PR/issue comments, commit messages, CHANGELOG, or README. GitHub issue numbers (e.g., `#102`) remain freely usable everywhere.

--- a/src/bin/lambda.rs
+++ b/src/bin/lambda.rs
@@ -62,10 +62,21 @@ async fn main() -> Result<(), Error> {
     let s3_syncer: Option<Arc<S3Syncer>> = if let Ok(bucket) = std::env::var("NETCIDR_S3_BUCKET") {
         let key = env_or("NETCIDR_S3_KEY", "netcidr/netcidr.db");
         let db_path = env_or("NETCIDR_DB", "/tmp/netcidr.db");
+        tracing::info!(
+            mode = "s3-sqlite",
+            bucket = %bucket,
+            key = %key,
+            db_path = %db_path,
+            "Lambda persistence mode selected",
+        );
         let syncer = S3Syncer::new(bucket, key, db_path);
         syncer.pull().await?;
         Some(Arc::new(syncer))
     } else {
+        tracing::info!(
+            mode = "direct",
+            "Lambda persistence mode selected; backend defers to NETCIDR_IPAM_BACKEND",
+        );
         None
     };
 

--- a/src/ipam/mod.rs
+++ b/src/ipam/mod.rs
@@ -12,8 +12,14 @@ use crate::error::{NetcidrError, Result};
 use config::IpamConfig;
 use std::sync::Arc;
 use store::IpamStore;
+use tracing::info;
 
 /// Create and initialize an IPAM store based on the configured backend.
+///
+/// Emits one `tracing::info!` line naming the chosen backend so operators can
+/// confirm at startup (CloudWatch / journald) which backend the process is
+/// talking to. The Postgres branch logs **host + port + database only** — the
+/// raw URL is never logged because it normally carries a password.
 ///
 /// - `cli_db`: SQLite database path override from CLI `--db` flag
 /// - `cli_db_url`: PostgreSQL connection URL override from CLI `--ipam-db-url` flag
@@ -25,6 +31,7 @@ pub async fn create_store(
     match config.backend {
         config::Backend::Sqlite => {
             let db_path = config::resolve_db_path(cli_db, &config.sqlite);
+            info!(backend = "sqlite", path = %db_path, "IPAM store initialized");
             let store = sqlite::SqliteStore::new(&db_path)?;
             store.initialize().await?;
             store.migrate().await?;
@@ -39,6 +46,7 @@ pub async fn create_store(
                             "PostgreSQL URL not configured. Set --ipam-db-url, NETCIDR_IPAM_DB_URL, or [ipam.postgres] url in config.".to_string(),
                         )
                     })?;
+                log_postgres_target(&url);
                 let store = postgres::PostgresStore::new(&url, &config.postgres).await?;
                 store.initialize().await?;
                 store.migrate().await?;
@@ -53,6 +61,108 @@ pub async fn create_store(
                 ))
             }
         }
+    }
+}
+
+/// Emit an `info!` line describing the Postgres target (host, port, database)
+/// without ever logging the password or username carried in the URL.
+///
+/// Parsing failures fall through to a non-revealing log line; the connection
+/// attempt itself will produce a downstream error if the URL is truly broken.
+#[cfg(feature = "ipam-postgres")]
+fn log_postgres_target(url: &str) {
+    use sqlx::postgres::PgConnectOptions;
+    use std::str::FromStr;
+    match PgConnectOptions::from_str(url) {
+        Ok(opts) => {
+            info!(
+                backend = "postgres",
+                host = opts.get_host(),
+                port = opts.get_port(),
+                database = opts.get_database().unwrap_or("<default>"),
+                "IPAM store initialized",
+            );
+        }
+        Err(_) => {
+            info!(
+                backend = "postgres",
+                "IPAM store initialized (URL not parseable for host/database extraction)",
+            );
+        }
+    }
+}
+
+#[cfg(all(test, feature = "ipam-postgres"))]
+mod startup_log_tests {
+    use super::log_postgres_target;
+    use std::io::{self, Write};
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::fmt::MakeWriter;
+
+    #[derive(Clone)]
+    struct BufMaker(Arc<Mutex<Vec<u8>>>);
+
+    impl<'a> MakeWriter<'a> for BufMaker {
+        type Writer = BufWriter;
+        fn make_writer(&'a self) -> Self::Writer {
+            BufWriter(self.0.clone())
+        }
+    }
+
+    struct BufWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for BufWriter {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn capture<F: FnOnce()>(f: F) -> String {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(BufMaker(buf.clone()))
+            .with_max_level(tracing::Level::INFO)
+            .with_ansi(false)
+            .finish();
+        tracing::subscriber::with_default(subscriber, f);
+        String::from_utf8(buf.lock().unwrap().clone()).expect("utf8")
+    }
+
+    #[test]
+    fn postgres_log_never_contains_credentials() {
+        let url = "postgres://alice:s3cr3t_PaSSworD@db.example.com:5432/netcidr_prod";
+        let out = capture(|| log_postgres_target(url));
+        assert!(
+            out.contains("db.example.com"),
+            "host missing from log: {out}"
+        );
+        assert!(
+            out.contains("netcidr_prod"),
+            "database name missing from log: {out}"
+        );
+        assert!(out.contains("5432"), "port missing from log: {out}");
+        assert!(
+            !out.contains("s3cr3t_PaSSworD"),
+            "PASSWORD LEAKED into log: {out}"
+        );
+        assert!(
+            !out.contains("alice"),
+            "username also leaked into log: {out}"
+        );
+    }
+
+    #[test]
+    fn postgres_log_handles_unparseable_url_without_panic() {
+        let out = capture(|| log_postgres_target("not a postgres url at all"));
+        assert!(out.contains("backend"), "expected backend log: {out}");
+        assert!(
+            !out.contains("not a postgres url at all"),
+            "raw URL leaked into log: {out}"
+        );
     }
 }
 


### PR DESCRIPTION
Closes #195

## Summary

- `ipam::create_store` now emits one `tracing::info!` event when the store is constructed, naming the backend and target — `backend=sqlite path=…` or `backend=postgres host=… port=… database=…` — so operators can grep CloudWatch / journald to confirm which backend the process is talking to.
- Postgres URL is parsed with `sqlx::postgres::PgConnectOptions::from_str`, emitting only `get_host()` / `get_port()` / `get_database()`. The raw URL is **never** logged because it normally carries a password. A new unit test (`postgres_log_never_contains_credentials`) captures the log output via a `MakeWriter` buffer and asserts the password and username are absent — that test is the regression gate.
- The Lambda entrypoint additionally logs the persistence-mode decision (`mode=s3-sqlite bucket=… key=… db_path=…` vs `mode=direct`) where `s3_syncer` is decided.
- CHANGELOG `[Unreleased]` updated under `### Added`.

## Test plan

- [x] `cargo test --features ipam-postgres --lib startup_log` — 2/2 new tests pass
- [x] `just check` — fmt + clippy + all test suites + semgrep all green
- [ ] CI green on the PR (`Format & Lint`, `Test`, `Security Audit`, CodeQL, Semgrep)
- [ ] Visual review: log lines render correctly under both the JSON formatter (Lambda) and the human formatter (`netcidr serve`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)