### PR TITLE
ci(image-scan): only upload SARIF when Grype actually ran

### DIFF
--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -67,7 +67,12 @@ jobs:
           output-format: sarif
 
       - name: Upload SARIF to code-scanning
-        if: always()
+        # Guard against Grype not producing output (e.g. earlier step failed
+        # before Grype ran, like a 500 from the base-image registry on the
+        # HEAD request). Without the empty-string check, this step errors
+        # with the misleading "Input required and not supplied: sarif_file"
+        # and masks the real upstream failure.
+        if: always() && steps.grype.outputs.sarif != ''
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: ${{ steps.grype.outputs.sarif }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`image-scan` workflow no longer masks upstream failures with a misleading SARIF error.** When the `Build image` step failed (e.g. the base-image registry returned a 500 on the HEAD request for the pinned distroless digest), the subsequent `Upload SARIF to code-scanning` step ran anyway because of `if: always()` and then errored with `Input required and not supplied: sarif_file`, burying the real cause. The guard is now `if: always() && steps.grype.outputs.sarif != ''`, so SARIF upload only runs when Grype actually produced output; transient registry hiccups now surface as the original `docker build` error instead of a confusing missing-input error.
+
 ### Added
 
 - **Startup log line naming the chosen IPAM backend ([#195](https://github.com/wingnut128/netcidr/issues/195)).** `ipam::create_store` now emits a single `tracing::info!` event when the store is constructed: `backend=sqlite path=...` or `backend=postgres host=... port=... database=...`. Both `netcidr serve` and the AWS Lambda entrypoint benefit — operators can grep CloudWatch / journald to confirm which backend a process is talking to, instead of inferring from env vars or the "data persists across cold starts" smell test. The Postgres branch parses the connection URL with `sqlx::postgres::PgConnectOptions::from_str` and emits only `get_host()` / `get_port()` / `get_database()`; the raw URL is never logged because it normally carries a password. A new unit test (`postgres_log_never_contains_credentials`) captures the log output via a `MakeWriter` buffer and asserts the password and username are absent — the test is the regression gate. In addition, the Lambda entrypoint logs the persistence-mode decision (`mode=s3-sqlite bucket=... key=... db_path=...` vs `mode=direct`) where `s3_syncer` is decided, so Lambda-specific routing is visible alongside the store-level log.


### PR DESCRIPTION
## Summary

The `Upload SARIF to code-scanning` step in `.github/workflows/image-scan.yml` had `if: always()`, which meant it ran even when the preceding `Build image` step failed before Grype produced any output. When that happened (most recently, Chainguard's registry returned a 500 on the HEAD request for the pinned `cgr.dev/chainguard/static@sha256:1f14…` digest), the SARIF-upload step errored with the confusing message:

> `Input required and not supplied: sarif_file`

…which buried the real cause. Adding `&& steps.grype.outputs.sarif != ''` to the guard makes the upload step skip cleanly when Grype never ran, surfacing the underlying `docker build` failure to operators reading the run summary.

The `if: always()` clause is retained intentionally so we still upload SARIF when Grype itself failed the build via `fail-build: true` — that's the case where `steps.grype.outputs.sarif` IS populated and we want code-scanning to see the findings.

## Files changed

- `.github/workflows/image-scan.yml` — one-line guard
- `CHANGELOG.md` — `[Unreleased]` entry under `### Fixed`

## Test plan

- [ ] Lint workflows pass (`actionlint` via the `Pin Check` workflow)
- [ ] PR's own `Image Scan` run still passes (it'll hit the green path on Chainguard up; no regression in the happy path)
- [ ] No effect on success/failure semantics: SARIF still uploads when Grype runs; failure to build still fails the workflow

## Notes

The triggering failure was on PR #194 (release-plz auto-PR for v0.26.2). I've re-run that workflow separately so it can proceed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)