### PR TITLE
chore: release v0.26.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.3](https://github.com/wingnut128/netcidr/compare/v0.26.2...v0.26.3) - 2026-05-28
+
+### Other
+
+- *(deps)* bump sqlx from 0.8.6 to 0.9.0 (with compat fix) ([#200](https://github.com/wingnut128/netcidr/pull/200))
+
 ## [0.26.2](https://github.com/wingnut128/netcidr/compare/v0.26.1...v0.26.2) - 2026-05-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "netcidr"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netcidr"
-version = "0.26.2"
+version = "0.26.3"
 edition = "2024"
 license = "MIT"
 description = "A fast IPv4 and IPv6 subnet calculator CLI and API"


### PR DESCRIPTION



## 🤖 New release

* `netcidr`: 0.26.2 -> 0.26.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.26.3](https://github.com/wingnut128/netcidr/compare/v0.26.2...v0.26.3) - 2026-05-28

### Other

- *(deps)* bump sqlx from 0.8.6 to 0.9.0 (with compat fix) ([#200](https://github.com/wingnut128/netcidr/pull/200))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).