### PR TITLE
feat(split): VLSM variable-length subnet allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **VLSM (variable-length) subnet splitting.** `netcidr split <cidr> --vlsm 26,28,28` carves a supernet into differently-sized sub-allocations in one pass, allocating each prefix greedily from the network address forward (Red Hat `ipcalc --split` style). Prefixes must be ordered largest-block-first (non-decreasing prefix length); out-of-order lists and allocations that overflow the supernet are rejected with a clear error naming the offending entry and the space remaining. Works for IPv4 and IPv6, across all four output formats (json/text/csv/yaml), and is exposed over HTTP at `GET /v4/vlsm` and `GET /v6/vlsm` (`?cidr=…&prefixes=26,28,28`). First phase of [#205](https://github.com/wingnut128/netcidr/issues/205); hierarchical/recursive splitting (`--steps`) follows in a second PR.
+
 ## [0.26.3](https://github.com/wingnut128/netcidr/compare/v0.26.2...v0.26.3) - 2026-05-28
 
 ### Other

--- a/README.md
+++ b/README.md
@@ -125,6 +125,29 @@ netcidr split 192.168.0.0/22 -p 27 --count-only
 netcidr split 2001:db8::/32 -p 48 -n 5
 ```
 
+#### VLSM (variable-length subnetting)
+
+Carve a supernet into differently-sized sub-allocations in one pass. Pass a
+comma-separated list of target prefixes, ordered largest-block-first
+(non-decreasing prefix length). Each prefix is allocated greedily from the
+network address forward (Red Hat `ipcalc --split` style):
+
+```bash
+# Carve a /24 into a /26 and two /28s
+netcidr split 192.168.0.0/24 --vlsm 26,28,28
+#   192.168.0.0/26   (64 hosts)
+#   192.168.0.64/28  (16 hosts)
+#   192.168.0.80/28  (16 hosts)
+
+# Works for IPv6 too
+netcidr split 2001:db8::/48 --vlsm 52,56,56
+```
+
+Out-of-order lists (a larger block requested after a smaller one) and
+allocations that overflow the supernet are rejected with a clear error naming
+the offending entry and the space remaining. `--vlsm` is mutually exclusive
+with `--prefix`/`--count`/`--max`/`--count-only`.
+
 ### Subnet Summarization
 
 Aggregate multiple CIDRs into the minimal covering set:
@@ -446,6 +469,8 @@ enable_swagger = false        # Swagger UI at /swagger-ui (default: false)
 | `GET /v6/split?cidr=<cidr>&prefix=<n>&count=<n>` | Split IPv6 cidr_block | `/v6/split?cidr=2001:db8::/32&prefix=48&count=10` |
 | `GET /v4/split?cidr=<cidr>&prefix=<n>&count_only=true` | Count available IPv4 subnets | `/v4/split?cidr=10.0.0.0/8&prefix=16&count_only=true` |
 | `GET /v6/split?cidr=<cidr>&prefix=<n>&count_only=true` | Count available IPv6 subnets | `/v6/split?cidr=2001:db8::/32&prefix=48&count_only=true` |
+| `GET /v4/vlsm?cidr=<cidr>&prefixes=<n,n,...>` | VLSM IPv4 allocation (largest block first) | `/v4/vlsm?cidr=192.168.0.0/24&prefixes=26,28,28` |
+| `GET /v6/vlsm?cidr=<cidr>&prefixes=<n,n,...>` | VLSM IPv6 allocation (largest block first) | `/v6/vlsm?cidr=2001:db8::/48&prefixes=52,56,56` |
 | `GET /v4/contains?cidr=<cidr>&address=<ip>` | Check IPv4 containment | `/v4/contains?cidr=192.168.1.0/24&address=192.168.1.100` |
 | `GET /v6/contains?cidr=<cidr>&address=<ip>` | Check IPv6 containment | `/v6/contains?cidr=2001:db8::/32&address=2001:db8::1` |
 | `GET /v4/summarize?cidrs=<cidr>,<cidr>` | Summarize IPv4 CIDRs | `/v4/summarize?cidrs=192.168.0.0/24,192.168.1.0/24` |

--- a/src/api.rs
+++ b/src/api.rs
@@ -42,8 +42,12 @@ use crate::ipv4::Ipv4Subnet;
 use crate::ipv6::Ipv6Subnet;
 use crate::output::{CsvOutput, OutputFormat, TextOutput};
 #[cfg(feature = "swagger")]
-use crate::subnet_generator::{Ipv4SubnetList, Ipv6SubnetList, SplitSummary};
-use crate::subnet_generator::{count_subnets, generate_ipv4_subnets, generate_ipv6_subnets};
+use crate::subnet_generator::{
+    Ipv4SubnetList, Ipv4VlsmList, Ipv6SubnetList, Ipv6VlsmList, SplitSummary,
+};
+use crate::subnet_generator::{
+    count_subnets, generate_ipv4_subnets, generate_ipv6_subnets, vlsm_split_ipv4, vlsm_split_ipv6,
+};
 #[cfg(feature = "swagger")]
 use crate::summarize::{Ipv4SummaryResult, Ipv6SummaryResult};
 use crate::summarize::{summarize_ipv4_with_limit, summarize_ipv6_with_limit};
@@ -97,6 +101,8 @@ impl Modify for SecurityAddon {
         calculate_ipv6,
         split_ipv4,
         split_ipv6,
+        vlsm_ipv4,
+        vlsm_ipv6,
         contains_ipv4,
         contains_ipv6,
         summarize_ipv4_handler,
@@ -130,6 +136,7 @@ impl Modify for SecurityAddon {
     components(
         schemas(
             Ipv4Subnet, Ipv6Subnet, Ipv4SubnetList, Ipv6SubnetList, SplitSummary,
+            Ipv4VlsmList, Ipv6VlsmList, VlsmQuery,
             ContainsResult, Ipv4SummaryResult, Ipv6SummaryResult, Ipv4FromRangeResult,
             Ipv6FromRangeResult, SubnetQuery, SplitQuery, ContainsQuery, SummarizeQuery,
             FromRangeQuery, BatchRequest, BatchResult, ErrorResponse, VersionResponse,
@@ -195,6 +202,22 @@ pub struct SplitQuery {
     /// Show only the number of available subnets (no generation)
     #[serde(default, alias = "count-only")]
     count_only: bool,
+    /// Pretty print JSON output
+    #[serde(default)]
+    pretty: bool,
+    /// Output format (json, text, csv, yaml)
+    #[serde(default)]
+    format: ApiOutputFormat,
+}
+
+#[derive(Deserialize)]
+#[cfg_attr(feature = "swagger", derive(ToSchema, IntoParams))]
+pub struct VlsmQuery {
+    /// Supernet in CIDR notation (e.g., 192.168.0.0/24 or 2001:db8::/48)
+    cidr: String,
+    /// Comma-separated target prefix lengths, largest block first
+    /// (non-decreasing, e.g. 26,28,28)
+    prefixes: String,
     /// Pretty print JSON output
     #[serde(default)]
     pretty: bool,
@@ -407,6 +430,8 @@ pub fn create_router(config: RouterConfig) -> Router {
         .route("/v6", get(calculate_ipv6))
         .route("/v4/split", get(split_ipv4))
         .route("/v6/split", get(split_ipv6))
+        .route("/v4/vlsm", get(vlsm_ipv4))
+        .route("/v6/vlsm", get(vlsm_ipv6))
         .route("/v4/contains", get(contains_ipv4))
         .route("/v6/contains", get(contains_ipv6))
         .route("/v4/summarize", get(summarize_ipv4_handler))
@@ -871,6 +896,109 @@ async fn contains_ipv6(Query(params): Query<ContainsQuery>) -> impl IntoResponse
         }
         Err(e) => {
             warn!(error = %e, "IPv6 containment check failed");
+            json_response(
+                ErrorResponse {
+                    error: e.to_string(),
+                },
+                params.pretty,
+                StatusCode::BAD_REQUEST,
+            )
+        }
+    }
+}
+
+/// Parse a comma-separated prefix list (e.g. "26,28,28") into prefix lengths.
+/// Returns a descriptive error string on any non-numeric or out-of-range entry.
+fn parse_prefix_list(raw: &str) -> std::result::Result<Vec<u8>, String> {
+    raw.split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            s.parse::<u8>()
+                .map_err(|_| format!("invalid prefix length '{s}': expected a number 0-128"))
+        })
+        .collect()
+}
+
+#[cfg_attr(feature = "swagger", utoipa::path(
+    get,
+    path = "/v4/vlsm",
+    params(
+        VlsmQuery
+    ),
+    responses(
+        (status = 200, description = "VLSM IPv4 allocation", body = Ipv4VlsmList),
+        (status = 400, description = "Invalid parameters", body = ErrorResponse)
+    ),
+    tag = "netcidr"
+))]
+#[instrument(skip_all, fields(cidr = %params.cidr, prefixes = %params.prefixes))]
+async fn vlsm_ipv4(Query(params): Query<VlsmQuery>) -> impl IntoResponse {
+    info!("VLSM splitting IPv4 supernet");
+    let prefixes = match parse_prefix_list(&params.prefixes) {
+        Ok(p) => p,
+        Err(error) => {
+            warn!(%error, "IPv4 VLSM prefix parse failed");
+            return json_response(
+                ErrorResponse { error },
+                params.pretty,
+                StatusCode::BAD_REQUEST,
+            );
+        }
+    };
+
+    match vlsm_split_ipv4(&params.cidr, &prefixes) {
+        Ok(result) => {
+            info!(allocations = result.subnets.len(), "IPv4 VLSM successful");
+            format_response(result, params.format, params.pretty, StatusCode::OK)
+        }
+        Err(e) => {
+            warn!(error = %e, "IPv4 VLSM failed");
+            json_response(
+                ErrorResponse {
+                    error: e.to_string(),
+                },
+                params.pretty,
+                StatusCode::BAD_REQUEST,
+            )
+        }
+    }
+}
+
+#[cfg_attr(feature = "swagger", utoipa::path(
+    get,
+    path = "/v6/vlsm",
+    params(
+        VlsmQuery
+    ),
+    responses(
+        (status = 200, description = "VLSM IPv6 allocation", body = Ipv6VlsmList),
+        (status = 400, description = "Invalid parameters", body = ErrorResponse)
+    ),
+    tag = "netcidr"
+))]
+#[instrument(skip_all, fields(cidr = %params.cidr, prefixes = %params.prefixes))]
+async fn vlsm_ipv6(Query(params): Query<VlsmQuery>) -> impl IntoResponse {
+    info!("VLSM splitting IPv6 supernet");
+    let prefixes = match parse_prefix_list(&params.prefixes) {
+        Ok(p) => p,
+        Err(error) => {
+            warn!(%error, "IPv6 VLSM prefix parse failed");
+            return json_response(
+                ErrorResponse { error },
+                params.pretty,
+                StatusCode::BAD_REQUEST,
+            );
+        }
+    };
+
+    match vlsm_split_ipv6(&params.cidr, &prefixes) {
+        Ok(result) => {
+            info!(allocations = result.subnets.len(), "IPv6 VLSM successful");
+            format_response(result, params.format, params.pretty, StatusCode::OK)
+        }
+        Err(e) => {
+            warn!(error = %e, "IPv6 VLSM failed");
             json_response(
                 ErrorResponse {
                     error: e.to_string(),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,9 +38,9 @@ pub enum Commands {
         /// Network in CIDR notation (or prefix notation for IPv6)
         cidr: String,
 
-        /// New prefix length for subnets
-        #[arg(short = 'p', long)]
-        prefix: u8,
+        /// New prefix length for fixed-size subnets (required unless --vlsm is used)
+        #[arg(short = 'p', long, required_unless_present = "vlsm")]
+        prefix: Option<u8>,
 
         /// Number of subnets to generate (mutually exclusive with --max)
         #[arg(short = 'n', long, conflicts_with = "max")]
@@ -53,6 +53,11 @@ pub enum Commands {
         /// Show only the number of available subnets (no generation)
         #[arg(long, conflicts_with_all = ["count", "max"])]
         count_only: bool,
+
+        /// VLSM: comma-separated descending prefix lengths to carve greedily
+        /// from the block, largest block first (e.g. --vlsm 26,28,28)
+        #[arg(long, value_delimiter = ',', conflicts_with_all = ["prefix", "count", "max", "count_only"])]
+        vlsm: Option<Vec<u8>>,
     },
 
     /// Check if an IP address is contained in a subnet

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,9 @@ use netcidr::ipv4::Ipv4Subnet;
 use netcidr::ipv6::Ipv6Subnet;
 use netcidr::logging::{LogConfig, init_logging, parse_log_level};
 use netcidr::output::{CsvOutput, OutputFormat, OutputWriter, TextOutput};
-use netcidr::subnet_generator::{count_subnets, generate_ipv4_subnets, generate_ipv6_subnets};
+use netcidr::subnet_generator::{
+    count_subnets, generate_ipv4_subnets, generate_ipv6_subnets, vlsm_split_ipv4, vlsm_split_ipv6,
+};
 use netcidr::summarize::{summarize_ipv4, summarize_ipv6};
 use serde::Serialize;
 use std::io::{self, BufRead, Write};
@@ -170,7 +172,22 @@ async fn async_main(cli: Cli) {
             count,
             max,
             count_only,
+            vlsm,
         }) => {
+            // VLSM mode: carve a variable-length allocation from the block.
+            if let Some(prefixes) = vlsm {
+                if cidr.contains(':') {
+                    handle_result(&writer, vlsm_split_ipv6(&cidr, &prefixes), &cli.output);
+                } else {
+                    handle_result(&writer, vlsm_split_ipv4(&cidr, &prefixes), &cli.output);
+                }
+                return;
+            }
+
+            // Fixed-size mode. clap guarantees --prefix is present here
+            // (required_unless_present = "vlsm").
+            let prefix = prefix.expect("clap enforces --prefix unless --vlsm is given");
+
             if count_only {
                 handle_result(&writer, count_subnets(&cidr, prefix), &cli.output);
                 return;

--- a/src/output.rs
+++ b/src/output.rs
@@ -4,7 +4,9 @@ use crate::error::{NetcidrError, Result};
 use crate::from_range::{Ipv4FromRangeResult, Ipv6FromRangeResult};
 use crate::ipv4::Ipv4Subnet;
 use crate::ipv6::Ipv6Subnet;
-use crate::subnet_generator::{Ipv4SubnetList, Ipv6SubnetList, SplitSummary};
+use crate::subnet_generator::{
+    Ipv4SubnetList, Ipv4VlsmList, Ipv6SubnetList, Ipv6VlsmList, SplitSummary,
+};
 use crate::summarize::{Ipv4SummaryResult, Ipv6SummaryResult};
 use serde::Serialize;
 use std::fmt::Write as FmtWrite;
@@ -210,6 +212,58 @@ impl TextOutput for Ipv6SubnetList {
                 i + 1,
                 subnet.network,
                 subnet.prefix_length
+            )
+            .unwrap();
+        }
+        out
+    }
+}
+
+impl TextOutput for Ipv4VlsmList {
+    fn to_text(&self) -> String {
+        let mut out = String::new();
+        writeln!(out, "IPv4 VLSM Allocation").unwrap();
+        writeln!(out, "====================").unwrap();
+        writeln!(out, "Supernet:   {}", self.cidr_block.input).unwrap();
+        writeln!(out, "Requested:  {} sub-allocations", self.requested_count).unwrap();
+        writeln!(out, "Allocated:  {} addresses", self.allocated_addresses).unwrap();
+        writeln!(out, "Remaining:  {} addresses\n", self.remaining_addresses).unwrap();
+
+        for (i, subnet) in self.subnets.iter().enumerate() {
+            writeln!(
+                out,
+                "  {}. {}/{} (Hosts: {}-{}, {} total)",
+                i + 1,
+                subnet.network,
+                subnet.prefix_length,
+                subnet.first_host,
+                subnet.last_host,
+                subnet.total_hosts
+            )
+            .unwrap();
+        }
+        out
+    }
+}
+
+impl TextOutput for Ipv6VlsmList {
+    fn to_text(&self) -> String {
+        let mut out = String::new();
+        writeln!(out, "IPv6 VLSM Allocation").unwrap();
+        writeln!(out, "====================").unwrap();
+        writeln!(out, "Supernet:   {}", self.cidr_block.input).unwrap();
+        writeln!(out, "Requested:  {} sub-allocations", self.requested_count).unwrap();
+        writeln!(out, "Allocated:  {} addresses", self.allocated_addresses).unwrap();
+        writeln!(out, "Remaining:  {} addresses\n", self.remaining_addresses).unwrap();
+
+        for (i, subnet) in self.subnets.iter().enumerate() {
+            writeln!(
+                out,
+                "  {}. {}/{} ({} addresses)",
+                i + 1,
+                subnet.network,
+                subnet.prefix_length,
+                subnet.total_addresses
             )
             .unwrap();
         }
@@ -466,6 +520,42 @@ impl CsvOutput for Ipv6SubnetList {
         writeln!(out, "# cidr_block: {}", self.cidr_block.input).unwrap();
         writeln!(out, "# new_prefix: {}", self.new_prefix).unwrap();
         writeln!(out, "# count: {}", self.requested_count).unwrap();
+
+        let mut wtr = csv::Writer::from_writer(Vec::new());
+        wtr.write_record(ipv6_csv_header()).map_err(csv_err)?;
+        for subnet in &self.subnets {
+            write_ipv6_csv_record(&mut wtr, subnet)?;
+        }
+        out.push_str(&finish_csv(wtr)?);
+        Ok(out)
+    }
+}
+
+impl CsvOutput for Ipv4VlsmList {
+    fn to_csv(&self) -> Result<String> {
+        let mut out = String::new();
+        writeln!(out, "# supernet: {}", self.cidr_block.input).unwrap();
+        writeln!(out, "# requested_count: {}", self.requested_count).unwrap();
+        writeln!(out, "# allocated_addresses: {}", self.allocated_addresses).unwrap();
+        writeln!(out, "# remaining_addresses: {}", self.remaining_addresses).unwrap();
+
+        let mut wtr = csv::Writer::from_writer(Vec::new());
+        wtr.write_record(ipv4_csv_header()).map_err(csv_err)?;
+        for subnet in &self.subnets {
+            write_ipv4_csv_record(&mut wtr, subnet)?;
+        }
+        out.push_str(&finish_csv(wtr)?);
+        Ok(out)
+    }
+}
+
+impl CsvOutput for Ipv6VlsmList {
+    fn to_csv(&self) -> Result<String> {
+        let mut out = String::new();
+        writeln!(out, "# supernet: {}", self.cidr_block.input).unwrap();
+        writeln!(out, "# requested_count: {}", self.requested_count).unwrap();
+        writeln!(out, "# allocated_addresses: {}", self.allocated_addresses).unwrap();
+        writeln!(out, "# remaining_addresses: {}", self.remaining_addresses).unwrap();
 
         let mut wtr = csv::Writer::from_writer(Vec::new());
         wtr.write_record(ipv6_csv_header()).map_err(csv_err)?;

--- a/src/subnet_generator.rs
+++ b/src/subnet_generator.rs
@@ -47,6 +47,45 @@ pub struct Ipv6SubnetList {
     pub subnets: Vec<Ipv6Subnet>,
 }
 
+/// A variable-length (VLSM) allocation carved out of an IPv4 supernet.
+///
+/// Subnets appear in the order they were requested; each is placed greedily
+/// from the supernet's network address forward. `subnets[i].prefix_length`
+/// is the prefix that was requested for entry `i`.
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "swagger", derive(utoipa::ToSchema))]
+pub struct Ipv4VlsmList {
+    /// The original supernet that was carved up.
+    pub cidr_block: Ipv4Subnet,
+    /// Number of sub-allocations requested (equals `subnets.len()`).
+    pub requested_count: u64,
+    /// The carved sub-allocations, in request order.
+    pub subnets: Vec<Ipv4Subnet>,
+    /// Total addresses consumed by the allocation (decimal string).
+    pub allocated_addresses: String,
+    /// Addresses still free in the supernet after the allocation (decimal string).
+    pub remaining_addresses: String,
+}
+
+/// A variable-length (VLSM) allocation carved out of an IPv6 supernet.
+///
+/// See [`Ipv4VlsmList`] for field semantics.
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "swagger", derive(utoipa::ToSchema))]
+pub struct Ipv6VlsmList {
+    /// The original supernet that was carved up.
+    pub cidr_block: Ipv6Subnet,
+    /// Number of sub-allocations requested (equals `subnets.len()`).
+    pub requested_count: u64,
+    /// The carved sub-allocations, in request order.
+    pub subnets: Vec<Ipv6Subnet>,
+    /// Total addresses consumed by the allocation (decimal string).
+    pub allocated_addresses: String,
+    /// Addresses still free in the supernet after the allocation
+    /// (decimal string, or `2^128 - N` form for a `/0` supernet).
+    pub remaining_addresses: String,
+}
+
 /// Count how many child subnets a split would produce, without generating them.
 ///
 /// Auto-detects IPv4 vs IPv6 from the CIDR string.
@@ -246,6 +285,200 @@ pub fn generate_ipv6_subnets(
     })
 }
 
+/// Validate one entry of a VLSM prefix list against the supernet and the
+/// preceding entry. Shared by the IPv4 and IPv6 allocators.
+///
+/// Enforces: each prefix is strictly longer than the supernet prefix, does not
+/// exceed `max_bits`, and is not shorter than the preceding prefix (entries
+/// must be ordered largest-block-first so the allocation cursor stays aligned).
+fn validate_vlsm_prefix(
+    p: u8,
+    index: usize,
+    supernet_prefix: u8,
+    max_bits: u8,
+    prev: Option<u8>,
+) -> Result<()> {
+    if p > max_bits {
+        return Err(NetcidrError::InvalidPrefixLength(p));
+    }
+    if p <= supernet_prefix {
+        return Err(NetcidrError::InvalidSubnetSplit {
+            new_prefix: p,
+            original_prefix: supernet_prefix,
+        });
+    }
+    if let Some(prev_p) = prev
+        && p < prev_p
+    {
+        return Err(NetcidrError::InvalidInput(format!(
+            "VLSM prefixes must be ordered largest-block-first \
+             (non-decreasing prefix length): /{p} at entry {} is a larger \
+             block than the preceding /{prev_p}",
+            index + 1
+        )));
+    }
+    Ok(())
+}
+
+/// Carve an IPv4 supernet into a variable-length (VLSM) allocation.
+///
+/// Each prefix in `prefixes` is allocated greedily from the supernet's network
+/// address forward, in the order given. Prefixes must be ordered
+/// largest-block-first (non-decreasing prefix length) so each sub-allocation
+/// lands on a natural boundary.
+///
+/// # Errors
+///
+/// * [`NetcidrError::InvalidInput`] if `prefixes` is empty, the list is
+///   out of order, or the requested allocations overflow the supernet
+///   (the error names the offending entry and the space remaining).
+/// * [`NetcidrError::InvalidSubnetSplit`] if a prefix is not longer than the
+///   supernet prefix.
+/// * [`NetcidrError::InvalidPrefixLength`] if a prefix exceeds 32.
+pub fn vlsm_split_ipv4(cidr: &str, prefixes: &[u8]) -> Result<Ipv4VlsmList> {
+    let cidr_block = Ipv4Subnet::from_cidr(cidr)?;
+
+    if prefixes.is_empty() {
+        return Err(NetcidrError::InvalidInput(
+            "no target prefixes provided for VLSM split".to_string(),
+        ));
+    }
+
+    let supernet_prefix = cidr_block.prefix_length;
+    // /0 → 1<<32, which still fits in u64.
+    let capacity: u64 = 1u64 << (32 - supernet_prefix);
+    let network_u32 = u32::from(cidr_block.network);
+
+    let mut cursor: u64 = 0;
+    let mut prev: Option<u8> = None;
+    let mut subnets = Vec::with_capacity(prefixes.len());
+
+    for (i, &p) in prefixes.iter().enumerate() {
+        validate_vlsm_prefix(p, i, supernet_prefix, 32, prev)?;
+
+        let subnet_size: u64 = 1u64 << (32 - p);
+        if cursor + subnet_size > capacity {
+            let remaining = capacity - cursor;
+            return Err(NetcidrError::InvalidInput(format!(
+                "cannot allocate /{p} (entry {}): needs {subnet_size} addresses \
+                 but only {remaining} remain in {}",
+                i + 1,
+                cidr_block.input
+            )));
+        }
+
+        let addr = Ipv4Addr::from(network_u32 + cursor as u32);
+        subnets.push(Ipv4Subnet::new(addr, p)?);
+        cursor += subnet_size;
+        prev = Some(p);
+    }
+
+    Ok(Ipv4VlsmList {
+        cidr_block,
+        requested_count: prefixes.len() as u64,
+        subnets,
+        allocated_addresses: cursor.to_string(),
+        remaining_addresses: (capacity - cursor).to_string(),
+    })
+}
+
+/// Carve an IPv6 supernet into a variable-length (VLSM) allocation.
+///
+/// See [`vlsm_split_ipv4`] for the allocation semantics and ordering rules.
+///
+/// # Errors
+///
+/// Same error conditions as [`vlsm_split_ipv4`], with prefixes capped at 128.
+pub fn vlsm_split_ipv6(cidr: &str, prefixes: &[u8]) -> Result<Ipv6VlsmList> {
+    let cidr_block = Ipv6Subnet::from_cidr(cidr)?;
+
+    if prefixes.is_empty() {
+        return Err(NetcidrError::InvalidInput(
+            "no target prefixes provided for VLSM split".to_string(),
+        ));
+    }
+
+    let supernet_prefix = cidr_block.prefix_length;
+    // A /0 supernet holds 2^128 addresses, which does not fit in u128;
+    // represent it as `None` (effectively unbounded for any real list).
+    let capacity: Option<u128> = if supernet_prefix == 0 {
+        None
+    } else {
+        Some(1u128 << (128 - supernet_prefix))
+    };
+    let network_u128 = u128::from(cidr_block.network);
+
+    let mut cursor: u128 = 0;
+    let mut prev: Option<u8> = None;
+    let mut subnets = Vec::with_capacity(prefixes.len());
+    // Set once the allocation consumes the entire 2^128 /0 space exactly —
+    // `cursor` cannot represent 2^128 in a u128, so we track the boundary here.
+    let mut filled = false;
+
+    // Render free space as a decimal string, or `2^128 - N` for a /0 supernet.
+    let remaining_str = |cursor: u128, filled: bool| -> String {
+        if filled {
+            return "0".to_string();
+        }
+        match capacity {
+            Some(cap) => (cap - cursor).to_string(),
+            None => format!("2^128 - {cursor}"),
+        }
+    };
+
+    for (i, &p) in prefixes.iter().enumerate() {
+        validate_vlsm_prefix(p, i, supernet_prefix, 128, prev)?;
+
+        // p is in 1..=128 here (strictly greater than supernet_prefix >= 0),
+        // so the shift width is 0..=127 and never overflows.
+        let subnet_size: u128 = 1u128 << (128 - p);
+
+        // The supernet is exhausted once a prior entry filled it exactly, or
+        // when this entry would not fit before the supernet's last address.
+        // `max_start` = 2^128 - subnet_size, the highest cursor at which a
+        // block of this size still fits in the full address space.
+        let max_start = u128::MAX - (subnet_size - 1);
+        let fits = !filled
+            && cursor <= max_start
+            && match capacity {
+                Some(cap) => cursor + subnet_size <= cap,
+                None => true,
+            };
+        if !fits {
+            return Err(NetcidrError::InvalidInput(format!(
+                "cannot allocate /{p} (entry {}): needs {subnet_size} addresses \
+                 but only {} remain in {}",
+                i + 1,
+                remaining_str(cursor, filled),
+                cidr_block.input
+            )));
+        }
+
+        let addr = Ipv6Addr::from(network_u128 + cursor);
+        subnets.push(Ipv6Subnet::new(addr, p)?);
+        prev = Some(p);
+
+        // Advance. A `None` here means the allocation reached exactly 2^128
+        // (an exact fill of a /0 supernet); record it rather than overflow.
+        match cursor.checked_add(subnet_size) {
+            Some(next) => cursor = next,
+            None => filled = true,
+        }
+    }
+
+    Ok(Ipv6VlsmList {
+        cidr_block,
+        requested_count: prefixes.len() as u64,
+        subnets,
+        allocated_addresses: if filled {
+            "340282366920938463463374607431768211456".to_string() // 2^128
+        } else {
+            cursor.to_string()
+        },
+        remaining_addresses: remaining_str(cursor, filled),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -321,6 +554,152 @@ mod tests {
             ),
             "expected InvalidSubnetSplit, got {:?}",
             result
+        );
+    }
+
+    #[test]
+    fn test_vlsm_ipv4_basic() {
+        // ipcalc-style example from the ticket.
+        let result = vlsm_split_ipv4("192.168.0.0/24", &[26, 28, 28]).unwrap();
+        assert_eq!(result.requested_count, 3);
+        assert_eq!(result.subnets.len(), 3);
+        assert_eq!(result.subnets[0].network, Ipv4Addr::new(192, 168, 0, 0));
+        assert_eq!(result.subnets[0].prefix_length, 26);
+        assert_eq!(result.subnets[1].network, Ipv4Addr::new(192, 168, 0, 64));
+        assert_eq!(result.subnets[1].prefix_length, 28);
+        assert_eq!(result.subnets[2].network, Ipv4Addr::new(192, 168, 0, 80));
+        // 64 + 16 + 16 = 96 allocated, 256 - 96 = 160 remaining.
+        assert_eq!(result.allocated_addresses, "96");
+        assert_eq!(result.remaining_addresses, "160");
+    }
+
+    #[test]
+    fn test_vlsm_ipv4_exact_fit() {
+        // Four /26s exactly fill a /24.
+        let result = vlsm_split_ipv4("10.0.0.0/24", &[26, 26, 26, 26]).unwrap();
+        assert_eq!(result.subnets.len(), 4);
+        assert_eq!(result.subnets[3].network, Ipv4Addr::new(10, 0, 0, 192));
+        assert_eq!(result.allocated_addresses, "256");
+        assert_eq!(result.remaining_addresses, "0");
+    }
+
+    #[test]
+    fn test_vlsm_ipv4_overflow() {
+        // Three /25s (128 each) cannot fit in a /24 (256).
+        let result = vlsm_split_ipv4("10.0.0.0/24", &[25, 25, 25]);
+        assert!(
+            matches!(&result, Err(NetcidrError::InvalidInput(msg)) if msg.contains("entry 3") && msg.contains("only 0")),
+            "expected InvalidInput overflow naming entry 3, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_vlsm_ipv4_rejects_out_of_order() {
+        // A larger block (/24) requested after a smaller block (/26) is rejected.
+        let result = vlsm_split_ipv4("10.0.0.0/22", &[26, 24]);
+        assert!(
+            matches!(&result, Err(NetcidrError::InvalidInput(msg)) if msg.contains("largest-block-first")),
+            "expected ordering error, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_vlsm_ipv4_rejects_empty() {
+        let result = vlsm_split_ipv4("10.0.0.0/24", &[]);
+        assert!(
+            matches!(&result, Err(NetcidrError::InvalidInput(msg)) if msg.contains("no target prefixes")),
+            "expected empty-list error, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_vlsm_ipv4_rejects_prefix_not_longer() {
+        let result = vlsm_split_ipv4("10.0.0.0/24", &[24]);
+        assert!(
+            matches!(
+                result,
+                Err(NetcidrError::InvalidSubnetSplit {
+                    new_prefix: 24,
+                    original_prefix: 24
+                })
+            ),
+            "expected InvalidSubnetSplit"
+        );
+    }
+
+    #[test]
+    fn test_vlsm_ipv6_basic() {
+        let result = vlsm_split_ipv6("2001:db8::/48", &[52, 56, 56]).unwrap();
+        assert_eq!(result.subnets.len(), 3);
+        assert_eq!(result.subnets[0].prefix_length, 52);
+        assert_eq!(
+            result.subnets[0].network,
+            "2001:db8::".parse::<Ipv6Addr>().unwrap()
+        );
+        // /52 = 2^76 addresses; /56 = 2^72. Second subnet starts one /52 in.
+        assert_eq!(
+            result.subnets[1].network,
+            "2001:db8:0:1000::".parse::<Ipv6Addr>().unwrap()
+        );
+        assert_eq!(
+            result.subnets[2].network,
+            "2001:db8:0:1100::".parse::<Ipv6Addr>().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_vlsm_ipv6_overflow() {
+        // Two /49s (each half of a /48) fit; a third overflows.
+        let result = vlsm_split_ipv6("2001:db8::/48", &[49, 49, 49]);
+        assert!(
+            matches!(&result, Err(NetcidrError::InvalidInput(msg)) if msg.contains("entry 3")),
+            "expected overflow at entry 3, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_vlsm_ipv6_zero_supernet_partial() {
+        // A /0 supernet has effectively unbounded capacity; a partial fill
+        // reports remaining space symbolically rather than panicking.
+        let result = vlsm_split_ipv6("::/0", &[2, 2, 2]).unwrap();
+        assert_eq!(result.subnets.len(), 3);
+        assert!(result.remaining_addresses.starts_with("2^128 -"));
+    }
+
+    #[test]
+    fn test_vlsm_ipv6_zero_supernet_exact_fill() {
+        // /1 + /2 + /2 = 2^127 + 2^126 + 2^126 = 2^128, exactly filling /0.
+        let result = vlsm_split_ipv6("::/0", &[1, 2, 2]).unwrap();
+        assert_eq!(result.subnets.len(), 3);
+        assert_eq!(result.remaining_addresses, "0");
+        assert_eq!(
+            result.allocated_addresses,
+            "340282366920938463463374607431768211456"
+        );
+        // A further entry must fail cleanly, not panic.
+        let overflow = vlsm_split_ipv6("::/0", &[1, 2, 2, 64]);
+        assert!(matches!(overflow, Err(NetcidrError::InvalidInput(_))));
+    }
+
+    #[test]
+    fn test_vlsm_ipv6_wraparound_high_supernet() {
+        // Allocate at the very top of the address space; must not wrap.
+        let result = vlsm_split_ipv6(
+            "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffc/126",
+            &[127, 128, 128],
+        )
+        .unwrap();
+        assert_eq!(result.subnets.len(), 3);
+        assert_eq!(result.remaining_addresses, "0");
+        assert_eq!(
+            result.subnets[2].network,
+            "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"
+                .parse::<Ipv6Addr>()
+                .unwrap()
         );
     }
 }

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -272,6 +272,59 @@ async fn test_v6_split() {
     assert_eq!(json["subnets"].as_array().unwrap().len(), 3);
 }
 
+// ── VLSM ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_v4_vlsm() {
+    let (status, body) = get("/v4/vlsm?cidr=192.168.0.0/24&prefixes=26,28,28").await;
+    assert_eq!(status, 200);
+    let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(json["requested_count"], 3);
+    let subnets = json["subnets"].as_array().unwrap();
+    assert_eq!(subnets.len(), 3);
+    assert_eq!(subnets[0]["network_address"], "192.168.0.0");
+    assert_eq!(subnets[1]["network_address"], "192.168.0.64");
+    assert_eq!(json["allocated_addresses"], "96");
+    assert_eq!(json["remaining_addresses"], "160");
+}
+
+#[tokio::test]
+async fn test_v6_vlsm() {
+    let (status, body) = get("/v6/vlsm?cidr=2001:db8::/48&prefixes=52,56,56").await;
+    assert_eq!(status, 200);
+    let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(json["subnets"].as_array().unwrap().len(), 3);
+}
+
+#[tokio::test]
+async fn test_v4_vlsm_overflow() {
+    let (status, body) = get("/v4/vlsm?cidr=10.0.0.0/24&prefixes=25,25,25").await;
+    assert_eq!(status, 400);
+    let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert!(json["error"].as_str().unwrap().contains("cannot allocate"));
+}
+
+#[tokio::test]
+async fn test_v4_vlsm_out_of_order() {
+    let (status, body) = get("/v4/vlsm?cidr=10.0.0.0/22&prefixes=26,24").await;
+    assert_eq!(status, 400);
+    let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap()
+            .contains("largest-block-first")
+    );
+}
+
+#[tokio::test]
+async fn test_v4_vlsm_invalid_prefix_list() {
+    let (status, body) = get("/v4/vlsm?cidr=10.0.0.0/24&prefixes=26,abc").await;
+    assert_eq!(status, 400);
+    let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert!(json["error"].as_str().unwrap().contains("invalid prefix"));
+}
+
 // ── IPv4 Contains ───────────────────────────────────────────────────
 
 #[tokio::test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -171,6 +171,59 @@ fn test_split_requires_count_or_max() {
 }
 
 #[test]
+fn test_split_vlsm_ipv4() {
+    let (stdout, _, success) = run_netcidr(&["split", "192.168.0.0/24", "--vlsm", "26,28,28"]);
+    assert!(success);
+
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("Invalid JSON");
+    assert_eq!(json["requested_count"], 3);
+    let subnets = json["subnets"].as_array().unwrap();
+    assert_eq!(subnets.len(), 3);
+    assert_eq!(subnets[0]["network_address"], "192.168.0.0");
+    assert_eq!(subnets[0]["prefix_length"], 26);
+    assert_eq!(subnets[1]["network_address"], "192.168.0.64");
+    assert_eq!(subnets[2]["network_address"], "192.168.0.80");
+    assert_eq!(json["allocated_addresses"], "96");
+    assert_eq!(json["remaining_addresses"], "160");
+}
+
+#[test]
+fn test_split_vlsm_ipv6() {
+    let (stdout, _, success) = run_netcidr(&["split", "2001:db8::/48", "--vlsm", "52,56,56"]);
+    assert!(success);
+
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("Invalid JSON");
+    assert_eq!(json["requested_count"], 3);
+    let subnets = json["subnets"].as_array().unwrap();
+    assert_eq!(subnets.len(), 3);
+    assert_eq!(subnets[0]["prefix_length"], 52);
+    assert_eq!(subnets[1]["network_address"], "2001:db8:0:1000::");
+}
+
+#[test]
+fn test_split_vlsm_overflow_fails() {
+    // Three /25s (128 addresses each) cannot fit in a /24.
+    let (_, stderr, success) = run_netcidr(&["split", "10.0.0.0/24", "--vlsm", "25,25,25"]);
+    assert!(!success);
+    assert!(stderr.contains("cannot allocate"));
+}
+
+#[test]
+fn test_split_vlsm_out_of_order_fails() {
+    let (_, stderr, success) = run_netcidr(&["split", "10.0.0.0/22", "--vlsm", "26,24"]);
+    assert!(!success);
+    assert!(stderr.contains("largest-block-first"));
+}
+
+#[test]
+fn test_split_vlsm_conflicts_with_prefix() {
+    // --vlsm and --prefix are mutually exclusive (clap-enforced).
+    let (_, stderr, success) = run_netcidr(&["split", "10.0.0.0/24", "-p", "26", "--vlsm", "26"]);
+    assert!(!success);
+    assert!(stderr.contains("cannot be used with"));
+}
+
+#[test]
 fn test_direct_ipv4() {
     let (stdout, _, success) = run_netcidr(&["192.168.1.0/24"]);
     assert!(success);
@@ -542,6 +595,34 @@ fn test_split_csv_output() {
         .collect();
     // header + 4 data rows = 5
     assert_eq!(data_lines.len(), 5);
+}
+
+#[test]
+fn test_split_vlsm_csv_output() {
+    let (stdout, _, success) = run_netcidr(&[
+        "split",
+        "192.168.0.0/24",
+        "--vlsm",
+        "26,28,28",
+        "--format",
+        "csv",
+    ]);
+    assert!(success);
+
+    let lines: Vec<&str> = stdout.lines().collect();
+    let comment_lines: Vec<&&str> = lines.iter().filter(|l| l.starts_with('#')).collect();
+    assert!(
+        comment_lines
+            .iter()
+            .any(|l| l.contains("allocated_addresses")),
+        "VLSM CSV should report allocated_addresses in metadata"
+    );
+    let data_lines: Vec<&&str> = lines
+        .iter()
+        .filter(|l| !l.starts_with('#') && !l.is_empty())
+        .collect();
+    // header + 3 data rows = 4
+    assert_eq!(data_lines.len(), 4);
 }
 
 #[test]


### PR DESCRIPTION
## What

Adds **VLSM (variable-length subnet masking)** splitting — phase 1 of #205. One supernet in, a list of differently-sized sub-allocations out, in a single pass.

```
netcidr split 192.168.0.0/24 --vlsm 26,28,28
→ 192.168.0.0/26   (64 hosts)
  192.168.0.64/28  (16 hosts)
  192.168.0.80/28  (16 hosts)
  # allocated 96, remaining 160
```

Each prefix is allocated greedily from the network address forward (Red Hat `ipcalc --split` style). Prefixes must be ordered largest-block-first (non-decreasing prefix length) so the allocation cursor stays naturally aligned.

## Changes

- **`subnet_generator.rs`** — `vlsm_split_ipv4` / `vlsm_split_ipv6` + `Ipv4VlsmList` / `Ipv6VlsmList`. Validates ordering, rejects empty lists, detects overflow (error names the offending entry and remaining space). IPv6 handles the `/0` exact-fill and top-of-address-space boundary without panicking.
- **`cli.rs` / `main.rs`** — `--vlsm <comma-list>`; `--prefix` is now optional (required unless `--vlsm`), mutually exclusive with `--prefix`/`--count`/`--max`/`--count-only`. Existing single-prefix `split` behavior is unchanged.
- **`output.rs`** — `TextOutput` + `CsvOutput` for both VLSM list types (json/yaml come for free via serde).
- **`api.rs`** — `VlsmQuery`, `GET /v4/vlsm` & `GET /v6/vlsm` (`?cidr=…&prefixes=26,28,28`), OpenAPI path + schema registration.
- **Docs** — README CLI Reference + API Endpoints tables, CHANGELOG `[Unreleased]`.

## Tests

22 new tests, all green:
- **11 unit** (`subnet_generator`): basic, exact-fit, overflow, out-of-order rejection, empty-list rejection, prefix-not-longer, IPv6 basic/overflow/wraparound/zero-supernet partial+exact-fill.
- **5 API** (`api_tests`): v4/v6 happy path, overflow 400, out-of-order 400, invalid prefix-list 400.
- **6 CLI** (`integration_tests`): v4/v6 happy path, overflow, out-of-order, prefix/vlsm conflict, CSV output.

`cargo fmt`, `clippy --all-targets --all-features -D warnings`, and the full test suite pass (the unrelated `test_postgres_backend` requires a live DB and is environmental). Verified live against a running `netcidr serve` instance.

## Out of scope (follow-up PR)

Hierarchical / recursive splitting (`--steps`), per the phasing in #205.

Closes part of #205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)