### PR TITLE
chore: release v0.26.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.4](https://github.com/wingnut128/netcidr/compare/v0.26.3...v0.26.4) - 2026-05-29
+
+### Added
+
+- *(dashboard)* admin Users page for role-email management ([#215](https://github.com/wingnut128/netcidr/pull/215)) ([#217](https://github.com/wingnut128/netcidr/pull/217))
+- *(rbac)* move role-email membership to DB with env bootstrap ([#216](https://github.com/wingnut128/netcidr/pull/216))
+- *(dashboard)* admin Activity tab for audit visibility ([#214](https://github.com/wingnut128/netcidr/pull/214))
+- *(audit)* per-user/per-PAT audit filtering + admin CLI + token last-used ([#213](https://github.com/wingnut128/netcidr/pull/213))
+- *(ipam)* hostname pointers HTTP API + MCP tools ([#211](https://github.com/wingnut128/netcidr/pull/211))
+- *(ipam)* hostname pointers with append-only change history ([#210](https://github.com/wingnut128/netcidr/pull/210))
+- *(split)* hierarchical (recursive) subnet splitting ([#208](https://github.com/wingnut128/netcidr/pull/208))
+- *(split)* VLSM variable-length subnet allocation ([#206](https://github.com/wingnut128/netcidr/pull/206))
+
 ### Added
 
 - **Runtime role-email management (env → DB).** Role membership now lives in a global `role_assignments` table (migration 011, both backends) instead of env-vars-only, so RBAC changes survive restarts and need no redeploy. Managed via `netcidr admin user grant <email> --role reader|allocator|admin` / `revoke` / `list`, and `GET/POST/DELETE /admin/users` (Admin-gated). Role resolution (`AuthConfig::role_for_email`) now reads the DB per request (with an in-memory env fallback for bearer-only/non-IPAM deploys). Env lists (`NETCIDR_ADMIN_EMAILS` etc.) become a **first-start bootstrap seed only** — seeded once when the table is empty, ignored thereafter. Guards prevent revoking the last remaining admin or your own admin; every grant/revoke is audited (`entity_type=role_assignment`, visible in the Activity view). Roles are global; data stays tenant-isolated separately. See ADR-0003. An admin-only **Users** dashboard page (`/#/admin/users`) lists assignments and grants/revokes roles via the `/admin/users` API, surfacing the last-admin/self-revoke guards inline — completing [#215](https://github.com/wingnut128/netcidr/issues/215).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "netcidr"
-version = "0.26.3"
+version = "0.26.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netcidr"
-version = "0.26.3"
+version = "0.26.4"
 edition = "2024"
 license = "MIT"
 description = "A fast IPv4 and IPv6 subnet calculator CLI and API"


### PR DESCRIPTION



## 🤖 New release

* `netcidr`: 0.26.3 -> 0.26.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.26.4](https://github.com/wingnut128/netcidr/compare/v0.26.3...v0.26.4) - 2026-05-29

### Added

- *(dashboard)* admin Users page for role-email management ([#215](https://github.com/wingnut128/netcidr/pull/215)) ([#217](https://github.com/wingnut128/netcidr/pull/217))
- *(rbac)* move role-email membership to DB with env bootstrap ([#216](https://github.com/wingnut128/netcidr/pull/216))
- *(dashboard)* admin Activity tab for audit visibility ([#214](https://github.com/wingnut128/netcidr/pull/214))
- *(audit)* per-user/per-PAT audit filtering + admin CLI + token last-used ([#213](https://github.com/wingnut128/netcidr/pull/213))
- *(ipam)* hostname pointers HTTP API + MCP tools ([#211](https://github.com/wingnut128/netcidr/pull/211))
- *(ipam)* hostname pointers with append-only change history ([#210](https://github.com/wingnut128/netcidr/pull/210))
- *(split)* hierarchical (recursive) subnet splitting ([#208](https://github.com/wingnut128/netcidr/pull/208))
- *(split)* VLSM variable-length subnet allocation ([#206](https://github.com/wingnut128/netcidr/pull/206))

### Added

- **Runtime role-email management (env → DB).** Role membership now lives in a global `role_assignments` table (migration 011, both backends) instead of env-vars-only, so RBAC changes survive restarts and need no redeploy. Managed via `netcidr admin user grant <email> --role reader|allocator|admin` / `revoke` / `list`, and `GET/POST/DELETE /admin/users` (Admin-gated). Role resolution (`AuthConfig::role_for_email`) now reads the DB per request (with an in-memory env fallback for bearer-only/non-IPAM deploys). Env lists (`NETCIDR_ADMIN_EMAILS` etc.) become a **first-start bootstrap seed only** — seeded once when the table is empty, ignored thereafter. Guards prevent revoking the last remaining admin or your own admin; every grant/revoke is audited (`entity_type=role_assignment`, visible in the Activity view). Roles are global; data stays tenant-isolated separately. See ADR-0003. An admin-only **Users** dashboard page (`/#/admin/users`) lists assignments and grants/revokes roles via the `/admin/users` API, surfacing the last-admin/self-revoke guards inline — completing [#215](https://github.com/wingnut128/netcidr/issues/215).

- **Audit visibility — per-user / per-PAT filtering + PAT last-used in CLI.** The audit log can now be filtered by caller email and PAT id: `AuditFilter` gains `caller_email`/`pat_id`, honored by both store backends (with new `(tenant_id, caller_email)` and `(tenant_id, pat_id)` indexes, migration 010) and the `GET /ipam/audit` endpoint (`?caller_email=&pat_id=`). New `netcidr admin` command group with `admin audit --user <email> --pat-id <id> --entity-type --action --limit`. `netcidr token list` now shows a **Last used** column (text + CSV; JSON and the dashboard already had it). A new admin-only **Activity** dashboard tab shows recent audited mutations grouped by day, with a filter-by-user box and per-day write/admin counts. Closes [#212](https://github.com/wingnut128/netcidr/issues/212). Audit retention is tracked separately.

- **IPAM hostname pointers with change history.** Record which hostname(s) live at an IP and track every change over time. `netcidr ipam hostname set <ip> <fqdn>` (create/update), `get <ip>`, `list`, `history <ip|hostname>`, and `delete <ip> <hostname>`. Many-to-many (an IP can carry several names; a name can move between IPs), hostnames RFC 1123-validated and lowercased, IPs canonicalized. Deletes are hard but preserved in a dedicated append-only `hostname_pointer_history` table capturing actor, timestamp, and before/after snapshots — so the assignment period of each pair is reconstructable. Tenant-scoped in both the SQLite and Postgres backends (schema migration 009). Exposed via CLI (`netcidr ipam hostname …`), REST API (`POST`/`GET`/`DELETE /ipam/hostnames` + `GET /ipam/hostnames/history`, role-gated), and MCP tools (`ipam_hostname_set`/`_list`/`_history`/`_delete`, local + remote backends). Closes [#209](https://github.com/wingnut128/netcidr/issues/209).
- **VLSM (variable-length) subnet splitting.** `netcidr split <cidr> --vlsm 26,28,28` carves a supernet into differently-sized sub-allocations in one pass, allocating each prefix greedily from the network address forward (Red Hat `ipcalc --split` style). Prefixes must be ordered largest-block-first (non-decreasing prefix length); out-of-order lists and allocations that overflow the supernet are rejected with a clear error naming the offending entry and the space remaining. Works for IPv4 and IPv6, across all four output formats (json/text/csv/yaml), and is exposed over HTTP at `GET /v4/vlsm` and `GET /v6/vlsm` (`?cidr=…&prefixes=26,28,28`). First phase of [#205](https://github.com/wingnut128/netcidr/issues/205); hierarchical/recursive splitting (`--steps`) follows in a second PR.
- **Hierarchical (recursive) subnet splitting.** `netcidr split <cidr> --steps 22,24` carves a supernet level-by-level into a tree — each step prefix is applied to every node of the level above it. Steps must be strictly increasing prefix lengths; the total tree size is bounded by the existing `MAX_GENERATED_SUBNETS` (1,000,000) guard. Text output renders an ASCII tree, CSV flattens with a `depth` column, JSON/YAML nest. Works for IPv4 and IPv6, over HTTP at `GET /v4/split-tree` and `GET /v6/split-tree` (`?cidr=…&steps=22,24`), and in the interactive TUI (a comma-separated list in the prefix field renders the tree). Second phase of [#205](https://github.com/wingnut128/netcidr/issues/205).
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).