### PR TITLE
test(ci): invoke prebuilt binary directly instead of `cargo run` (#226)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CI: integration tests no longer shell out to `cargo run`.** `tests/integration_tests.rs` invoked the binary via `cargo run` on every CLI call, so under nextest's parallel execution all 83 integration tests serialized on Cargo's build-directory file lock — stretching the `Format, Lint & Test` step to ~29 minutes (each integration test reported 60–240s+ in nextest's SLOW warnings). The helpers now invoke the prebuilt binary directly via `env!("CARGO_BIN_EXE_netcidr")`: no per-call dependency-graph walk, no build-lock contention, and the binary matches the test harness's feature set. Locally the full integration suite dropped from being the dominant cost to ~2s. ([#226](https://github.com/wingnut128/netcidr/issues/226))
+
 ## [0.26.5](https://github.com/wingnut128/netcidr/compare/v0.26.4...v0.26.5) - 2026-06-01
 
 ### Fixed

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,9 +1,16 @@
 use std::io::Write;
 use std::process::{Command, Stdio};
 
+/// Path to the binary under test. Cargo builds the `netcidr` bin (with the
+/// same feature set as the test harness) before running integration tests and
+/// exposes its path here. Invoking it directly avoids `cargo run`, which would
+/// re-walk the dependency graph and contend on Cargo's build-directory file
+/// lock on every call — under nextest's parallelism that serialized all 83
+/// integration tests and stretched the CI test step to ~29 minutes. (#226)
+const NETCIDR_BIN: &str = env!("CARGO_BIN_EXE_netcidr");
+
 fn run_netcidr(args: &[&str]) -> (String, String, bool) {
-    let output = Command::new("cargo")
-        .args(["run", "--quiet", "--"])
+    let output = Command::new(NETCIDR_BIN)
         .args(args)
         .output()
         .expect("Failed to run netcidr");
@@ -14,8 +21,7 @@ fn run_netcidr(args: &[&str]) -> (String, String, bool) {
 }
 
 fn run_netcidr_stdin(args: &[&str], input: &str) -> (String, String, bool) {
-    let mut child = Command::new("cargo")
-        .args(["run", "--quiet", "--"])
+    let mut child = Command::new(NETCIDR_BIN)
         .args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())


### PR DESCRIPTION
Closes #226.

## Problem

The `Format, Lint & Test` CI job takes ~30 min. Per-step timing shows it's **entirely the test step** (`cargo nextest run` ≈ 1738s; clippy `--all-targets --all-features` is only 88s — compilation is *not* the bottleneck). nextest's SLOW warnings show individual integration tests at 60–240s+:

```
SLOW [>240s] integration_tests test_admin_user_role_management
SLOW [>240s] integration_tests test_ipam_allocation_workflow
SLOW [>180s] integration_tests test_ipam_find_ip / test_ipam_cidr_block_lifecycle / ...
```

## Root cause

`run_netcidr` / `run_netcidr_stdin` invoked the binary via `Command::new("cargo").args(["run","--quiet","--"])` on **every** CLI call. Under nextest's parallelism, the 83 integration tests' `cargo run` processes all hit `target/` at once and **serialize on Cargo's build-directory file lock** ("Blocking waiting for file lock on build directory"). Each call also re-walks the dependency graph and builds a *separate* default-feature binary distinct from the `mcp,tui` test harness. (In-process unit/`api_tests` ran in ~0.02s — only the `cargo run` tests were slow.)

## Fix

Invoke the prebuilt binary directly via `env!("CARGO_BIN_EXE_netcidr")` — the path Cargo exposes to integration tests, built with the harness's feature set. No cargo invocation, no graph re-check, no build-lock contention.

## Measured

| | Before | After |
|---|---|---|
| `test_admin_user_role_management` | >240s (CI SLOW) | **1.54s** |
| Full `integration_tests` suite (local, `cargo test`) | dominant cost | **2.17s** (83 passed) |

This PR's own CI run is the before/after proof — the `Format, Lint & Test` step should drop from ~29 min to a few minutes. No behavior change to the tests themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)