### PR TITLE
chore: release v0.26.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.7](https://github.com/wingnut128/netcidr/compare/v0.26.6...v0.26.7) - 2026-06-01
+
+### Added
+
+- *(dashboard)* hostname pointers page (set/list/history/delete) ([#228](https://github.com/wingnut128/netcidr/pull/228)) ([#229](https://github.com/wingnut128/netcidr/pull/229))
+
 ### Added
 
 - **Dashboard Hostnames page.** Hostname pointers (shipped headless in the CLI/API/MCP) now have a dashboard UI at `/#/hostnames`: list current IP↔hostname pointers with filter-by-IP / filter-by-hostname, a set form (IP + hostname + optional allocation id / notes; create-or-update), per-row delete, and a per-pointer **History** modal showing the append-only change trail (create/update/delete, actor, timestamp). Visible whenever IPAM is enabled; reads need Reader and set/delete need Allocator, with the backend's role/validation errors surfaced inline. Completes the dashboard half of the hostname-pointers feature ([#228](https://github.com/wingnut128/netcidr/issues/228)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "netcidr"
-version = "0.26.6"
+version = "0.26.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netcidr"
-version = "0.26.6"
+version = "0.26.7"
 edition = "2024"
 license = "MIT"
 description = "A fast IPv4 and IPv6 subnet calculator CLI and API"


### PR DESCRIPTION



## 🤖 New release

* `netcidr`: 0.26.6 -> 0.26.7

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.26.7](https://github.com/wingnut128/netcidr/compare/v0.26.6...v0.26.7) - 2026-06-01

### Added

- *(dashboard)* hostname pointers page (set/list/history/delete) ([#228](https://github.com/wingnut128/netcidr/pull/228)) ([#229](https://github.com/wingnut128/netcidr/pull/229))

### Added

- **Dashboard Hostnames page.** Hostname pointers (shipped headless in the CLI/API/MCP) now have a dashboard UI at `/#/hostnames`: list current IP↔hostname pointers with filter-by-IP / filter-by-hostname, a set form (IP + hostname + optional allocation id / notes; create-or-update), per-row delete, and a per-pointer **History** modal showing the append-only change trail (create/update/delete, actor, timestamp). Visible whenever IPAM is enabled; reads need Reader and set/delete need Allocator, with the backend's role/validation errors surfaced inline. Completes the dashboard half of the hostname-pointers feature ([#228](https://github.com/wingnut128/netcidr/issues/228)).
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).