### PR TITLE
fix(deps): bump rand to 0.8.6 to clear GHSA-cq8v-f236-94qc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Bump `rand` from 0.8.5 to 0.8.6 to clear [GHSA-cq8v-f236-94qc](https://github.com/advisories/GHSA-cq8v-f236-94qc) (rand is unsound with a custom logger using `rand::rng()`). 0.8.6 is an API-identical soundness patch — no source changes. Direct `rand = "0.8.6"` bump plus a `--precise` lockfile update; transitive consumers (jsonwebtoken, num-bigint-dig via rsa) resolve up automatically.
+
 ## [0.26.7](https://github.com/wingnut128/netcidr/compare/v0.26.6...v0.26.7) - 2026-06-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,7 +1959,7 @@ dependencies = [
  "p256",
  "p384",
  "pem",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "serde_json",
@@ -2285,7 +2285,7 @@ dependencies = [
  "proptest",
  "r2d2",
  "r2d2_sqlite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "ratatui",
  "regex",
  "reqwest 0.13.4",
@@ -2387,7 +2387,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -2708,7 +2708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3019,9 +3019,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ schemars = { version = "1", optional = true }
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "query"] }
 jsonwebtoken = { version = "10.4", features = ["rust_crypto"] }
 base64 = "0.22"
-rand = "0.8"
+rand = "0.8.6"
 regex = "1"
 ratatui = { version = "0.30", optional = true }
 crossterm = { version = "0.29", optional = true }


### PR DESCRIPTION
Remediates Dependabot alert #9 — [GHSA-cq8v-f236-94qc](https://github.com/advisories/GHSA-cq8v-f236-94qc).

## What

- `rand` 0.8.5 is unsound when a custom logger calls `rand::rng()`. Vulnerable range `>=0.7.0,<0.8.6`; patched in **0.8.6**.
- netcidr directly declares `rand = "0.8"` (resolved 0.8.5). Bumped to `rand = "0.8.6"` and ran `cargo update -p rand@0.8.5 --precise 0.8.6` to update the lockfile.
- 0.8.6 is **API-identical** to 0.8.5 (soundness patch only) — `src/auth.rs` (`thread_rng()`) and `src/pat.rs` (`RngCore` / `OsRng`) are unchanged. No source changes.
- Transitive pullers (jsonwebtoken 10.4.0, num-bigint-dig via rsa) use `^0.8` and resolve up to 0.8.6 automatically. `cargo tree -i rand@0.8.5` now matches nothing.

## Verification

- `cargo build`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`: clean
- `cargo test`: all pass, 0 failures

No version bump (batched under `[Unreleased]` Security). No README change (no user-facing behaviour change).

Closes #239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)