### PR TITLE
chore: release v0.26.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.8](https://github.com/wingnut128/netcidr/compare/v0.26.7...v0.26.8) - 2026-06-08
+
+### Fixed
+
+- *(deps)* bump rand to 0.8.6 to clear GHSA-cq8v-f236-94qc ([#240](https://github.com/wingnut128/netcidr/pull/240))
+- patch react-router-dom DoS vuln and bump opentelemetry group to 0.32 ([#238](https://github.com/wingnut128/netcidr/pull/238))
+
 ### Security
 
 - Bump `rand` from 0.8.5 to 0.8.6 to clear [GHSA-cq8v-f236-94qc](https://github.com/advisories/GHSA-cq8v-f236-94qc) (rand is unsound with a custom logger using `rand::rng()`). 0.8.6 is an API-identical soundness patch — no source changes. Direct `rand = "0.8.6"` bump plus a `--precise` lockfile update; transitive consumers (jsonwebtoken, num-bigint-dig via rsa) resolve up automatically.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "netcidr"
-version = "0.26.7"
+version = "0.26.8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netcidr"
-version = "0.26.7"
+version = "0.26.8"
 edition = "2024"
 license = "MIT"
 description = "A fast IPv4 and IPv6 subnet calculator CLI and API"


### PR DESCRIPTION



## 🤖 New release

* `netcidr`: 0.26.7 -> 0.26.8

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.26.8](https://github.com/wingnut128/netcidr/compare/v0.26.7...v0.26.8) - 2026-06-08

### Fixed

- *(deps)* bump rand to 0.8.6 to clear GHSA-cq8v-f236-94qc ([#240](https://github.com/wingnut128/netcidr/pull/240))
- patch react-router-dom DoS vuln and bump opentelemetry group to 0.32 ([#238](https://github.com/wingnut128/netcidr/pull/238))

### Security

- Bump `rand` from 0.8.5 to 0.8.6 to clear [GHSA-cq8v-f236-94qc](https://github.com/advisories/GHSA-cq8v-f236-94qc) (rand is unsound with a custom logger using `rand::rng()`). 0.8.6 is an API-identical soundness patch — no source changes. Direct `rand = "0.8.6"` bump plus a `--precise` lockfile update; transitive consumers (jsonwebtoken, num-bigint-dig via rsa) resolve up automatically.
### Changed

- Bump `react-router-dom` from 7.14.2 to 7.17.0 in the dashboard, fixing high-severity DoS vulnerability GHSA-8x6r-g9mw-2r78
- Bump `opentelemetry`, `opentelemetry_sdk`, `opentelemetry-otlp` from 0.31 to 0.32 and `tracing-opentelemetry` from 0.32 to 0.33; adapt `RedactingExporter::shutdown` and `force_flush` to the new `&self` receiver required by `SpanExporter` 0.32
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).