### PR TITLE
feat: add docker-push/docker-login just recipes for registry publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `just docker-push` and `just docker-login` recipes for publishing the Docker image. `docker-push` pushes both the `:<version>` and `:latest` tags; the registry target is the `docker_image` just variable (default `netcidr`), overridable on the command line (e.g. `just docker_image=ghcr.io/you/netcidr docker-push`). `docker-login` is a Cloudsmith convenience that authenticates using `CLOUDSMITH_API_KEY` (and optional `CLOUDSMITH_USER`, default `token`) from the environment via stdin.
+
 ## [0.26.8](https://github.com/wingnut128/netcidr/compare/v0.26.7...v0.26.8) - 2026-06-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -651,6 +651,37 @@ curl http://localhost:8080/health
 If you need compose-level ordering, use `depends_on: { condition: service_started }` rather than
 `service_healthy`.
 
+### Publishing to a registry
+
+`just docker` builds the image tagged `netcidr:<version>` and `netcidr:latest` by default. To publish
+to a registry, override the `docker_image` variable on the command line (it's a plain just variable —
+no need to edit the justfile) and point it at your repository:
+
+```bash
+# Build both :<version> and :latest under your registry path
+just docker_image=ghcr.io/you/netcidr docker
+just docker_image=ghcr.io/you/netcidr docker-push
+```
+
+`just docker-push` pushes both the `:<version>` and `:latest` tags. Authenticate first with your
+registry's normal `docker login`.
+
+**Cloudsmith example.** The maintainer publishes to Cloudsmith
+(`docker.cloudsmith.io/cloudreaper/artifacts/netcidr`); `just docker-login` automates that login:
+
+```bash
+export CLOUDSMITH_API_KEY=...        # inject via your secrets manager, e.g. `op run -- just docker-push`
+just docker-login                    # Cloudsmith uses username `token` + your API key as the password
+
+img=docker.cloudsmith.io/cloudreaper/artifacts/netcidr
+just docker_image=$img docker
+just docker_image=$img docker-push
+```
+
+`docker-login` reads `CLOUDSMITH_API_KEY` (and optional `CLOUDSMITH_USER`, default `token`) from the
+environment and pipes the secret via `--password-stdin` — nothing is interpolated into the recipe or
+echoed to the terminal.
+
 For Kubernetes, use an `httpGet` probe against `/health` on port 8080 for both liveness and readiness:
 
 ```yaml

--- a/justfile
+++ b/justfile
@@ -118,6 +118,15 @@ docker:
 docker-run:
     docker run --rm -p 8080:8080 {{docker_image}}:latest serve --address 0.0.0.0
 
+# Log in to the Cloudsmith registry (reads CLOUDSMITH_API_KEY / CLOUDSMITH_USER from the env)
+docker-login:
+    @printf '%s' "$CLOUDSMITH_API_KEY" | docker login docker.cloudsmith.io -u "${CLOUDSMITH_USER:-token}" --password-stdin
+
+# Push Docker image to registry (both :<version> and :latest tags)
+docker-push:
+    docker push {{docker_image}}:{{docker_tag}}
+    docker push {{docker_image}}:latest
+
 # ──────────────────────────────── Install ───────────────────────────────
 
 # Install binary locally (default features: swagger)


### PR DESCRIPTION
## Summary

Adds just recipes for publishing the Docker image to a container registry, with a generic default so the repo carries no org-specific configuration.

## Changes

- **`just docker-push`** — pushes both the `:<version>` and `:latest` tags.
- **`just docker-login`** — Cloudsmith convenience login: reads `CLOUDSMITH_API_KEY` (and optional `CLOUDSMITH_USER`, default `token`) from the environment and authenticates via `--password-stdin`. The secret is never interpolated into the recipe or echoed to the terminal.
- The registry target is the `docker_image` just variable, defaulting to the generic **`netcidr`**. Override on the command line rather than editing the justfile, e.g. `just docker_image=ghcr.io/you/netcidr docker-push`.

## Docs

- README Docker section gains a **Publishing to a registry** subsection — generic override pattern first, Cloudsmith shown as a labeled maintainer example.
- CHANGELOG `[Unreleased]` updated.

## Notes

No secrets are committed; the API key only ever comes from the environment (e.g. `op run -- just docker-push`).

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)