### PR TITLE
chore: release v0.26.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.10](https://github.com/wingnut128/netcidr/compare/v0.26.9...v0.26.10) - 2026-06-17
+
+### Added
+
+- *(ipam)* add tenant_id to allocation_tags for defense-in-depth isolation ([#266](https://github.com/wingnut128/netcidr/pull/266))
+- *(ipam)* paginate list endpoints and cap audit limit ([#265](https://github.com/wingnut128/netcidr/pull/265))
+
+### Fixed
+
+- *(ipam)* restrict SQLite DB perms to 0600 and cap auto-allocate count ([#264](https://github.com/wingnut128/netcidr/pull/264))
+- *(mcp)* encode remote-client URLs and send bearer token ([#257](https://github.com/wingnut128/netcidr/pull/257))
+- *(mcp)* refuse non-loopback HTTP bind without --allow-public-bind ([#255](https://github.com/wingnut128/netcidr/pull/255))
+- *(dashboard)* bump vite 8.0.10 -> 8.0.16 to clear GHSA-fx2h-pf6j-xcff ([#256](https://github.com/wingnut128/netcidr/pull/256))
+
+### Other
+
+- *(deps)* bump the npm-minor-and-patch group in /dashboard with 7 updates ([#249](https://github.com/wingnut128/netcidr/pull/249))
+- remove S3-backed SQLite persistence for Lambda ([#258](https://github.com/wingnut128/netcidr/pull/258))
+- *(deps)* bump release-plz/action from 0.5.129 to 0.5.130 ([#248](https://github.com/wingnut128/netcidr/pull/248))
+- *(dashboard)* pin npm deps to exact versions and harden install config ([#247](https://github.com/wingnut128/netcidr/pull/247))
+
 ### Added
 
 - Pagination for the IPAM list endpoints. `GET /ipam/cidr-blocks`, `GET /ipam/cidr-blocks/{id}/allocations`, `GET /ipam/hostnames`, and `GET /ipam/hostnames/history` now accept `limit` and `offset` query params, applied as SQL `LIMIT`/`OFFSET` (SQLite and Postgres). The HTTP layer defaults `limit` to 100 and clamps it to a maximum of 1000, bounding response size and memory; CLI and internal callers remain unbounded ([#260](https://github.com/wingnut128/netcidr/issues/260)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "netcidr"
-version = "0.26.9"
+version = "0.26.10"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netcidr"
-version = "0.26.9"
+version = "0.26.10"
 edition = "2024"
 license = "MIT"
 description = "A fast IPv4 and IPv6 subnet calculator CLI and API"


### PR DESCRIPTION



## 🤖 New release

* `netcidr`: 0.26.9 -> 0.26.10

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.26.10](https://github.com/wingnut128/netcidr/compare/v0.26.9...v0.26.10) - 2026-06-17

### Added

- *(ipam)* add tenant_id to allocation_tags for defense-in-depth isolation ([#266](https://github.com/wingnut128/netcidr/pull/266))
- *(ipam)* paginate list endpoints and cap audit limit ([#265](https://github.com/wingnut128/netcidr/pull/265))

### Fixed

- *(ipam)* restrict SQLite DB perms to 0600 and cap auto-allocate count ([#264](https://github.com/wingnut128/netcidr/pull/264))
- *(mcp)* encode remote-client URLs and send bearer token ([#257](https://github.com/wingnut128/netcidr/pull/257))
- *(mcp)* refuse non-loopback HTTP bind without --allow-public-bind ([#255](https://github.com/wingnut128/netcidr/pull/255))
- *(dashboard)* bump vite 8.0.10 -> 8.0.16 to clear GHSA-fx2h-pf6j-xcff ([#256](https://github.com/wingnut128/netcidr/pull/256))

### Other

- *(deps)* bump the npm-minor-and-patch group in /dashboard with 7 updates ([#249](https://github.com/wingnut128/netcidr/pull/249))
- remove S3-backed SQLite persistence for Lambda ([#258](https://github.com/wingnut128/netcidr/pull/258))
- *(deps)* bump release-plz/action from 0.5.129 to 0.5.130 ([#248](https://github.com/wingnut128/netcidr/pull/248))
- *(dashboard)* pin npm deps to exact versions and harden install config ([#247](https://github.com/wingnut128/netcidr/pull/247))

### Added

- Pagination for the IPAM list endpoints. `GET /ipam/cidr-blocks`, `GET /ipam/cidr-blocks/{id}/allocations`, `GET /ipam/hostnames`, and `GET /ipam/hostnames/history` now accept `limit` and `offset` query params, applied as SQL `LIMIT`/`OFFSET` (SQLite and Postgres). The HTTP layer defaults `limit` to 100 and clamps it to a maximum of 1000, bounding response size and memory; CLI and internal callers remain unbounded ([#260](https://github.com/wingnut128/netcidr/issues/260)).

### Removed

- Removed the S3-backed SQLite persistence mode for the Lambda binary (`NETCIDR_S3_BUCKET`/`NETCIDR_S3_KEY`, the `s3_sync` module, and the `hmac` dependency). The Lambda binary now uses the Postgres backend exclusively (`NETCIDR_DATABASE_URL`). This removes the attack surface behind the S3 sync finding — no integrity check on pull, no client-side encryption, and a symlink-unsafe local DB path ([#254](https://github.com/wingnut128/netcidr/issues/254)).

### Security

- **Harden dashboard package files (supply-chain).** Pinned every dashboard dependency in `dashboard/package.json` to an exact version (removed `^` caret ranges) matching the resolved `bun.lock`, so the manifest is the source of truth and nothing silently floats forward. Added a `packageManager` pin (`bun@1.3.14`) and an `engines` constraint, plus `dashboard/bunfig.toml` with `[install] exact = true` so future `bun add` invocations stay pinned. Lifecycle/postinstall scripts remain disabled by Bun's default (no `trustedDependencies`).
- Bump dashboard `vite` from 8.0.10 to 8.0.16, clearing high-severity advisory [GHSA-fx2h-pf6j-xcff](https://github.com/advisories/GHSA-fx2h-pf6j-xcff) (`server.fs.deny` bypass via Windows alternate paths). The dev server isn't shipped in the embedded single-file build, but the bump unblocks the CI `bun audit` gate.
- The MCP HTTP transport now refuses to bind to a non-loopback address unless the new `--allow-public-bind` flag is passed. The HTTP transport has no authentication, so a non-loopback bind previously exposed every IPAM tool (read and write) to any reachable client. The default bind (`127.0.0.1`) is unaffected; operators who intentionally front the server with their own auth (reverse proxy, network policy) can opt back in with `--allow-public-bind` ([#252](https://github.com/wingnut128/netcidr/issues/252)).
- The MCP remote IPAM client (`mcp-serve --api-url`) now percent-encodes caller-controlled path segments and builds query strings via the request builder, so an `id`/`resource_id`/`address` containing `/`, `?`, or `#` can no longer inject extra path segments or a query string into the upstream request. It also sends a bearer token via the new `--api-token` flag (or `NETCIDR_API_TOKEN`), letting the remote `netcidr serve` enforce authentication instead of running open; the token header is marked sensitive so it is redacted from logs ([#253](https://github.com/wingnut128/netcidr/issues/253)).
- The SQLite IPAM database file is now created with owner-only (`0600`) permissions on Unix, instead of inheriting the umask (typically world-readable `0644`). The database holds all CIDR blocks, allocations, hostnames, and the audit log ([#261](https://github.com/wingnut128/netcidr/issues/261)).
- Auto-allocate now rejects a `count` above 1000 at both the CLI (`--count` value range) and the operations layer (covering the HTTP API), preventing an unbounded number of allocation writes from a single request ([#263](https://github.com/wingnut128/netcidr/issues/263)).
- The IPAM list endpoints now bound their result sets via `limit`/`offset` pagination (default 100, max 1000), and the audit endpoint (`GET /ipam/audit`) defaults and clamps its `limit` so omitting it can no longer dump the entire audit log ([#260](https://github.com/wingnut128/netcidr/issues/260)).
- `allocation_tags` now carries a `tenant_id` column (migration 012, SQLite + Postgres) — backfilled from the parent allocation, filtered on in tag reads/writes, and enforced by a tenant-match trigger. Previously cross-tenant tag isolation rested solely on an application-layer pre-check plus UUID unguessability; this adds DB-level defense-in-depth consistent with the other tenant-scoped tables ([#262](https://github.com/wingnut128/netcidr/issues/262)).
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).