### PR TITLE
chore: release v0.26.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.9](https://github.com/wingnut128/netcidr/compare/v0.26.8...v0.26.9) - 2026-06-08
+
 ### Added
 
 - `just docker-push` and `just docker-login` recipes for publishing the Docker image. `docker-push` pushes both the `:<version>` and `:latest` tags; the registry target is the `docker_image` just variable (default `netcidr`), overridable on the command line (e.g. `just docker_image=ghcr.io/you/netcidr docker-push`). `docker-login` is a Cloudsmith convenience that authenticates using `CLOUDSMITH_API_KEY` (and optional `CLOUDSMITH_USER`, default `token`) from the environment via stdin.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "netcidr"
-version = "0.26.8"
+version = "0.26.9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netcidr"
-version = "0.26.8"
+version = "0.26.9"
 edition = "2024"
 license = "MIT"
 description = "A fast IPv4 and IPv6 subnet calculator CLI and API"


### PR DESCRIPTION
## Release v0.26.9

Cuts a patch release for the Docker publishing recipes merged in #243.

### Changes
- Bump `version` to `0.26.9` in `Cargo.toml` (and `Cargo.lock`).
- Move the `just docker-push` / `docker-login` CHANGELOG entry from `[Unreleased]` into a dated `[0.26.9]` section.

### Notes
- Patch bump: the change is build/publish tooling only — no runtime, API, or CLI behavior ships to users. Minor stays `.26`, so `SECURITY.md` needs no update.
- Merging this to `main` auto-triggers the Release workflow (the `detect` job sees the version bump and tags `v0.26.9`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)