### PR TITLE
fix(mcp): refuse non-loopback HTTP bind without --allow-public-bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Harden dashboard package files (supply-chain).** Pinned every dashboard dependency in `dashboard/package.json` to an exact version (removed `^` caret ranges) matching the resolved `bun.lock`, so the manifest is the source of truth and nothing silently floats forward. Added a `packageManager` pin (`bun@1.3.14`) and an `engines` constraint, plus `dashboard/bunfig.toml` with `[install] exact = true` so future `bun add` invocations stay pinned. Lifecycle/postinstall scripts remain disabled by Bun's default (no `trustedDependencies`).
 - Bump dashboard `vite` from 8.0.10 to 8.0.16, clearing high-severity advisory [GHSA-fx2h-pf6j-xcff](https://github.com/advisories/GHSA-fx2h-pf6j-xcff) (`server.fs.deny` bypass via Windows alternate paths). The dev server isn't shipped in the embedded single-file build, but the bump unblocks the CI `bun audit` gate.
+- The MCP HTTP transport now refuses to bind to a non-loopback address unless the new `--allow-public-bind` flag is passed. The HTTP transport has no authentication, so a non-loopback bind previously exposed every IPAM tool (read and write) to any reachable client. The default bind (`127.0.0.1`) is unaffected; operators who intentionally front the server with their own auth (reverse proxy, network policy) can opt back in with `--allow-public-bind` ([#252](https://github.com/wingnut128/netcidr/issues/252)).
 
 ## [0.26.9](https://github.com/wingnut128/netcidr/compare/v0.26.8...v0.26.9) - 2026-06-08
 

--- a/README.md
+++ b/README.md
@@ -309,8 +309,11 @@ just build-mcp
 # Start MCP server (Streamable HTTP on 127.0.0.1:3000)
 netcidr mcp-serve
 
-# Custom address and port
-netcidr mcp-serve --address 0.0.0.0 --port 4000
+# Custom port (loopback)
+netcidr mcp-serve --port 4000
+
+# Bind to a non-loopback address (see security note below — requires opt-in)
+netcidr mcp-serve --address 0.0.0.0 --port 4000 --allow-public-bind
 
 # Use stdio transport (for pipe-based clients like Claude Code)
 netcidr mcp-serve --transport stdio
@@ -322,6 +325,8 @@ netcidr mcp-serve --api-url http://localhost:8080
 # Run as a background daemon
 netcidr mcp-serve --daemonize --pid-file /var/run/netcidr-mcp.pid --log-file /var/log/netcidr-mcp.log
 ```
+
+> **Security:** the MCP HTTP transport has **no authentication** — any client that can reach the port can call every tool, including read/write IPAM operations. It therefore binds to loopback (`127.0.0.1`) by default and **refuses non-loopback binds** unless you pass `--allow-public-bind`. Only opt in when you have placed your own authentication in front of it (e.g. a reverse proxy or network policy). The `stdio` transport is unaffected (it runs under the parent process).
 
 #### Running as a Service
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -113,6 +113,14 @@ pub enum Commands {
         #[arg(short, long, default_value = "3000")]
         port: u16,
 
+        /// Allow the HTTP transport to bind to a non-loopback address.
+        ///
+        /// The MCP HTTP transport has no authentication; by default a
+        /// non-loopback bind is refused. Only set this when you have placed
+        /// your own auth (reverse proxy, network policy) in front of it.
+        #[arg(long)]
+        allow_public_bind: bool,
+
         /// Run as a background daemon (HTTP transport only)
         #[arg(long)]
         daemonize: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -372,7 +372,7 @@ fn resolve_email_list(env_var: &str, fallback: &[String]) -> Vec<String> {
     raw.into_iter().map(|s| s.to_ascii_lowercase()).collect()
 }
 
-fn is_loopback_bind_address(bind_address: &str) -> Result<bool> {
+pub(crate) fn is_loopback_bind_address(bind_address: &str) -> Result<bool> {
     let trimmed = bind_address.trim();
     let host = trimmed
         .strip_prefix('[')

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,11 +100,19 @@ fn main() {
         ref pid_file,
         ref log_file,
         ref transport,
+        ref address,
+        allow_public_bind,
         ..
     }) = cli.command
     {
         if *transport == netcidr::cli::McpTransport::Stdio {
             eprintln!("Error: --daemonize is only supported with HTTP transport");
+            std::process::exit(1);
+        }
+        // Fail closed before forking so the operator sees the error on the
+        // controlling terminal rather than a daemon that silently exits.
+        if let Err(e) = netcidr::mcp::check_http_bind_allowed(address, allow_public_bind) {
+            eprintln!("Error: {}", e);
             std::process::exit(1);
         }
         if let Err(e) = netcidr::mcp::daemonize_process(pid_file, log_file.as_deref()) {
@@ -295,6 +303,7 @@ async fn async_main(cli: Cli) {
             transport,
             address,
             port,
+            allow_public_bind,
             daemonize: _,
             pid_file,
             log_file,
@@ -305,6 +314,7 @@ async fn async_main(cli: Cli) {
                 transport,
                 address: &address,
                 port,
+                allow_public_bind,
                 // Daemonization already happened in main() before the tokio
                 // runtime was created, so we never daemonize inside the async
                 // context where it would corrupt the I/O reactor.

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -899,6 +899,30 @@ pub struct McpServerConfig<'a> {
     pub log_file: Option<&'a str>,
     pub ipam_db: Option<&'a str>,
     pub api_url: Option<&'a str>,
+    /// Allow the HTTP transport to bind to a non-loopback address.
+    ///
+    /// The MCP HTTP transport has no authentication, so by default we refuse
+    /// any non-loopback bind. Setting this acknowledges that the operator has
+    /// placed their own auth (e.g. a reverse proxy or network policy) in front.
+    pub allow_public_bind: bool,
+}
+
+/// Decide whether the MCP HTTP transport is allowed to bind to `address`.
+///
+/// The HTTP transport exposes every IPAM tool with no authentication, so a
+/// non-loopback bind means anyone who can reach the port gets full IPAM
+/// access. We therefore fail closed: a non-loopback address is rejected unless
+/// `allow_public_bind` is set. Mirrors `config::validate_deployment`'s gate.
+pub fn check_http_bind_allowed(address: &str, allow_public_bind: bool) -> crate::error::Result<()> {
+    if crate::config::is_loopback_bind_address(address)? || allow_public_bind {
+        return Ok(());
+    }
+    Err(crate::error::NetcidrError::InvalidInput(format!(
+        "refusing to start the MCP HTTP server on non-loopback address '{address}': \
+         the MCP HTTP transport has no authentication, so anyone who can reach it gains \
+         full IPAM access. Bind to a loopback address (127.0.0.1 or ::1), or pass \
+         --allow-public-bind to override once you have your own auth in front."
+    )))
 }
 
 pub async fn run_mcp_server(config: McpServerConfig<'_>) -> crate::error::Result<()> {
@@ -930,6 +954,9 @@ pub async fn run_mcp_server(config: McpServerConfig<'_>) -> crate::error::Result
             run_mcp_stdio(ipam).await
         }
         crate::cli::McpTransport::Http => {
+            // Fail closed before any side effects (daemonizing, binding) if the
+            // unauthenticated HTTP transport would be exposed beyond loopback.
+            check_http_bind_allowed(config.address, config.allow_public_bind)?;
             if config.daemonize {
                 daemonize_process(config.pid_file, config.log_file)?;
             }
@@ -1022,6 +1049,45 @@ mod tests {
     // -------------------------------------------------------------------
     // Calculator tool tests
     // -------------------------------------------------------------------
+
+    #[test]
+    fn http_bind_allows_loopback_without_override() {
+        // Loopback binds are always allowed regardless of the override flag.
+        assert!(check_http_bind_allowed("127.0.0.1", false).is_ok());
+        assert!(check_http_bind_allowed("::1", false).is_ok());
+        assert!(check_http_bind_allowed("[::1]", false).is_ok());
+    }
+
+    #[test]
+    fn http_bind_refuses_public_without_override() {
+        // Non-loopback bind with no auth and no override must fail closed.
+        let err = check_http_bind_allowed("0.0.0.0", false)
+            .expect_err("non-loopback bind without override must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("0.0.0.0"),
+            "error should name the address: {msg}"
+        );
+        assert!(
+            msg.contains("--allow-public-bind"),
+            "error should point at the override: {msg}"
+        );
+
+        assert!(check_http_bind_allowed("192.168.1.10", false).is_err());
+    }
+
+    #[test]
+    fn http_bind_allows_public_with_override() {
+        // The explicit override lets an operator opt into a public bind.
+        assert!(check_http_bind_allowed("0.0.0.0", true).is_ok());
+        assert!(check_http_bind_allowed("192.168.1.10", true).is_ok());
+    }
+
+    #[test]
+    fn http_bind_rejects_unparseable_address() {
+        // An address we can't prove is loopback is rejected (mirrors `serve`).
+        assert!(check_http_bind_allowed("localhost", false).is_err());
+    }
 
     #[test]
     fn test_is_ipv6() {
@@ -1744,6 +1810,7 @@ mod tests {
             transport: crate::cli::McpTransport::Stdio,
             address: "127.0.0.1",
             port: 3000,
+            allow_public_bind: false,
             daemonize: false,
             pid_file: "/tmp/netcidr-test.pid",
             log_file: None,


### PR DESCRIPTION
Closes #252

## Problem

The MCP **HTTP** transport (`run_mcp_http`, `src/mcp.rs`) mounts every IPAM tool with **no authentication** — `Router::new().nest_service("/mcp", service)` has no auth middleware, and the local backend runs as a fixed `Tenant::LOCAL`. Binding to a non-loopback address therefore exposed full read/write IPAM access to any reachable client. The bind address was never checked, so `--address 0.0.0.0` silently opened the whole surface. (STRIDE finding E4 — Spoofing / Elevation-of-privilege.)

## Fix

Fail closed. The HTTP transport now refuses a non-loopback bind unless the new `--allow-public-bind` flag is set, mirroring `config::validate_deployment`'s loopback gate (the existing `is_loopback_bind_address` helper is reused, now `pub(crate)`).

- New `check_http_bind_allowed(address, allow_public_bind)` — pure, unit-tested; loopback always allowed, non-loopback requires the override, unparseable addresses rejected (consistent with `serve`).
- Gate runs in `run_mcp_server` before any bind, **and** before forking in the `--daemonize` path so the operator sees the error on the controlling terminal instead of a daemon that silently exits.
- New `--allow-public-bind` CLI flag on `mcp-serve`.

The default `127.0.0.1` bind and the **stdio** transport are unaffected. Operators who front the server with their own auth (reverse proxy / network policy) opt back in with `--allow-public-bind`.

## Scope note

This closes the immediate critical exposure. A **full MCP authentication layer** (so `--allow-public-bind` could be paired with real auth rather than operator-provided fronting) is larger and tracked as follow-up.

## Tests

- `http_bind_allows_loopback_without_override`
- `http_bind_refuses_public_without_override`
- `http_bind_allows_public_with_override`
- `http_bind_rejects_unparseable_address`

`cargo test --features mcp --lib` (369 tests) and `cargo clippy --features mcp -- -D warnings` pass. Manually verified: `--address 0.0.0.0` is rejected with a clear message; default loopback start binds normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)