### PR TITLE
feat(ipam): paginate list endpoints and cap audit limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Pagination for the IPAM list endpoints. `GET /ipam/cidr-blocks`, `GET /ipam/cidr-blocks/{id}/allocations`, `GET /ipam/hostnames`, and `GET /ipam/hostnames/history` now accept `limit` and `offset` query params, applied as SQL `LIMIT`/`OFFSET` (SQLite and Postgres). The HTTP layer defaults `limit` to 100 and clamps it to a maximum of 1000, bounding response size and memory; CLI and internal callers remain unbounded ([#260](https://github.com/wingnut128/netcidr/issues/260)).
+
 ### Removed
 
 - Removed the S3-backed SQLite persistence mode for the Lambda binary (`NETCIDR_S3_BUCKET`/`NETCIDR_S3_KEY`, the `s3_sync` module, and the `hmac` dependency). The Lambda binary now uses the Postgres backend exclusively (`NETCIDR_DATABASE_URL`). This removes the attack surface behind the S3 sync finding — no integrity check on pull, no client-side encryption, and a symlink-unsafe local DB path ([#254](https://github.com/wingnut128/netcidr/issues/254)).
@@ -19,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The MCP remote IPAM client (`mcp-serve --api-url`) now percent-encodes caller-controlled path segments and builds query strings via the request builder, so an `id`/`resource_id`/`address` containing `/`, `?`, or `#` can no longer inject extra path segments or a query string into the upstream request. It also sends a bearer token via the new `--api-token` flag (or `NETCIDR_API_TOKEN`), letting the remote `netcidr serve` enforce authentication instead of running open; the token header is marked sensitive so it is redacted from logs ([#253](https://github.com/wingnut128/netcidr/issues/253)).
 - The SQLite IPAM database file is now created with owner-only (`0600`) permissions on Unix, instead of inheriting the umask (typically world-readable `0644`). The database holds all CIDR blocks, allocations, hostnames, and the audit log ([#261](https://github.com/wingnut128/netcidr/issues/261)).
 - Auto-allocate now rejects a `count` above 1000 at both the CLI (`--count` value range) and the operations layer (covering the HTTP API), preventing an unbounded number of allocation writes from a single request ([#263](https://github.com/wingnut128/netcidr/issues/263)).
+- The IPAM list endpoints now bound their result sets via `limit`/`offset` pagination (default 100, max 1000), and the audit endpoint (`GET /ipam/audit`) defaults and clamps its `limit` so omitting it can no longer dump the entire audit log ([#260](https://github.com/wingnut128/netcidr/issues/260)).
 
 ## [0.26.9](https://github.com/wingnut128/netcidr/compare/v0.26.8...v0.26.9) - 2026-06-08
 

--- a/README.md
+++ b/README.md
@@ -946,6 +946,8 @@ netcidr serve --ipam-enabled --ipam-db /path/to/ipam.db
 | `/admin/users` | `POST` | Grant/update a role (Admin) |
 | `/admin/users` | `DELETE` | Revoke a role (`?email=`, Admin; last-admin guarded) |
 
+**Pagination:** the list endpoints (`/ipam/cidr-blocks`, `/ipam/cidr-blocks/{id}/allocations`, `/ipam/hostnames`, `/ipam/hostnames/history`) accept `?limit=&offset=`. `limit` defaults to 100 and is capped at 1000; `offset` defaults to 0. The audit endpoint (`/ipam/audit`) likewise defaults and caps its `limit`.
+
 **Status:** Fully integrated — available via CLI (`netcidr ipam`), REST API (`netcidr serve --ipam-enabled`), and MCP server (`netcidr mcp-serve --ipam-db <path>`).
 
 #### Idempotency keys

--- a/src/ipam/models.rs
+++ b/src/ipam/models.rs
@@ -164,6 +164,11 @@ pub struct AllocationFilter {
     pub resource_type: Option<String>,
     pub environment: Option<String>,
     pub owner: Option<String>,
+    /// Max rows to return. `None` means unbounded (CLI/internal callers);
+    /// the HTTP API always sets a clamped value.
+    pub limit: Option<u32>,
+    /// Rows to skip before returning results. `None` is treated as 0.
+    pub offset: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -597,6 +602,10 @@ pub struct HostnamePointerFilter {
     pub ip_address: Option<String>,
     pub hostname: Option<String>,
     pub allocation_id: Option<String>,
+    /// Max rows to return. `None` means unbounded (CLI/internal callers).
+    pub limit: Option<u32>,
+    /// Rows to skip before returning results. `None` is treated as 0.
+    pub offset: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -664,6 +673,10 @@ pub struct HostnamePointerHistoryEntry {
 pub struct HostnameHistoryFilter {
     pub ip_address: Option<String>,
     pub hostname: Option<String>,
+    /// Max rows to return. `None` means unbounded (CLI/internal callers).
+    pub limit: Option<u32>,
+    /// Rows to skip before returning results. `None` is treated as 0.
+    pub offset: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/ipam/operations.rs
+++ b/src/ipam/operations.rs
@@ -144,6 +144,19 @@ impl IpamOps {
         self.store.list_cidr_blocks(tenant_id).await
     }
 
+    /// Paginated cidr_block listing for the HTTP list endpoint. `limit`/`offset`
+    /// of `None` means unbounded (the API always passes clamped values).
+    pub async fn list_cidr_blocks_page(
+        &self,
+        tenant_id: &str,
+        limit: Option<u32>,
+        offset: Option<u32>,
+    ) -> Result<Vec<CidrBlock>> {
+        self.store
+            .list_cidr_blocks_page(tenant_id, limit, offset)
+            .await
+    }
+
     pub async fn delete_cidr_block(&self, tenant_id: &str, id: &str) -> Result<()> {
         validation::validate_identifier(id)?;
         let sn = self.store.get_cidr_block(tenant_id, id).await?;
@@ -1163,6 +1176,8 @@ impl IpamOps {
                 .map(validation::normalize_hostname)
                 .transpose()?,
             allocation_id: filter.allocation_id.clone(),
+            limit: filter.limit,
+            offset: filter.offset,
         };
         self.store
             .list_hostname_pointers(tenant_id, &normalized)
@@ -1220,6 +1235,8 @@ impl IpamOps {
                 .as_deref()
                 .map(validation::normalize_hostname)
                 .transpose()?,
+            limit: filter.limit,
+            offset: filter.offset,
         };
         self.store
             .list_hostname_history(tenant_id, &normalized)

--- a/src/ipam/postgres/mod.rs
+++ b/src/ipam/postgres/mod.rs
@@ -264,13 +264,26 @@ impl IpamStore for PostgresStore {
     }
 
     async fn list_cidr_blocks(&self, tenant_id: &str) -> Result<Vec<CidrBlock>> {
-        let rows = sqlx::query(
-            "SELECT id, tenant_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, name, description, ip_version, created_at, updated_at FROM cidr_blocks WHERE tenant_id = $1 ORDER BY created_at",
-        )
-        .bind(tenant_id)
-        .fetch_all(&self.pool)
-        .await
-        .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
+        self.list_cidr_blocks_page(tenant_id, None, None).await
+    }
+
+    async fn list_cidr_blocks_page(
+        &self,
+        tenant_id: &str,
+        limit: Option<u32>,
+        offset: Option<u32>,
+    ) -> Result<Vec<CidrBlock>> {
+        let mut builder = sqlx::QueryBuilder::<sqlx::Postgres>::new(
+            "SELECT id, tenant_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, name, description, ip_version, created_at, updated_at FROM cidr_blocks WHERE tenant_id = ",
+        );
+        builder.push_bind(tenant_id);
+        builder.push(" ORDER BY created_at");
+        builder.push(crate::ipam::store::limit_offset_clause(limit, offset));
+        let rows = builder
+            .build()
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
 
         Ok(rows
             .iter()
@@ -509,6 +522,10 @@ impl IpamStore for PostgresStore {
         }
 
         builder.push(" ORDER BY created_at");
+        builder.push(crate::ipam::store::limit_offset_clause(
+            filter.limit,
+            filter.offset,
+        ));
 
         let rows = builder
             .build()
@@ -823,6 +840,10 @@ impl IpamStore for PostgresStore {
             builder.push_bind(a.as_str());
         }
         builder.push(" ORDER BY hostname, ip_address");
+        builder.push(crate::ipam::store::limit_offset_clause(
+            filter.limit,
+            filter.offset,
+        ));
 
         let rows = builder
             .build()
@@ -916,6 +937,10 @@ impl IpamStore for PostgresStore {
             builder.push_bind(h.as_str());
         }
         builder.push(" ORDER BY changed_at");
+        builder.push(crate::ipam::store::limit_offset_clause(
+            filter.limit,
+            filter.offset,
+        ));
 
         let rows = builder
             .build()

--- a/src/ipam/sqlite/mod.rs
+++ b/src/ipam/sqlite/mod.rs
@@ -304,9 +304,22 @@ impl IpamStore for SqliteStore {
     }
 
     async fn list_cidr_blocks(&self, tenant_id: &str) -> Result<Vec<CidrBlock>> {
+        self.list_cidr_blocks_page(tenant_id, None, None).await
+    }
+
+    async fn list_cidr_blocks_page(
+        &self,
+        tenant_id: &str,
+        limit: Option<u32>,
+        offset: Option<u32>,
+    ) -> Result<Vec<CidrBlock>> {
         let conn = self.conn()?;
+        let sql = format!(
+            "SELECT id, tenant_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, name, description, ip_version, created_at, updated_at FROM cidr_blocks WHERE tenant_id = ?1 ORDER BY created_at{}",
+            crate::ipam::store::limit_offset_clause(limit, offset)
+        );
         let mut stmt = conn
-            .prepare("SELECT id, tenant_id, cidr, network_address, broadcast_address, prefix_length, total_hosts, name, description, ip_version, created_at, updated_at FROM cidr_blocks WHERE tenant_id = ?1 ORDER BY created_at")
+            .prepare(&sql)
             .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
         let rows = stmt
             .query_map(params![tenant_id], |row| {
@@ -535,6 +548,10 @@ impl IpamStore for SqliteStore {
         }
 
         sql.push_str(" ORDER BY created_at");
+        sql.push_str(&crate::ipam::store::limit_offset_clause(
+            filter.limit,
+            filter.offset,
+        ));
 
         let params_refs: Vec<&dyn rusqlite::types::ToSql> =
             param_values.iter().map(|p| p.as_ref()).collect();
@@ -869,6 +886,10 @@ impl IpamStore for SqliteStore {
             sql.push_str(&format!(" AND allocation_id = ?{}", binds.len()));
         }
         sql.push_str(" ORDER BY hostname, ip_address");
+        sql.push_str(&crate::ipam::store::limit_offset_clause(
+            filter.limit,
+            filter.offset,
+        ));
 
         let mut stmt = conn
             .prepare(&sql)
@@ -962,6 +983,10 @@ impl IpamStore for SqliteStore {
             sql.push_str(&format!(" AND hostname = ?{}", binds.len()));
         }
         sql.push_str(" ORDER BY changed_at");
+        sql.push_str(&crate::ipam::store::limit_offset_clause(
+            filter.limit,
+            filter.offset,
+        ));
 
         let mut stmt = conn
             .prepare(&sql)
@@ -1519,6 +1544,91 @@ mod tests {
         store.initialize().await.unwrap();
         store.migrate().await.unwrap();
         store
+    }
+
+    #[tokio::test]
+    async fn list_pagination_limits_and_offsets() {
+        let store = test_store().await;
+
+        // Three cidr_blocks (ordered by created_at).
+        for cidr in ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"] {
+            store
+                .create_cidr_block(
+                    TEST_TENANT,
+                    &CreateCidrBlock {
+                        cidr: cidr.to_string(),
+                        name: None,
+                        description: None,
+                    },
+                )
+                .await
+                .unwrap();
+        }
+
+        // Unbounded (None) returns all three.
+        assert_eq!(
+            store
+                .list_cidr_blocks_page(TEST_TENANT, None, None)
+                .await
+                .unwrap()
+                .len(),
+            3
+        );
+        // limit caps the page.
+        assert_eq!(
+            store
+                .list_cidr_blocks_page(TEST_TENANT, Some(2), None)
+                .await
+                .unwrap()
+                .len(),
+            2
+        );
+        // offset skips, so only the third remains.
+        assert_eq!(
+            store
+                .list_cidr_blocks_page(TEST_TENANT, Some(10), Some(2))
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+
+        // Allocations under the first block.
+        let block = &store.list_cidr_blocks(TEST_TENANT).await.unwrap()[0];
+        for i in 0..5u8 {
+            store
+                .create_allocation(
+                    TEST_TENANT,
+                    &CreateAllocation {
+                        cidr_block_id: block.id.clone(),
+                        cidr: format!("10.0.{i}.0/24"),
+                        status: None,
+                        resource_id: None,
+                        resource_type: None,
+                        name: None,
+                        description: None,
+                        environment: None,
+                        owner: None,
+                        parent_allocation_id: None,
+                        tags: None,
+                        ttl_seconds: None,
+                    },
+                )
+                .await
+                .unwrap();
+        }
+        let page = store
+            .list_allocations(
+                TEST_TENANT,
+                &AllocationFilter {
+                    cidr_block_id: Some(block.id.clone()),
+                    limit: Some(3),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(page.len(), 3, "limit must cap the allocation page");
     }
 
     #[cfg(unix)]

--- a/src/ipam/store.rs
+++ b/src/ipam/store.rs
@@ -3,6 +3,23 @@ use async_trait::async_trait;
 use crate::error::Result;
 use crate::ipam::models::*;
 
+/// Build a trailing `LIMIT … OFFSET …` SQL clause for a paginated list query.
+///
+/// `limit`/`offset` are `u32`, so the values are pure digits — formatting them
+/// directly into SQL carries no injection risk and keeps the clause backend
+/// agnostic (works for both the rusqlite and sqlx builders). `None`/`None`
+/// yields an empty string (unbounded, for CLI and internal callers); an offset
+/// without a limit uses `LIMIT -1` as SQLite/Postgres both require a limit
+/// before an offset.
+pub(crate) fn limit_offset_clause(limit: Option<u32>, offset: Option<u32>) -> String {
+    match (limit, offset) {
+        (Some(l), Some(o)) => format!(" LIMIT {l} OFFSET {o}"),
+        (Some(l), None) => format!(" LIMIT {l}"),
+        (None, Some(o)) => format!(" LIMIT -1 OFFSET {o}"),
+        (None, None) => String::new(),
+    }
+}
+
 /// Core storage abstraction for the IPAM persistence layer.
 ///
 /// All tenant-scoped methods take an explicit `tenant_id: &str` parameter so
@@ -24,6 +41,14 @@ pub trait IpamStore: Send + Sync {
     ) -> Result<CidrBlock>;
     async fn get_cidr_block(&self, tenant_id: &str, id: &str) -> Result<CidrBlock>;
     async fn list_cidr_blocks(&self, tenant_id: &str) -> Result<Vec<CidrBlock>>;
+    /// Like [`list_cidr_blocks`](Self::list_cidr_blocks) but with pagination for
+    /// the HTTP list endpoint. `limit`/`offset` of `None` means unbounded.
+    async fn list_cidr_blocks_page(
+        &self,
+        tenant_id: &str,
+        limit: Option<u32>,
+        offset: Option<u32>,
+    ) -> Result<Vec<CidrBlock>>;
     async fn delete_cidr_block(&self, tenant_id: &str, id: &str) -> Result<()>;
 
     // --- allocations ---

--- a/src/ipam_api.rs
+++ b/src/ipam_api.rs
@@ -186,6 +186,28 @@ impl AutoAllocateBody {
     }
 }
 
+/// Default number of rows a list endpoint returns when no `limit` is given.
+const DEFAULT_PAGE_LIMIT: u32 = 100;
+/// Hard ceiling on `limit` for any list endpoint, to bound response size and
+/// memory regardless of what a caller requests.
+const MAX_PAGE_LIMIT: u32 = 1000;
+
+/// Resolve a caller-supplied `limit` into an enforced page size: default when
+/// absent, clamped to `[1, MAX_PAGE_LIMIT]`.
+fn page_limit(limit: Option<u32>) -> u32 {
+    limit.unwrap_or(DEFAULT_PAGE_LIMIT).clamp(1, MAX_PAGE_LIMIT)
+}
+
+/// Pagination query params shared by the list endpoints.
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "swagger", derive(IntoParams))]
+pub struct CidrBlockListQuery {
+    /// Max rows to return (default 100, max 1000)
+    pub limit: Option<u32>,
+    /// Rows to skip before returning results (default 0)
+    pub offset: Option<u32>,
+}
+
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "swagger", derive(IntoParams))]
 pub struct AllocationFilterQuery {
@@ -199,6 +221,10 @@ pub struct AllocationFilterQuery {
     pub environment: Option<String>,
     /// Filter by owner
     pub owner: Option<String>,
+    /// Max rows to return (default 100, max 1000)
+    pub limit: Option<u32>,
+    /// Rows to skip before returning results (default 0)
+    pub offset: Option<u32>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -221,7 +247,7 @@ pub struct AuditQuery {
     pub caller_email: Option<String>,
     /// Filter by the personal access token id that performed the action
     pub pat_id: Option<String>,
-    /// Maximum number of entries to return
+    /// Maximum number of entries to return (default 100, max 1000)
     pub limit: Option<u32>,
 }
 
@@ -234,6 +260,10 @@ pub struct HostnameListQuery {
     pub hostname: Option<String>,
     /// Filter by associated allocation ID
     pub allocation_id: Option<String>,
+    /// Max rows to return (default 100, max 1000)
+    pub limit: Option<u32>,
+    /// Rows to skip before returning results (default 0)
+    pub offset: Option<u32>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -243,6 +273,10 @@ pub struct HostnameHistoryQuery {
     pub ip: Option<String>,
     /// Filter history by hostname
     pub hostname: Option<String>,
+    /// Max rows to return (default 100, max 1000)
+    pub limit: Option<u32>,
+    /// Rows to skip before returning results (default 0)
+    pub offset: Option<u32>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -440,6 +474,7 @@ async fn ipam_create_cidr_block(
 #[cfg_attr(feature = "swagger", utoipa::path(
     get,
     path = "/ipam/cidr-blocks",
+    params(CidrBlockListQuery),
     responses(
         (status = 200, description = "List of cidr_blocks", body = CidrBlockList),
     ),
@@ -450,8 +485,12 @@ async fn ipam_list_cidr_blocks(
     Extension(ops): Extension<Arc<IpamOps>>,
     tenant: crate::tenant::Tenant,
     _: RequireReader,
+    Query(query): Query<CidrBlockListQuery>,
 ) -> impl IntoResponse {
-    match ops.list_cidr_blocks(tenant.as_str()).await {
+    match ops
+        .list_cidr_blocks_page(tenant.as_str(), Some(page_limit(query.limit)), query.offset)
+        .await
+    {
         Ok(cidr_blocks) => {
             let list = CidrBlockList {
                 count: cidr_blocks.len(),
@@ -646,6 +685,8 @@ async fn ipam_list_cidr_block_allocations(
         resource_type: query.resource_type,
         environment: query.environment,
         owner: query.owner,
+        limit: Some(page_limit(query.limit)),
+        offset: query.offset,
     };
     match ops.list_allocations(tenant.as_str(), &filter).await {
         Ok(allocations) => {
@@ -895,6 +936,8 @@ async fn ipam_list_hostnames(
         ip_address: query.ip,
         hostname: query.hostname,
         allocation_id: query.allocation_id,
+        limit: Some(page_limit(query.limit)),
+        offset: query.offset,
     };
     match ops.list_hostname_pointers(tenant.as_str(), &filter).await {
         Ok(pointers) => {
@@ -927,6 +970,8 @@ async fn ipam_hostname_history(
     let filter = HostnameHistoryFilter {
         ip_address: query.ip,
         hostname: query.hostname,
+        limit: Some(page_limit(query.limit)),
+        offset: query.offset,
     };
     match ops.list_hostname_history(tenant.as_str(), &filter).await {
         Ok(entries) => {
@@ -988,7 +1033,8 @@ async fn ipam_query_audit(
         action: query.action,
         caller_email: query.caller_email,
         pat_id: query.pat_id,
-        limit: query.limit,
+        // Default + clamp so omitting `limit` can't dump the whole audit log.
+        limit: Some(page_limit(query.limit)),
     };
     match ops.query_audit(tenant.as_str(), &filter).await {
         Ok(entries) => {
@@ -1088,5 +1134,21 @@ async fn ipam_batch_summary(
     {
         Ok(summary) => Json(summary).into_response(),
         Err(e) => ipam_error_response(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn page_limit_defaults_and_clamps() {
+        assert_eq!(page_limit(None), DEFAULT_PAGE_LIMIT);
+        assert_eq!(page_limit(Some(50)), 50);
+        // Clamped up from 0 to the minimum of 1.
+        assert_eq!(page_limit(Some(0)), 1);
+        // Clamped down to the hard ceiling.
+        assert_eq!(page_limit(Some(u32::MAX)), MAX_PAGE_LIMIT);
+        assert_eq!(page_limit(Some(MAX_PAGE_LIMIT + 1)), MAX_PAGE_LIMIT);
     }
 }

--- a/src/ipam_cli.rs
+++ b/src/ipam_cli.rs
@@ -203,6 +203,7 @@ pub async fn handle_ipam_command(
                             resource_type,
                             environment,
                             owner,
+                            ..Default::default()
                         },
                     )
                     .await?;
@@ -403,6 +404,7 @@ pub async fn handle_ipam_command(
                             ip_address: ip,
                             hostname,
                             allocation_id,
+                            ..Default::default()
                         },
                     )
                     .await?;
@@ -418,11 +420,13 @@ pub async fn handle_ipam_command(
                     HostnameHistoryFilter {
                         ip_address: Some(target),
                         hostname: None,
+                        ..Default::default()
                     }
                 } else {
                     HostnameHistoryFilter {
                         ip_address: None,
                         hostname: Some(target),
+                        ..Default::default()
                     }
                 };
                 let entries = ops.list_hostname_history(Tenant::LOCAL, &filter).await?;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -669,6 +669,7 @@ impl NetcidrMcp {
             resource_type: None,
             environment: params.environment,
             owner: params.owner,
+            ..Default::default()
         };
         result_to_string(backend.list_allocations(&filter).await)
     }
@@ -833,6 +834,7 @@ impl NetcidrMcp {
             ip_address: params.ip,
             hostname: params.hostname,
             allocation_id: params.allocation_id,
+            ..Default::default()
         };
         result_to_string(backend.list_hostname_pointers(&filter).await)
     }
@@ -851,6 +853,7 @@ impl NetcidrMcp {
         let filter = HostnameHistoryFilter {
             ip_address: params.ip,
             hostname: params.hostname,
+            ..Default::default()
         };
         result_to_string(backend.list_hostname_history(&filter).await)
     }

--- a/tests/ipam_store_contract.rs
+++ b/tests/ipam_store_contract.rs
@@ -1267,6 +1267,7 @@ macro_rules! store_contract_tests {
                     &HostnameHistoryFilter {
                         ip_address: Some("10.0.1.5".to_string()),
                         hostname: None,
+                        ..Default::default()
                     },
                 )
                 .await


### PR DESCRIPTION
Closes #260

## Problem (STRIDE finding E1/E3 — DoS / availability)

IPAM list endpoints returned the full result set with no pagination, and `GET /ipam/audit` passed `limit` through uncapped (and unbounded when omitted). A large tenant — or a caller omitting `limit` — could force large allocations and response bodies, pressuring memory.

## Approach

Pagination is enforced at the **HTTP boundary** (the DoS surface), while the store gains `LIMIT`/`OFFSET` support. CLI, MCP, and internal callers stay unbounded (`limit`/`offset = None`), so behavior there is unchanged — important because `list_cidr_blocks` is reused internally for overlap detection and IP/resource lookup, which need *all* rows.

- **models**: `limit`/`offset` added to `AllocationFilter`, `HostnamePointerFilter`, `HostnameHistoryFilter` (carried through `ops`' normalization).
- **store/SQL**: shared `limit_offset_clause` helper (digits-only `u32`, no injection); applied in SQLite (rusqlite) and Postgres (`QueryBuilder`) for allocations, hostnames, and history. New `list_cidr_blocks_page` (trait + both backends + ops) leaves the unbounded `list_cidr_blocks` intact for internal use.
- **API**: `limit`/`offset` query params on the four list endpoints; `limit` defaults to **100**, clamped to **1000** via `page_limit`. The audit handler now defaults+clamps `limit` so omitting it can't dump the whole log.

## Tests
- `list_pagination_limits_and_offsets` — store-level: limit caps, offset skips, `None` is unbounded (cidr-blocks + allocations).
- `page_limit_defaults_and_clamps` — default 100, min-clamp to 1, max-clamp to 1000.

`cargo test` (default, all suites), `cargo clippy --features ipam-postgres,mcp,swagger -- -D warnings`, and the postgres contract-test compile all pass. CHANGELOG + README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)