### PR TITLE
feat(ipam): add tenant_id to allocation_tags for defense-in-depth isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The SQLite IPAM database file is now created with owner-only (`0600`) permissions on Unix, instead of inheriting the umask (typically world-readable `0644`). The database holds all CIDR blocks, allocations, hostnames, and the audit log ([#261](https://github.com/wingnut128/netcidr/issues/261)).
 - Auto-allocate now rejects a `count` above 1000 at both the CLI (`--count` value range) and the operations layer (covering the HTTP API), preventing an unbounded number of allocation writes from a single request ([#263](https://github.com/wingnut128/netcidr/issues/263)).
 - The IPAM list endpoints now bound their result sets via `limit`/`offset` pagination (default 100, max 1000), and the audit endpoint (`GET /ipam/audit`) defaults and clamps its `limit` so omitting it can no longer dump the entire audit log ([#260](https://github.com/wingnut128/netcidr/issues/260)).
+- `allocation_tags` now carries a `tenant_id` column (migration 012, SQLite + Postgres) — backfilled from the parent allocation, filtered on in tag reads/writes, and enforced by a tenant-match trigger. Previously cross-tenant tag isolation rested solely on an application-layer pre-check plus UUID unguessability; this adds DB-level defense-in-depth consistent with the other tenant-scoped tables ([#262](https://github.com/wingnut128/netcidr/issues/262)).
 
 ## [0.26.9](https://github.com/wingnut128/netcidr/compare/v0.26.8...v0.26.9) - 2026-06-08
 

--- a/src/ipam/postgres/migrations.rs
+++ b/src/ipam/postgres/migrations.rs
@@ -12,6 +12,7 @@ pub const MIGRATIONS: &[(u32, &str)] = &[
     (9, MIGRATION_009),
     (10, MIGRATION_010),
     (11, MIGRATION_011),
+    (12, MIGRATION_012),
 ];
 
 const MIGRATION_001: &str = r#"
@@ -320,6 +321,39 @@ CREATE TABLE IF NOT EXISTS role_assignments (
 );
 
 CREATE INDEX IF NOT EXISTS idx_role_assignments_role ON role_assignments(role);
+"#;
+
+/// Adds tenant_id to allocation_tags so tag isolation no longer relies solely on
+/// the parent-allocation pre-check + UUID unguessability. Backfills from the
+/// parent allocation, enforces NOT NULL, and mirrors the allocations
+/// tenant-match invariant with a trigger. Mirrors SQLite migration 012.
+const MIGRATION_012: &str = r#"
+ALTER TABLE allocation_tags ADD COLUMN tenant_id TEXT;
+
+UPDATE allocation_tags
+SET tenant_id = a.tenant_id
+FROM allocations a
+WHERE a.id = allocation_tags.allocation_id;
+
+ALTER TABLE allocation_tags ALTER COLUMN tenant_id SET NOT NULL;
+
+CREATE INDEX idx_allocation_tags_tenant ON allocation_tags(tenant_id, allocation_id);
+
+CREATE OR REPLACE FUNCTION assert_alloc_tags_tenant_match() RETURNS trigger AS $$
+BEGIN
+    IF NEW.tenant_id IS DISTINCT FROM (SELECT tenant_id FROM allocations WHERE id = NEW.allocation_id) THEN
+        RAISE EXCEPTION 'allocation_tags tenant_id must match parent allocation tenant_id';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_allocation_tags_tenant_match_insert
+    BEFORE INSERT ON allocation_tags
+    FOR EACH ROW EXECUTE FUNCTION assert_alloc_tags_tenant_match();
+CREATE TRIGGER trg_allocation_tags_tenant_match_update
+    BEFORE UPDATE OF tenant_id, allocation_id ON allocation_tags
+    FOR EACH ROW EXECUTE FUNCTION assert_alloc_tags_tenant_match();
 "#;
 
 #[cfg(all(test, feature = "ipam-postgres"))]

--- a/src/ipam/postgres/mod.rs
+++ b/src/ipam/postgres/mod.rs
@@ -39,12 +39,19 @@ impl PostgresStore {
         Utc::now().to_rfc3339()
     }
 
-    async fn load_tags_for_allocation(&self, allocation_id: &str) -> Result<Vec<Tag>> {
-        let rows = sqlx::query("SELECT key, value FROM allocation_tags WHERE allocation_id = $1")
-            .bind(allocation_id)
-            .fetch_all(&self.pool)
-            .await
-            .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
+    async fn load_tags_for_allocation(
+        &self,
+        tenant_id: &str,
+        allocation_id: &str,
+    ) -> Result<Vec<Tag>> {
+        let rows = sqlx::query(
+            "SELECT key, value FROM allocation_tags WHERE allocation_id = $1 AND tenant_id = $2",
+        )
+        .bind(allocation_id)
+        .bind(tenant_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
         Ok(rows
             .iter()
             .map(|row| Tag {
@@ -433,9 +440,10 @@ impl IpamStore for PostgresStore {
         if let Some(ref tags) = input.tags {
             for tag in tags {
                 sqlx::query(
-                    "INSERT INTO allocation_tags (allocation_id, key, value) VALUES ($1, $2, $3)",
+                    "INSERT INTO allocation_tags (allocation_id, tenant_id, key, value) VALUES ($1, $2, $3, $4)",
                 )
                 .bind(&id)
+                .bind(tenant_id)
                 .bind(&tag.key)
                 .bind(&tag.value)
                 .execute(&self.pool)
@@ -482,7 +490,7 @@ impl IpamStore for PostgresStore {
         .ok_or_else(|| NetcidrError::AllocationNotFound(id.to_string()))?;
 
         let mut alloc = Self::row_to_allocation(&row);
-        alloc.tags = self.load_tags_for_allocation(id).await?;
+        alloc.tags = self.load_tags_for_allocation(tenant_id, id).await?;
         Ok(alloc)
     }
 
@@ -535,7 +543,7 @@ impl IpamStore for PostgresStore {
 
         let mut allocations: Vec<Allocation> = rows.iter().map(Self::row_to_allocation).collect();
         for alloc in &mut allocations {
-            alloc.tags = self.load_tags_for_allocation(&alloc.id).await?;
+            alloc.tags = self.load_tags_for_allocation(tenant_id, &alloc.id).await?;
         }
         Ok(allocations)
     }
@@ -657,7 +665,7 @@ impl IpamStore for PostgresStore {
 
         let mut allocations: Vec<Allocation> = rows.iter().map(Self::row_to_allocation).collect();
         for alloc in &mut allocations {
-            alloc.tags = self.load_tags_for_allocation(&alloc.id).await?;
+            alloc.tags = self.load_tags_for_allocation(tenant_id, &alloc.id).await?;
         }
         Ok(allocations)
     }
@@ -668,17 +676,19 @@ impl IpamStore for PostgresStore {
         self.assert_allocation_in_tenant(tenant_id, allocation_id)
             .await?;
 
-        sqlx::query("DELETE FROM allocation_tags WHERE allocation_id = $1")
+        sqlx::query("DELETE FROM allocation_tags WHERE allocation_id = $1 AND tenant_id = $2")
             .bind(allocation_id)
+            .bind(tenant_id)
             .execute(&self.pool)
             .await
             .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
 
         for tag in tags {
             sqlx::query(
-                "INSERT INTO allocation_tags (allocation_id, key, value) VALUES ($1, $2, $3)",
+                "INSERT INTO allocation_tags (allocation_id, tenant_id, key, value) VALUES ($1, $2, $3, $4)",
             )
             .bind(allocation_id)
+            .bind(tenant_id)
             .bind(&tag.key)
             .bind(&tag.value)
             .execute(&self.pool)
@@ -691,7 +701,8 @@ impl IpamStore for PostgresStore {
     async fn get_tags(&self, tenant_id: &str, allocation_id: &str) -> Result<Vec<Tag>> {
         self.assert_allocation_in_tenant(tenant_id, allocation_id)
             .await?;
-        self.load_tags_for_allocation(allocation_id).await
+        self.load_tags_for_allocation(tenant_id, allocation_id)
+            .await
     }
 
     // --- hostname pointers ---

--- a/src/ipam/sqlite/migrations.rs
+++ b/src/ipam/sqlite/migrations.rs
@@ -12,6 +12,7 @@ pub const MIGRATIONS: &[(u32, &str)] = &[
     (9, MIGRATION_009),
     (10, MIGRATION_010),
     (11, MIGRATION_011),
+    (12, MIGRATION_012),
 ];
 
 const MIGRATION_001: &str = r#"
@@ -320,6 +321,38 @@ CREATE TABLE IF NOT EXISTS role_assignments (
 );
 
 CREATE INDEX IF NOT EXISTS idx_role_assignments_role ON role_assignments(role);
+"#;
+
+// Adds tenant_id to allocation_tags so tag isolation no longer relies solely on
+// the parent-allocation pre-check + UUID unguessability. Backfills from the
+// parent allocation and enforces the match with triggers (mirroring the
+// allocations tenant-match invariant). The column is left nullable at the schema
+// level — SQLite can't add a NOT NULL column to an existing table — but the
+// triggers reject any NULL/mismatched tenant_id on insert/update.
+const MIGRATION_012: &str = r#"
+ALTER TABLE allocation_tags ADD COLUMN tenant_id TEXT;
+
+UPDATE allocation_tags
+SET tenant_id = (SELECT a.tenant_id FROM allocations a WHERE a.id = allocation_tags.allocation_id);
+
+CREATE INDEX idx_allocation_tags_tenant ON allocation_tags(tenant_id, allocation_id);
+
+CREATE TRIGGER trg_allocation_tags_tenant_match_insert
+    BEFORE INSERT ON allocation_tags
+    FOR EACH ROW
+    WHEN NEW.tenant_id IS NULL
+      OR NEW.tenant_id != (SELECT tenant_id FROM allocations WHERE id = NEW.allocation_id)
+    BEGIN
+        SELECT RAISE(ABORT, 'allocation_tags tenant_id must match parent allocation tenant_id');
+    END;
+CREATE TRIGGER trg_allocation_tags_tenant_match_update
+    BEFORE UPDATE OF tenant_id, allocation_id ON allocation_tags
+    FOR EACH ROW
+    WHEN NEW.tenant_id IS NULL
+      OR NEW.tenant_id != (SELECT tenant_id FROM allocations WHERE id = NEW.allocation_id)
+    BEGIN
+        SELECT RAISE(ABORT, 'allocation_tags tenant_id must match parent allocation tenant_id');
+    END;
 "#;
 
 #[cfg(test)]

--- a/src/ipam/sqlite/mod.rs
+++ b/src/ipam/sqlite/mod.rs
@@ -88,13 +88,16 @@ impl SqliteStore {
 
     fn load_tags_for_allocation(
         conn: &rusqlite::Connection,
+        tenant_id: &str,
         allocation_id: &str,
     ) -> Result<Vec<Tag>> {
         let mut stmt = conn
-            .prepare("SELECT key, value FROM allocation_tags WHERE allocation_id = ?1")
+            .prepare(
+                "SELECT key, value FROM allocation_tags WHERE allocation_id = ?1 AND tenant_id = ?2",
+            )
             .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
         let tags = stmt
-            .query_map(params![allocation_id], |row| {
+            .query_map(params![allocation_id, tenant_id], |row| {
                 Ok(Tag {
                     key: row.get(0)?,
                     value: row.get(1)?,
@@ -451,8 +454,8 @@ impl IpamStore for SqliteStore {
         if let Some(ref tags) = input.tags {
             for tag in tags {
                 conn.execute(
-                    "INSERT INTO allocation_tags (allocation_id, key, value) VALUES (?1, ?2, ?3)",
-                    params![id, tag.key, tag.value],
+                    "INSERT INTO allocation_tags (allocation_id, tenant_id, key, value) VALUES (?1, ?2, ?3, ?4)",
+                    params![id, tenant_id, tag.key, tag.value],
                 )
                 .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
             }
@@ -496,7 +499,7 @@ impl IpamStore for SqliteStore {
                 rusqlite::Error::QueryReturnedNoRows => NetcidrError::AllocationNotFound(id.to_string()),
                 _ => NetcidrError::DatabaseError(e.to_string()),
             })?;
-        alloc.tags = Self::load_tags_for_allocation(&conn, id)?;
+        alloc.tags = Self::load_tags_for_allocation(&conn, tenant_id, id)?;
         Ok(alloc)
     }
 
@@ -568,7 +571,7 @@ impl IpamStore for SqliteStore {
         // Load tags for each allocation
         let mut allocations = rows;
         for alloc in &mut allocations {
-            alloc.tags = Self::load_tags_for_allocation(&conn, &alloc.id)?;
+            alloc.tags = Self::load_tags_for_allocation(&conn, tenant_id, &alloc.id)?;
         }
         Ok(allocations)
     }
@@ -639,7 +642,7 @@ impl IpamStore for SqliteStore {
                 Self::row_to_allocation,
             )
             .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
-        alloc.tags = Self::load_tags_for_allocation(&conn, id)?;
+        alloc.tags = Self::load_tags_for_allocation(&conn, tenant_id, id)?;
         Ok(alloc)
     }
 
@@ -676,7 +679,7 @@ impl IpamStore for SqliteStore {
                 Self::row_to_allocation,
             )
             .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
-        alloc.tags = Self::load_tags_for_allocation(&conn, id)?;
+        alloc.tags = Self::load_tags_for_allocation(&conn, tenant_id, id)?;
         Ok(alloc)
     }
 
@@ -718,7 +721,7 @@ impl IpamStore for SqliteStore {
 
         let mut allocations = rows;
         for alloc in &mut allocations {
-            alloc.tags = Self::load_tags_for_allocation(&conn, &alloc.id)?;
+            alloc.tags = Self::load_tags_for_allocation(&conn, tenant_id, &alloc.id)?;
         }
         Ok(allocations)
     }
@@ -730,15 +733,15 @@ impl IpamStore for SqliteStore {
         Self::assert_allocation_in_tenant(&conn, tenant_id, allocation_id)?;
 
         conn.execute(
-            "DELETE FROM allocation_tags WHERE allocation_id = ?1",
-            params![allocation_id],
+            "DELETE FROM allocation_tags WHERE allocation_id = ?1 AND tenant_id = ?2",
+            params![allocation_id, tenant_id],
         )
         .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
 
         for tag in tags {
             conn.execute(
-                "INSERT INTO allocation_tags (allocation_id, key, value) VALUES (?1, ?2, ?3)",
-                params![allocation_id, tag.key, tag.value],
+                "INSERT INTO allocation_tags (allocation_id, tenant_id, key, value) VALUES (?1, ?2, ?3, ?4)",
+                params![allocation_id, tenant_id, tag.key, tag.value],
             )
             .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
         }
@@ -748,7 +751,7 @@ impl IpamStore for SqliteStore {
     async fn get_tags(&self, tenant_id: &str, allocation_id: &str) -> Result<Vec<Tag>> {
         let conn = self.conn()?;
         Self::assert_allocation_in_tenant(&conn, tenant_id, allocation_id)?;
-        Self::load_tags_for_allocation(&conn, allocation_id)
+        Self::load_tags_for_allocation(&conn, tenant_id, allocation_id)
     }
 
     // --- hostname pointers ---
@@ -1629,6 +1632,67 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(page.len(), 3, "limit must cap the allocation page");
+    }
+
+    #[tokio::test]
+    async fn allocation_tags_carry_tenant_and_trigger_enforces_match() {
+        let store = test_store().await;
+        let sn = store
+            .create_cidr_block(
+                TEST_TENANT,
+                &CreateCidrBlock {
+                    cidr: "10.0.0.0/8".to_string(),
+                    name: None,
+                    description: None,
+                },
+            )
+            .await
+            .unwrap();
+        let alloc = store
+            .create_allocation(
+                TEST_TENANT,
+                &CreateAllocation {
+                    cidr_block_id: sn.id.clone(),
+                    cidr: "10.0.0.0/24".to_string(),
+                    status: None,
+                    resource_id: None,
+                    resource_type: None,
+                    name: None,
+                    description: None,
+                    environment: None,
+                    owner: None,
+                    parent_allocation_id: None,
+                    tags: Some(vec![Tag {
+                        key: "env".to_string(),
+                        value: "prod".to_string(),
+                    }]),
+                    ttl_seconds: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Tags created via create_allocation are readable for the owning tenant
+        // (the tenant-filtered read still works with the new column).
+        let tags = store.get_tags(TEST_TENANT, &alloc.id).await.unwrap();
+        assert_eq!(tags.len(), 1);
+
+        // A different tenant cannot read or replace them (pre-check gate).
+        assert!(
+            store
+                .get_tags("other@example.com", &alloc.id)
+                .await
+                .is_err()
+        );
+
+        // DB-level defense-in-depth: the trigger rejects a tag row whose
+        // tenant_id does not match the parent allocation's, even via raw SQL.
+        let conn = store.conn().unwrap();
+        let res = conn.execute(
+            "INSERT INTO allocation_tags (allocation_id, tenant_id, key, value) VALUES (?1, ?2, ?3, ?4)",
+            params![alloc.id, "other@example.com", "x", "y"],
+        );
+        assert!(res.is_err(), "trigger must reject mismatched tenant_id");
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
Closes #262

## Problem (STRIDE finding E3 — Information-disclosure / confidentiality)

`allocation_tags` was the only tenant-scoped table without a `tenant_id` column. Cross-tenant tag isolation rested entirely on a single application-layer pre-check (`assert_allocation_in_tenant`) plus the UUIDv4 unguessability of `allocation_id` — weaker defense-in-depth than the other tables, where DB triggers enforce the tenant invariant. A logic bug that skipped the pre-check could read or modify another tenant's tags.

## Fix

- **Migration 012 (SQLite + Postgres):** add `tenant_id`, backfill from the parent allocation, add `(tenant_id, allocation_id)` index, and a tenant-match trigger mirroring the `allocations` invariant. Postgres also enforces `NOT NULL`; SQLite relies on the trigger (it can't add a `NOT NULL` column to an existing table) which rejects NULL/mismatched values.
- **Store (both backends):** set `tenant_id` on every tag insert (`create_allocation` + `set_tags`) and filter tag reads/deletes by `tenant_id`. `load_tags_for_allocation` now takes `tenant_id`.

CLI/MCP/API callers are unaffected — they already pass `tenant_id` through.

## Tests
- `allocation_tags_carry_tenant_and_trigger_enforces_match`: tags created via `create_allocation` read back for the owner, are unreadable cross-tenant, and the DB trigger rejects a mismatched-tenant tag row inserted via raw SQL.

`cargo test` (default + contract), `cargo clippy --features ipam-postgres,mcp,swagger -- -D warnings` pass. CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)