### PR TITLE
chore: release v0.26.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.12](https://github.com/wingnut128/netcidr/compare/v0.26.11...v0.26.12) - 2026-06-18
+
+### Fixed
+
+- *(dashboard)* use delVoid for CIDR block delete to handle 204 No Content
+
+### Other
+
+- prohibit direct commits to main in CLAUDE.md
+
 ## [0.26.11](https://github.com/wingnut128/netcidr/compare/v0.26.10...v0.26.11) - 2026-06-18
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "netcidr"
-version = "0.26.11"
+version = "0.26.12"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netcidr"
-version = "0.26.11"
+version = "0.26.12"
 edition = "2024"
 license = "MIT"
 description = "A fast IPv4 and IPv6 subnet calculator CLI and API"


### PR DESCRIPTION



## 🤖 New release

* `netcidr`: 0.26.11 -> 0.26.12

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.26.12](https://github.com/wingnut128/netcidr/compare/v0.26.11...v0.26.12) - 2026-06-18

### Fixed

- *(dashboard)* use delVoid for CIDR block delete to handle 204 No Content

### Other

- prohibit direct commits to main in CLAUDE.md
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).