### PR TITLE
feat(auth): cap active PATs per tenant — ENG-108

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- *(auth)* cap active PATs per tenant (default 25, configurable via `max_pats_per_tenant`); `POST /me/tokens` returns 429 when the cap is reached (ENG-108)
+
 ## [0.26.12](https://github.com/wingnut128/netcidr/compare/v0.26.11...v0.26.12) - 2026-06-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ rate_limit_per_second = 20    # Sustained rate limit per IP (default: 20; 0 = di
 rate_limit_burst = 50         # Burst allowance per IP (default: 50)
 timeout_seconds = 30          # Request timeout (default: 30s)
 enable_swagger = false        # Swagger UI at /swagger-ui (default: false)
+max_pats_per_tenant = 25      # Max active PATs per tenant (default: 25; POST /me/tokens returns 429 when reached)
 ```
 
 **Security defaults**: All endpoints are protected by per-IP rate limiting, request body size limits, request timeouts, restrictive CORS (no origins allowed by default), and security headers (`X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Cache-Control: no-store`).

--- a/src/api.rs
+++ b/src/api.rs
@@ -518,6 +518,7 @@ pub fn create_router(config: RouterConfig) -> Router {
             let lifecycle = Arc::new(crate::pat_lifecycle::PatLifecycle::new(
                 ops.store_arc(),
                 Arc::clone(pepper),
+                config.server.max_pats_per_tenant,
             ));
             let me_router = crate::me_api::create_me_router()
                 .layer(Extension(lifecycle))

--- a/src/config.rs
+++ b/src/config.rs
@@ -86,6 +86,9 @@ pub struct ServerConfig {
     pub allow_public_bind: bool,
     /// Require authentication when binding the HTTP API to a non-loopback address.
     pub require_auth_for_public_bind: bool,
+    /// Maximum number of active (non-revoked, non-expired) PATs per tenant.
+    /// Callers that exceed this cap receive 429 and must revoke a token first.
+    pub max_pats_per_tenant: u32,
 }
 
 impl Default for ServerConfig {
@@ -112,6 +115,7 @@ impl Default for ServerConfig {
             oidc_reader_emails: Vec::new(),
             allow_public_bind: false,
             require_auth_for_public_bind: true,
+            max_pats_per_tenant: 25,
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -102,6 +102,9 @@ pub enum NetcidrError {
     #[error("Personal access token not found: {0}")]
     PatNotFound(String),
 
+    #[error("PAT limit reached: {count} active tokens (max {limit}); revoke a token to create a new one")]
+    PatLimitExceeded { count: u32, limit: u32 },
+
     /// An idempotency key was reused with a different request body for
     /// the same operation scope. The key is bound to the *first* payload
     /// it saw; reusing it for a new payload is almost always a client

--- a/src/error.rs
+++ b/src/error.rs
@@ -102,7 +102,9 @@ pub enum NetcidrError {
     #[error("Personal access token not found: {0}")]
     PatNotFound(String),
 
-    #[error("PAT limit reached: {count} active tokens (max {limit}); revoke a token to create a new one")]
+    #[error(
+        "PAT limit reached: {count} active tokens (max {limit}); revoke a token to create a new one"
+    )]
     PatLimitExceeded { count: u32, limit: u32 },
 
     /// An idempotency key was reused with a different request body for

--- a/src/error_presenter.rs
+++ b/src/error_presenter.rs
@@ -86,6 +86,13 @@ pub fn present(err: &NetcidrError) -> PresentedError {
             log_level: LogLevel::None,
         },
 
+        // 429 — per-tenant active PAT cap exceeded.
+        PatLimitExceeded { .. } => PresentedError {
+            status: 429,
+            client_msg: err.to_string(),
+            log_level: LogLevel::None,
+        },
+
         // 409 — conflict
         AllocationConflict { .. } | CidrBlockHasActiveAllocations(_) | LastAdmin => {
             PresentedError {

--- a/src/ipam/postgres/mod.rs
+++ b/src/ipam/postgres/mod.rs
@@ -1246,6 +1246,27 @@ impl IpamStore for PostgresStore {
 
     // --- personal access tokens ---
 
+    async fn pat_count_active_for_owner(
+        &self,
+        tenant_id: &str,
+        owner_sub: &str,
+        now_rfc3339: &str,
+    ) -> Result<u32> {
+        let row = sqlx::query(
+            "SELECT COUNT(*) FROM personal_access_tokens \
+             WHERE tenant_id = $1 AND owner_sub = $2 \
+               AND revoked_at IS NULL AND expires_at > $3",
+        )
+        .bind(tenant_id)
+        .bind(owner_sub)
+        .bind(now_rfc3339)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
+        let count: i64 = row.get(0);
+        Ok(count as u32)
+    }
+
     async fn pat_create(&self, input: &CreatePersonalAccessToken) -> Result<PersonalAccessToken> {
         let id = uuid::Uuid::new_v4().to_string();
         let now = Self::now();

--- a/src/ipam/sqlite/mod.rs
+++ b/src/ipam/sqlite/mod.rs
@@ -2585,31 +2585,58 @@ mod tests {
 
         // Active
         let active = store
-            .pat_create(&pat_input(TEST_TENANT, "sub-1", "a1", 0x60, "2099-01-01T00:00:00Z"))
+            .pat_create(&pat_input(
+                TEST_TENANT,
+                "sub-1",
+                "a1",
+                0x60,
+                "2099-01-01T00:00:00Z",
+            ))
             .await
             .unwrap();
 
         // Expired
         store
-            .pat_create(&pat_input(TEST_TENANT, "sub-1", "e1", 0x61, "2020-01-01T00:00:00Z"))
+            .pat_create(&pat_input(
+                TEST_TENANT,
+                "sub-1",
+                "e1",
+                0x61,
+                "2020-01-01T00:00:00Z",
+            ))
             .await
             .unwrap();
 
         // Revoked
         let rev = store
-            .pat_create(&pat_input(TEST_TENANT, "sub-1", "r1", 0x62, "2099-01-01T00:00:00Z"))
+            .pat_create(&pat_input(
+                TEST_TENANT,
+                "sub-1",
+                "r1",
+                0x62,
+                "2099-01-01T00:00:00Z",
+            ))
             .await
             .unwrap();
-        store.pat_revoke(TEST_TENANT, "sub-1", &rev.id, now).await.unwrap();
+        store
+            .pat_revoke(TEST_TENANT, "sub-1", &rev.id, now)
+            .await
+            .unwrap();
 
         let count = store
             .pat_count_active_for_owner(TEST_TENANT, "sub-1", now)
             .await
             .unwrap();
-        assert_eq!(count, 1, "only the non-expired non-revoked token should count");
+        assert_eq!(
+            count, 1,
+            "only the non-expired non-revoked token should count"
+        );
 
         // Revoke the last active one → count drops to zero.
-        store.pat_revoke(TEST_TENANT, "sub-1", &active.id, now).await.unwrap();
+        store
+            .pat_revoke(TEST_TENANT, "sub-1", &active.id, now)
+            .await
+            .unwrap();
         let count_after = store
             .pat_count_active_for_owner(TEST_TENANT, "sub-1", now)
             .await

--- a/src/ipam/sqlite/mod.rs
+++ b/src/ipam/sqlite/mod.rs
@@ -1339,6 +1339,25 @@ impl IpamStore for SqliteStore {
 
     // --- personal access tokens ---
 
+    async fn pat_count_active_for_owner(
+        &self,
+        tenant_id: &str,
+        owner_sub: &str,
+        now_rfc3339: &str,
+    ) -> Result<u32> {
+        let conn = self.conn()?;
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM personal_access_tokens \
+                 WHERE tenant_id = ?1 AND owner_sub = ?2 \
+                   AND revoked_at IS NULL AND expires_at > ?3",
+                params![tenant_id, owner_sub, now_rfc3339],
+                |row| row.get(0),
+            )
+            .map_err(|e| NetcidrError::DatabaseError(e.to_string()))?;
+        Ok(count as u32)
+    }
+
     async fn pat_create(&self, input: &CreatePersonalAccessToken) -> Result<PersonalAccessToken> {
         let conn = self.conn()?;
         let id = uuid::Uuid::new_v4().to_string();
@@ -2557,5 +2576,44 @@ mod tests {
             .unwrap();
         assert_eq!(remaining.len(), 1);
         assert_eq!(remaining[0].id, valid.id);
+    }
+
+    #[tokio::test]
+    async fn pat_count_active_excludes_revoked_and_expired() {
+        let store = test_store().await;
+        let now = "2026-06-01T00:00:00Z";
+
+        // Active
+        let active = store
+            .pat_create(&pat_input(TEST_TENANT, "sub-1", "a1", 0x60, "2099-01-01T00:00:00Z"))
+            .await
+            .unwrap();
+
+        // Expired
+        store
+            .pat_create(&pat_input(TEST_TENANT, "sub-1", "e1", 0x61, "2020-01-01T00:00:00Z"))
+            .await
+            .unwrap();
+
+        // Revoked
+        let rev = store
+            .pat_create(&pat_input(TEST_TENANT, "sub-1", "r1", 0x62, "2099-01-01T00:00:00Z"))
+            .await
+            .unwrap();
+        store.pat_revoke(TEST_TENANT, "sub-1", &rev.id, now).await.unwrap();
+
+        let count = store
+            .pat_count_active_for_owner(TEST_TENANT, "sub-1", now)
+            .await
+            .unwrap();
+        assert_eq!(count, 1, "only the non-expired non-revoked token should count");
+
+        // Revoke the last active one → count drops to zero.
+        store.pat_revoke(TEST_TENANT, "sub-1", &active.id, now).await.unwrap();
+        let count_after = store
+            .pat_count_active_for_owner(TEST_TENANT, "sub-1", now)
+            .await
+            .unwrap();
+        assert_eq!(count_after, 0);
     }
 }

--- a/src/ipam/store.rs
+++ b/src/ipam/store.rs
@@ -157,6 +157,15 @@ pub trait IpamStore: Send + Sync {
 
     // --- personal access tokens ---
 
+    /// Count active (non-revoked, non-expired) PATs for `(tenant_id, owner_sub)`.
+    /// `now_rfc3339` is the caller's "now" used in the expiry predicate.
+    async fn pat_count_active_for_owner(
+        &self,
+        tenant_id: &str,
+        owner_sub: &str,
+        now_rfc3339: &str,
+    ) -> Result<u32>;
+
     /// Insert a new PAT row. Caller has already computed `prefix` and
     /// `token_hash`; the store trusts those inputs and parameterizes them.
     async fn pat_create(&self, input: &CreatePersonalAccessToken) -> Result<PersonalAccessToken>;

--- a/src/pat_lifecycle.rs
+++ b/src/pat_lifecycle.rs
@@ -68,8 +68,16 @@ pub struct PatLifecycle {
 }
 
 impl PatLifecycle {
-    pub fn new(store: Arc<dyn IpamStore>, pepper: Arc<PatPepper>, max_pats_per_tenant: u32) -> Self {
-        Self { store, pepper, max_pats_per_tenant }
+    pub fn new(
+        store: Arc<dyn IpamStore>,
+        pepper: Arc<PatPepper>,
+        max_pats_per_tenant: u32,
+    ) -> Self {
+        Self {
+            store,
+            pepper,
+            max_pats_per_tenant,
+        }
     }
 
     pub async fn mint_for_owner(

--- a/src/pat_lifecycle.rs
+++ b/src/pat_lifecycle.rs
@@ -64,11 +64,12 @@ pub enum VerifyPatError {
 pub struct PatLifecycle {
     store: Arc<dyn IpamStore>,
     pepper: Arc<PatPepper>,
+    max_pats_per_tenant: u32,
 }
 
 impl PatLifecycle {
-    pub fn new(store: Arc<dyn IpamStore>, pepper: Arc<PatPepper>) -> Self {
-        Self { store, pepper }
+    pub fn new(store: Arc<dyn IpamStore>, pepper: Arc<PatPepper>, max_pats_per_tenant: u32) -> Self {
+        Self { store, pepper, max_pats_per_tenant }
     }
 
     pub async fn mint_for_owner(
@@ -79,8 +80,21 @@ impl PatLifecycle {
     ) -> Result<MintedPat> {
         let name = validate_name(&request.name)?;
         let days = validate_expires_in_days(request.expires_in_days)?;
-        let minted = pat::mint(self.pepper.as_ref());
         let now = chrono::Utc::now();
+        let now_rfc3339 = now.to_rfc3339();
+
+        let active = self
+            .store
+            .pat_count_active_for_owner(&owner.tenant_id, &owner.subject, &now_rfc3339)
+            .await?;
+        if active >= self.max_pats_per_tenant {
+            return Err(NetcidrError::PatLimitExceeded {
+                count: active,
+                limit: self.max_pats_per_tenant,
+            });
+        }
+
+        let minted = pat::mint(self.pepper.as_ref());
         let expires_at = (now + chrono::Duration::days(days as i64)).to_rfc3339();
 
         let row = self

--- a/tests/pat_lifecycle_tests.rs
+++ b/tests/pat_lifecycle_tests.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use netcidr::auth::{AuthMethod, AuthenticatedPrincipal, PrincipalKind, Role};
+use netcidr::error::NetcidrError;
 use netcidr::ipam::sqlite::SqliteStore;
 use netcidr::ipam::store::IpamStore;
 use netcidr::pat::PatPepper;
-use netcidr::error::NetcidrError;
 use netcidr::pat_lifecycle::{self, CreatePatRequest, PatLifecycle, PatOwner, VerifyPatError};
 
 const OWNER_EMAIL: &str = "owner@example.com";
@@ -261,8 +261,14 @@ async fn mint_is_rejected_when_active_pat_cap_is_reached() {
         role: None,
     };
 
-    lifecycle.mint_for_owner(&owner(), Role::Admin, make_req(1)).await.unwrap();
-    lifecycle.mint_for_owner(&owner(), Role::Admin, make_req(2)).await.unwrap();
+    lifecycle
+        .mint_for_owner(&owner(), Role::Admin, make_req(1))
+        .await
+        .unwrap();
+    lifecycle
+        .mint_for_owner(&owner(), Role::Admin, make_req(2))
+        .await
+        .unwrap();
 
     // Third mint must be rejected with PatLimitExceeded.
     let err = lifecycle
@@ -288,30 +294,47 @@ async fn mint_succeeds_after_revoking_to_below_cap() {
         .mint_for_owner(
             &owner(),
             Role::Admin,
-            CreatePatRequest { name: "first".to_string(), expires_in_days: Some(30), role: None },
+            CreatePatRequest {
+                name: "first".to_string(),
+                expires_in_days: Some(30),
+                role: None,
+            },
         )
         .await
         .unwrap();
 
     // At cap — second mint fails.
-    assert!(lifecycle
-        .mint_for_owner(
-            &owner(),
-            Role::Admin,
-            CreatePatRequest { name: "second".to_string(), expires_in_days: Some(30), role: None },
-        )
-        .await
-        .is_err());
+    assert!(
+        lifecycle
+            .mint_for_owner(
+                &owner(),
+                Role::Admin,
+                CreatePatRequest {
+                    name: "second".to_string(),
+                    expires_in_days: Some(30),
+                    role: None
+                },
+            )
+            .await
+            .is_err()
+    );
 
     // Revoke the first token.
-    lifecycle.revoke_for_owner(&owner(), &minted.summary.id).await.unwrap();
+    lifecycle
+        .revoke_for_owner(&owner(), &minted.summary.id)
+        .await
+        .unwrap();
 
     // Now below cap — third mint succeeds.
     lifecycle
         .mint_for_owner(
             &owner(),
             Role::Admin,
-            CreatePatRequest { name: "third".to_string(), expires_in_days: Some(30), role: None },
+            CreatePatRequest {
+                name: "third".to_string(),
+                expires_in_days: Some(30),
+                role: None,
+            },
         )
         .await
         .unwrap();

--- a/tests/pat_lifecycle_tests.rs
+++ b/tests/pat_lifecycle_tests.rs
@@ -4,6 +4,7 @@ use netcidr::auth::{AuthMethod, AuthenticatedPrincipal, PrincipalKind, Role};
 use netcidr::ipam::sqlite::SqliteStore;
 use netcidr::ipam::store::IpamStore;
 use netcidr::pat::PatPepper;
+use netcidr::error::NetcidrError;
 use netcidr::pat_lifecycle::{self, CreatePatRequest, PatLifecycle, PatOwner, VerifyPatError};
 
 const OWNER_EMAIL: &str = "owner@example.com";
@@ -16,7 +17,7 @@ async fn lifecycle() -> (PatLifecycle, Arc<dyn IpamStore>, Arc<PatPepper>) {
     let store: Arc<dyn IpamStore> = Arc::new(store);
     let pepper = Arc::new(PatPepper::from_bytes(&[0xA5u8; 32]).unwrap());
     (
-        PatLifecycle::new(Arc::clone(&store), Arc::clone(&pepper)),
+        PatLifecycle::new(Arc::clone(&store), Arc::clone(&pepper), 25),
         store,
         pepper,
     )
@@ -242,4 +243,76 @@ async fn mint_for_principal_clamps_requested_role_to_callers_role() {
         Role::Reader,
         "admin narrowing to reader must be honored"
     );
+}
+
+#[tokio::test]
+async fn mint_is_rejected_when_active_pat_cap_is_reached() {
+    let store = SqliteStore::in_memory().unwrap();
+    store.initialize().await.unwrap();
+    store.migrate().await.unwrap();
+    let store: Arc<dyn IpamStore> = Arc::new(store);
+    let pepper = Arc::new(PatPepper::from_bytes(&[0xA5u8; 32]).unwrap());
+    // Use a cap of 2 to keep the test fast.
+    let lifecycle = PatLifecycle::new(Arc::clone(&store), Arc::clone(&pepper), 2);
+
+    let make_req = |n: u8| CreatePatRequest {
+        name: format!("tok-{n}"),
+        expires_in_days: Some(30),
+        role: None,
+    };
+
+    lifecycle.mint_for_owner(&owner(), Role::Admin, make_req(1)).await.unwrap();
+    lifecycle.mint_for_owner(&owner(), Role::Admin, make_req(2)).await.unwrap();
+
+    // Third mint must be rejected with PatLimitExceeded.
+    let err = lifecycle
+        .mint_for_owner(&owner(), Role::Admin, make_req(3))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, NetcidrError::PatLimitExceeded { count: 2, limit: 2 }),
+        "expected PatLimitExceeded {{count:2,limit:2}}, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn mint_succeeds_after_revoking_to_below_cap() {
+    let store = SqliteStore::in_memory().unwrap();
+    store.initialize().await.unwrap();
+    store.migrate().await.unwrap();
+    let store: Arc<dyn IpamStore> = Arc::new(store);
+    let pepper = Arc::new(PatPepper::from_bytes(&[0xA5u8; 32]).unwrap());
+    let lifecycle = PatLifecycle::new(Arc::clone(&store), Arc::clone(&pepper), 1);
+
+    let minted = lifecycle
+        .mint_for_owner(
+            &owner(),
+            Role::Admin,
+            CreatePatRequest { name: "first".to_string(), expires_in_days: Some(30), role: None },
+        )
+        .await
+        .unwrap();
+
+    // At cap — second mint fails.
+    assert!(lifecycle
+        .mint_for_owner(
+            &owner(),
+            Role::Admin,
+            CreatePatRequest { name: "second".to_string(), expires_in_days: Some(30), role: None },
+        )
+        .await
+        .is_err());
+
+    // Revoke the first token.
+    lifecycle.revoke_for_owner(&owner(), &minted.summary.id).await.unwrap();
+
+    // Now below cap — third mint succeeds.
+    lifecycle
+        .mint_for_owner(
+            &owner(),
+            Role::Admin,
+            CreatePatRequest { name: "third".to_string(), expires_in_days: Some(30), role: None },
+        )
+        .await
+        .unwrap();
 }


### PR DESCRIPTION
## Summary

- `POST /me/tokens` had no per-tenant active PAT count limit, allowing bulk creation of durable credentials (Kill Chain Phase 5 / Installation, STRIDE D+E — ENG-108)
- Adds `max_pats_per_tenant` config field (default 25) to `ServerConfig`
- Counts active (non-revoked, non-expired) PATs before minting; returns 429 `PatLimitExceeded` on breach
- New `pat_count_active_for_owner` store method implemented for both SQLite and Postgres backends

Closes #269

## Test plan

- [ ] `cargo test pat_count_active` — new SQLite store unit test
- [ ] `cargo test mint_is_rejected_when_active_pat_cap_is_reached` — cap enforcement integration test
- [ ] `cargo test mint_succeeds_after_revoking_to_below_cap` — cap clears after revoke
- [ ] `cargo test` — full suite passes
- [ ] `error_presenter` exhaustive-match test confirms 429 arm compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)