### PR TITLE
chore: release v0.26.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.13](https://github.com/wingnut128/netcidr/compare/v0.26.12...v0.26.13) - 2026-06-18
+
+### Added
+
+- *(auth)* cap active PATs per tenant — ENG-108 ([#270](https://github.com/wingnut128/netcidr/pull/270))
+
+### Fixed
+
+- *(api)* enable per-IP rate limiting under Lambda via X-Forwarded-For — ENG-103 ([#272](https://github.com/wingnut128/netcidr/pull/272))
+
 ### Security
 
 - *(auth)* cap active PATs per tenant (default 25, configurable via `max_pats_per_tenant`); `POST /me/tokens` returns 429 when the cap is reached (ENG-108)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "netcidr"
-version = "0.26.12"
+version = "0.26.13"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netcidr"
-version = "0.26.12"
+version = "0.26.13"
 edition = "2024"
 license = "MIT"
 description = "A fast IPv4 and IPv6 subnet calculator CLI and API"


### PR DESCRIPTION



## 🤖 New release

* `netcidr`: 0.26.12 -> 0.26.13

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.26.13](https://github.com/wingnut128/netcidr/compare/v0.26.12...v0.26.13) - 2026-06-18

### Added

- *(auth)* cap active PATs per tenant — ENG-108 ([#270](https://github.com/wingnut128/netcidr/pull/270))

### Fixed

- *(api)* enable per-IP rate limiting under Lambda via X-Forwarded-For — ENG-103 ([#272](https://github.com/wingnut128/netcidr/pull/272))

### Security

- *(auth)* cap active PATs per tenant (default 25, configurable via `max_pats_per_tenant`); `POST /me/tokens` returns 429 when the cap is reached (ENG-108)
- *(api)* enable per-IP rate limiting under Lambda via tower-governor's `SmartIpKeyExtractor`, which keys on the `X-Forwarded-For` header API Gateway sets (falls back to the TCP peer for direct clients). The Lambda limit is tunable with `NETCIDR_RATE_LIMIT` / `NETCIDR_RATE_LIMIT_BURST`. Auth-specific throttling is explicitly deferred — see ADR-0005 (ENG-103)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).