### PR TITLE
fix(api): enable per-IP rate limiting under Lambda via X-Forwarded-For — ENG-103

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - *(auth)* cap active PATs per tenant (default 25, configurable via `max_pats_per_tenant`); `POST /me/tokens` returns 429 when the cap is reached (ENG-108)
+- *(api)* enable per-IP rate limiting under Lambda via tower-governor's `SmartIpKeyExtractor`, which keys on the `X-Forwarded-For` header API Gateway sets (falls back to the TCP peer for direct clients). The Lambda limit is tunable with `NETCIDR_RATE_LIMIT` / `NETCIDR_RATE_LIMIT_BURST`. Auth-specific throttling is explicitly deferred — see ADR-0005 (ENG-103)
 
 ## [0.26.12](https://github.com/wingnut128/netcidr/compare/v0.26.11...v0.26.12) - 2026-06-18
 

--- a/README.md
+++ b/README.md
@@ -1007,8 +1007,12 @@ cargo lambda build --release --arm64 --bin lambda --features lambda,ipam-postgre
 | `NETCIDR_IPAM_BACKEND` | No | `postgres` | IPAM backend |
 | `NETCIDR_AUTH_MODE` | No | `oidc` | `oidc`, `bearer`, or `none` |
 | `NETCIDR_IPAM_ENABLED` | No | `true` | Disable IPAM endpoints |
+| `NETCIDR_RATE_LIMIT` | No | `20` | Sustained per-IP requests/sec (`0` disables) |
+| `NETCIDR_RATE_LIMIT_BURST` | No | `50` | Per-IP burst allowance |
 
 Point `NETCIDR_DATABASE_URL` at a serverless Postgres (e.g. [Neon](https://neon.tech)) or RDS. For RDS, consider RDS Proxy to manage connection pooling across Lambda invocations.
+
+**Per-IP rate limiting under Lambda.** The router derives the client IP from the `X-Forwarded-For` header (via tower-governor's `SmartIpKeyExtractor`), so the limiter works behind API Gateway even though `lambda_http` provides no TCP peer address. This is only trustworthy because **API Gateway is a trusted proxy that overwrites `X-Forwarded-For`** with the real client IP — never expose the Lambda Function URL directly, or callers could spoof the header to evade throttling. For `netcidr serve` (direct TCP), clients that send no forwarding header fall back to the connection's peer IP. Tune the limit per environment with `NETCIDR_RATE_LIMIT` / `NETCIDR_RATE_LIMIT_BURST` without redeploying.
 
 ## License
 

--- a/docs/adr/0005-lambda-rate-limiting-via-forwarded-header.md
+++ b/docs/adr/0005-lambda-rate-limiting-via-forwarded-header.md
@@ -1,0 +1,79 @@
+# Lambda rate limiting via X-Forwarded-For; auth-specific throttling deferred
+
+**Status:** Accepted
+**Date:** 2026-06-18
+**Issue:** [#259](https://github.com/wingnut128/netcidr/issues/259) (ENG-103)
+**Related:** [[ADR-0002 — RBAC role config and per-handler extractors]](./0002-rbac-role-config-and-per-handler-extractors.md)
+
+## Context
+
+`netcidr serve` has per-IP rate limiting (tower-governor, default 20 req/s,
+burst 50, applied as a global layer in `api.rs`). The default
+`PeerIpKeyExtractor` reads the client IP from `ConnectInfo<SocketAddr>` — the
+TCP peer address — which `lambda_http` does not provide. So the Lambda binary
+set `rate_limit_per_second: 0` to avoid every request 500ing with "Unable To
+Extract Key", leaving the Lambda deployment with **no application-level
+throttling** (it fell entirely to out-of-band AWS controls).
+
+Separately, even on `serve` there is no auth-specific throttling: OIDC
+validation is CPU-bound (RSA signature verify) and a distributed source set
+could force repeated verifications within per-IP limits.
+
+## Decisions
+
+1. **Key the limiter on `X-Forwarded-For` via `SmartIpKeyExtractor`.**
+   tower-governor 0.8 ships `SmartIpKeyExtractor`, which derives the client IP
+   from `X-Forwarded-For`, then `X-Real-IP`, then `Forwarded`, falling back to
+   `ConnectInfo<SocketAddr>` and the socket address. The router now uses it
+   unconditionally (`api.rs`). Under Lambda, API Gateway always sets
+   `X-Forwarded-For`, so the limiter works without any TCP peer. Under
+   `netcidr serve`, clients that send no forwarding header fall back to the
+   connection peer IP exactly as before. No custom extractor code is needed.
+
+2. **Enable the limiter under Lambda, tunable by env var.** `lambda.rs` no
+   longer hardcodes `0`. It reads `NETCIDR_RATE_LIMIT` (default 20 req/s; `0`
+   disables) and `NETCIDR_RATE_LIMIT_BURST` (default 50), so operators tune
+   throttling per environment without a redeploy.
+
+3. **Trust boundary: API Gateway only.** `X-Forwarded-For` is trustworthy
+   *only* because API Gateway is a trusted proxy that overwrites it with the
+   real client IP. The Lambda Function URL must **not** be exposed directly —
+   a direct caller could spoof the header to land every request in a different
+   bucket and evade throttling. This is documented in the README Lambda
+   section and is the operative deployment constraint.
+
+4. **Auth-specific throttling: explicitly accepted (deferred), not
+   implemented.** Per the ENG-103 acceptance criteria, we record the decision
+   to *accept* the residual risk rather than build per-account/per-token
+   lockout now. Rationale:
+   - The per-IP limiter (20 req/s default) now covers both `serve` and Lambda,
+     bounding brute-force throughput from any single source.
+   - Account lockout introduces its own DoS vector (an attacker locks out a
+     victim by spamming their identifier) and state that does not fit the
+     stateless Lambda model without an external store.
+   - OIDC tokens are validated against cached JWKS; there is no password to
+     brute-force, only signature verification, which the per-IP limit already
+     throttles.
+
+   A stricter limit scoped to auth/token-mint endpoints remains a clean
+   follow-up if abuse is observed.
+
+## Consequences
+
+- The Lambda deployment now enforces application-level per-IP throttling
+  instead of relying solely on AWS-side controls.
+- `serve` behavior is unchanged for direct clients (peer-IP fallback) and now
+  additionally honors a forwarding header when present — correct when `serve`
+  itself runs behind a trusted reverse proxy.
+- New tunable-to-extract-key 500s are possible only in the pathological case
+  of a Lambda request with neither a forwarding header nor a socket address,
+  which API Gateway never produces.
+- Spoofable `X-Forwarded-For` is a real risk if the Function URL is exposed
+  directly; mitigated by the documented "API Gateway only" constraint.
+
+## Out of scope (follow-ups)
+
+- Per-route / auth-endpoint-specific rate limits (tighter bucket for
+  `/me/tokens`, OIDC validation paths).
+- Distributed rate-limit state shared across Lambda concurrency (today each
+  execution environment keeps its own in-memory governor state).

--- a/src/api.rs
+++ b/src/api.rs
@@ -12,6 +12,7 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use tower_governor::GovernorLayer;
 use tower_governor::governor::GovernorConfigBuilder;
+use tower_governor::key_extractor::SmartIpKeyExtractor;
 use tower_http::cors::CorsLayer;
 use tower_http::limit::RequestBodyLimitLayer;
 use tower_http::set_header::SetResponseHeaderLayer;
@@ -582,13 +583,20 @@ pub fn create_router(config: RouterConfig) -> Router {
         ));
 
     // Per-IP rate limiting via tower-governor (disabled when rate_limit_per_second == 0).
-    // Requires ConnectInfo<SocketAddr> — the server must use
-    // `into_make_service_with_connect_info::<SocketAddr>()`.
+    // SmartIpKeyExtractor derives the client IP from the X-Forwarded-For,
+    // X-Real-IP, or Forwarded headers (set by a trusted proxy such as API
+    // Gateway), falling back to ConnectInfo<SocketAddr> for direct TCP
+    // clients. This lets the limiter run under Lambda, where lambda_http
+    // provides no ConnectInfo but API Gateway always sets X-Forwarded-For.
+    // For `netcidr serve`, the server must use
+    // `into_make_service_with_connect_info::<SocketAddr>()` so the fallback
+    // works for clients that send no forwarding header.
     let router =
         if let Some(replenish_ms) = 1000u64.checked_div(config.server.rate_limit_per_second) {
             match GovernorConfigBuilder::default()
                 .per_millisecond(replenish_ms)
                 .burst_size(config.server.rate_limit_burst)
+                .key_extractor(SmartIpKeyExtractor)
                 .finish()
             {
                 Some(governor_config) => router.layer(GovernorLayer::new(governor_config)),

--- a/src/bin/lambda.rs
+++ b/src/bin/lambda.rs
@@ -23,6 +23,15 @@ fn env_or<S: Into<String>>(key: &str, fallback: S) -> String {
     std::env::var(key).unwrap_or_else(|_| fallback.into())
 }
 
+/// Parse a numeric environment variable, falling back to `fallback` when the
+/// variable is unset or cannot be parsed.
+fn env_parse<T: std::str::FromStr>(key: &str, fallback: T) -> T {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(fallback)
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     use tracing_subscriber::layer::SubscriberExt;
@@ -64,11 +73,13 @@ async fn main() -> Result<(), Error> {
         ipam_db: None,
         ipam_db_url: std::env::var("NETCIDR_DATABASE_URL").ok(),
         enable_swagger: env_or("NETCIDR_ENABLE_SWAGGER", "true") == "true",
-        // Disable the per-IP rate limiter under Lambda. tower_governor needs
-        // ConnectInfo<SocketAddr> from a real TCP peer, which lambda_http
-        // doesn't provide — every request would 500 with "Unable To Extract
-        // Key!". AWS Lambda's own concurrency limits cover throttling.
-        rate_limit_per_second: 0,
+        // Per-IP rate limiting works under Lambda because the router uses
+        // SmartIpKeyExtractor, which reads the client IP from the
+        // X-Forwarded-For header that API Gateway sets (lambda_http provides
+        // no ConnectInfo). Tunable without a redeploy via NETCIDR_RATE_LIMIT
+        // (requests/sec, 0 disables) and NETCIDR_RATE_LIMIT_BURST.
+        rate_limit_per_second: env_parse("NETCIDR_RATE_LIMIT", 20),
+        rate_limit_burst: env_parse("NETCIDR_RATE_LIMIT_BURST", 50),
         ..ServerConfig::default()
     };
 

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -990,3 +990,65 @@ async fn test_rate_limit_allows_burst() {
     let resp = client.get(&url).send().await.unwrap();
     assert_eq!(resp.status(), 429);
 }
+
+#[tokio::test]
+async fn test_rate_limit_keys_on_x_forwarded_for() {
+    use std::net::SocketAddr;
+    use tokio::net::TcpListener;
+
+    // Burst of 1 so the second request from the same client IP is throttled.
+    // SmartIpKeyExtractor derives the client IP from X-Forwarded-For — the
+    // header API Gateway sets in front of Lambda — rather than the TCP peer.
+    let config = RouterConfig {
+        server: ServerConfig {
+            rate_limit_per_second: 1,
+            rate_limit_burst: 1,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let app = create_router(config);
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .await
+        .unwrap();
+    });
+
+    let client = reqwest::Client::new();
+    let url = format!("http://{}/health", addr);
+
+    // First request from 203.0.113.1 succeeds and exhausts its burst.
+    let resp = client
+        .get(&url)
+        .header("X-Forwarded-For", "203.0.113.1")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    // Second request from the same forwarded IP is throttled — proving the
+    // limiter keys on the header, not the shared loopback TCP peer.
+    let resp = client
+        .get(&url)
+        .header("X-Forwarded-For", "203.0.113.1")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 429);
+
+    // A different forwarded IP gets its own bucket and is allowed through.
+    let resp = client
+        .get(&url)
+        .header("X-Forwarded-For", "203.0.113.2")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+}


### PR DESCRIPTION
## Summary

Closes #259. The Lambda binary previously set `rate_limit_per_second: 0` because tower-governor's default `PeerIpKeyExtractor` needs `ConnectInfo<SocketAddr>`, which `lambda_http` doesn't provide — so the Lambda deployment had no application-level throttling.

- **`SmartIpKeyExtractor`** — the governor layer now derives the client IP from `X-Forwarded-For` (then `X-Real-IP`, `Forwarded`), falling back to the TCP peer for direct clients. API Gateway always sets `X-Forwarded-For`, so the limiter works under Lambda with no TCP peer.
- **Lambda limiter enabled + tunable** — `lambda.rs` reads `NETCIDR_RATE_LIMIT` (default 20 req/s, `0` disables) and `NETCIDR_RATE_LIMIT_BURST` (default 50).
- **Auth-specific throttling explicitly deferred** — recorded in ADR-0005 with rationale (per-IP limiter now covers both transports; account lockout adds its own DoS vector and stateful complexity ill-suited to stateless Lambda).

## Trust boundary

`X-Forwarded-For` is trusted only because API Gateway overwrites it. The Lambda Function URL must not be exposed directly, or callers could spoof the header to evade throttling. Documented in the README Lambda section and ADR-0005.

## Acceptance criteria (#259)

- [x] Lambda deployment has enforced request throttling
- [x] Decision recorded on auth-specific throttling (explicitly accepted — ADR-0005)
- [x] CHANGELOG/README/docs updated

## Tests

New `test_rate_limit_keys_on_x_forwarded_for` proves the limiter keys on the header (same forwarded IP → 429, different IP → fresh bucket). All 68 `api_tests` pass; fmt + clippy clean under `lambda,ipam-postgres`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)