### PR TITLE
chore: release v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0](https://github.com/wingnut128/netcidr/compare/v0.26.12...v0.27.0) - 2026-06-18
+
 ### Security
 
 - *(auth)* cap active PATs per tenant (default 25, configurable via `max_pats_per_tenant`); `POST /me/tokens` returns 429 when the cap is reached (ENG-108)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "netcidr"
-version = "0.26.12"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netcidr"
-version = "0.26.12"
+version = "0.27.0"
 edition = "2024"
 license = "MIT"
 description = "A fast IPv4 and IPv6 subnet calculator CLI and API"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,9 @@ We actively support and provide security updates for the following versions:
 
 | Version | Supported          | Notes                                    |
 | ------- | ------------------ | ---------------------------------------- |
-| 0.26.x  | :white_check_mark: | Current stable release (recommended)     |
-| 0.25.x  | :white_check_mark: | Supported                                |
-| < 0.25  | :x:                | No longer supported                      |
+| 0.27.x  | :white_check_mark: | Current stable release (recommended)     |
+| 0.26.x  | :white_check_mark: | Supported                                |
+| < 0.26  | :x:                | No longer supported                      |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary

Cuts **v0.27.0**. Minor bump — this release adds new user-facing configuration (a per-tenant PAT cap and tunable Lambda rate limiting), so it crosses a minor boundary under semver.

- `Cargo.toml` / `Cargo.lock` → `0.27.0`
- `CHANGELOG.md` → `[Unreleased]` entries moved to dated `[0.27.0]`
- `SECURITY.md` → supported versions shifted to `0.27.x` (current) + `0.26.x`

## Included since v0.26.12

- *(auth)* cap active PATs per tenant (`max_pats_per_tenant`, default 25); `POST /me/tokens` → 429 at the cap (ENG-108)
- *(api)* per-IP rate limiting under Lambda via `SmartIpKeyExtractor` keyed on `X-Forwarded-For`; tunable with `NETCIDR_RATE_LIMIT` / `NETCIDR_RATE_LIMIT_BURST`; auth-specific throttling deferred (ADR-0005, ENG-103)

Merging this triggers the tag-driven release workflow (`detect` sees the bump and builds `v0.27.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)