### PR TITLE
chore: release v0.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.1](https://github.com/wingnut128/netcidr/compare/v0.27.0...v0.27.1) - 2026-06-22
+
+### Other
+
+- *(deps)* bump actions/checkout from 6.0.3 to 7.0.0
+- *(deps)* bump react-router-dom from 7.17.0 to 7.18.0 in /dashboard in the npm-minor-and-patch group ([#275](https://github.com/wingnut128/netcidr/pull/275))
+- *(deps)* bump ratatui ([#276](https://github.com/wingnut128/netcidr/pull/276))
+- *(deps)* bump tower-http from 0.6.11 to 0.7.0 ([#278](https://github.com/wingnut128/netcidr/pull/278))
+
 ## [0.27.0](https://github.com/wingnut128/netcidr/compare/v0.26.12...v0.27.0) - 2026-06-18
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "netcidr"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netcidr"
-version = "0.27.0"
+version = "0.27.1"
 edition = "2024"
 license = "MIT"
 description = "A fast IPv4 and IPv6 subnet calculator CLI and API"


### PR DESCRIPTION



## 🤖 New release

* `netcidr`: 0.27.0 -> 0.27.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.27.1](https://github.com/wingnut128/netcidr/compare/v0.27.0...v0.27.1) - 2026-06-22

### Other

- *(deps)* bump actions/checkout from 6.0.3 to 7.0.0
- *(deps)* bump react-router-dom from 7.17.0 to 7.18.0 in /dashboard in the npm-minor-and-patch group ([#275](https://github.com/wingnut128/netcidr/pull/275))
- *(deps)* bump ratatui ([#276](https://github.com/wingnut128/netcidr/pull/276))
- *(deps)* bump tower-http from 0.6.11 to 0.7.0 ([#278](https://github.com/wingnut128/netcidr/pull/278))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).